### PR TITLE
fix: repair red main CI (Rust + Frontend gates)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,6 +25,7 @@ jobs:
             test
             style
             perf
+            ci
           # Subject must be lowercase and not end with a period.
           subjectPattern: ^(?![A-Z])(?!.*\.$).+$
           subjectPatternError: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Allowed typ
 - `test` — tests only
 - `style` — formatting / whitespace
 - `perf` — performance improvement
+- `ci` — CI / workflow / build-pipeline config (used by the
+  github-actions Dependabot group)
 
 Scope is optional but encouraged when it disambiguates (`feat(tui):`, `fix(blocks):`, `refactor(http):`). Subject in imperative mood, lowercase, no trailing period. Wrap the body at ~72 columns.
 

--- a/httui-core/src/block_history/mod.rs
+++ b/httui-core/src/block_history/mod.rs
@@ -354,7 +354,9 @@ mod tests {
     #[tokio::test]
     async fn plan_defaults_to_none_for_regular_runs() {
         let pool = setup().await;
-        insert_history_entry(&pool, entry("GET", 200)).await.unwrap();
+        insert_history_entry(&pool, entry("GET", 200))
+            .await
+            .unwrap();
         let rows = list_history(&pool, "/notes/test.md", "req1").await.unwrap();
         assert_eq!(rows.len(), 1);
         assert!(rows[0].plan.is_none());
@@ -425,7 +427,10 @@ mod tests {
         assert_eq!(removed, 2);
         // Other file's row survives.
         assert_eq!(
-            list_history(&pool, "/other.md", "req1").await.unwrap().len(),
+            list_history(&pool, "/other.md", "req1")
+                .await
+                .unwrap()
+                .len(),
             1,
         );
     }
@@ -469,8 +474,10 @@ mod tests {
         }"#;
         let parsed: InsertEntry = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.method, "GET");
-        assert!(parsed.plan.is_none(),
-                "plan should default to None when omitted from wire");
+        assert!(
+            parsed.plan.is_none(),
+            "plan should default to None when omitted from wire"
+        );
     }
 
     #[test]
@@ -541,7 +548,9 @@ mod tests {
     async fn list_history_for_file_respects_explicit_limit() {
         let pool = setup().await;
         for i in 0..6 {
-            insert_history_entry(&pool, entry("GET", 200 + i)).await.unwrap();
+            insert_history_entry(&pool, entry("GET", 200 + i))
+                .await
+                .unwrap();
         }
         let rows = list_history_for_file(&pool, "/notes/test.md", 3)
             .await
@@ -553,7 +562,9 @@ mod tests {
     async fn list_history_for_file_falls_back_to_50_when_limit_non_positive() {
         let pool = setup().await;
         for i in 0..3 {
-            insert_history_entry(&pool, entry("GET", 200 + i)).await.unwrap();
+            insert_history_entry(&pool, entry("GET", 200 + i))
+                .await
+                .unwrap();
         }
         // limit <= 0 → effective fallback of 50; 3 inserted rows fit easily.
         let rows = list_history_for_file(&pool, "/notes/test.md", 0)
@@ -569,9 +580,7 @@ mod tests {
     #[tokio::test]
     async fn list_history_for_file_returns_empty_when_no_rows() {
         let pool = setup().await;
-        let rows = list_history_for_file(&pool, "/empty.md", 50)
-            .await
-            .unwrap();
+        let rows = list_history_for_file(&pool, "/empty.md", 50).await.unwrap();
         assert!(rows.is_empty());
     }
 
@@ -590,7 +599,9 @@ mod tests {
             .await
             .unwrap();
         for _ in 0..2 {
-            insert_history_entry(&pool, entry("GET", 200)).await.unwrap();
+            insert_history_entry(&pool, entry("GET", 200))
+                .await
+                .unwrap();
         }
         // 2 rows fits the default cap (10) with room to spare.
         let rows = list_history(&pool, "/notes/test.md", "req1").await.unwrap();
@@ -604,7 +615,9 @@ mod tests {
             .await
             .unwrap();
         for _ in 0..2 {
-            insert_history_entry(&pool, entry("GET", 200)).await.unwrap();
+            insert_history_entry(&pool, entry("GET", 200))
+                .await
+                .unwrap();
         }
         let rows = list_history(&pool, "/notes/test.md", "req1").await.unwrap();
         // 4 inserted total, default cap is 10 — all 4 visible.

--- a/httui-core/src/block_history/summary.rs
+++ b/httui-core/src/block_history/summary.rs
@@ -69,10 +69,9 @@ pub fn summarize_last_run(entries: &[HistoryEntry]) -> LastRunSummary {
         // When timestamps are parseable, restrict the session window;
         // when they aren't, fall through and include the row so a
         // malformed entry doesn't silently drop the count to zero.
-        if let (Some(latest_ts), Ok(entry_ts)) = (
-            latest_ts,
-            DateTime::parse_from_rfc3339(&entry.ran_at),
-        ) {
+        if let (Some(latest_ts), Ok(entry_ts)) =
+            (latest_ts, DateTime::parse_from_rfc3339(&entry.ran_at))
+        {
             let diff = (latest_ts - entry_ts).num_seconds();
             if !(0..=SESSION_WINDOW_SECS).contains(&diff) {
                 continue;

--- a/httui-core/src/blocks/http_normalize.rs
+++ b/httui-core/src/blocks/http_normalize.rs
@@ -32,9 +32,7 @@
 use serde_json::Value;
 
 const URL_INLINE_LIMIT: usize = 80;
-const HTTP_METHODS: &[&str] = &[
-    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
-];
+const HTTP_METHODS: &[&str] = &["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
 /// Walk a markdown string, find ```http fences, and rewrite legacy JSON bodies
 /// in canonical HTTP-message form. Bodies that aren't legacy JSON are
@@ -137,7 +135,9 @@ fn try_normalize_legacy(body: &str) -> Option<String> {
         .unwrap_or("")
         .to_string();
 
-    Some(stringify_http_message(&method, &url, &params, &headers, &body_text))
+    Some(stringify_http_message(
+        &method, &url, &params, &headers, &body_text,
+    ))
 }
 
 fn extract_kv_array(value: Option<&Value>) -> Vec<(String, String)> {

--- a/httui-core/src/captures_cache.rs
+++ b/httui-core/src/captures_cache.rs
@@ -22,10 +22,7 @@ use std::path::{Path, PathBuf};
 /// Read the captures JSON for `file_path`. Returns `Ok(None)` when
 /// the file doesn't exist (the auto-capture was either OFF or
 /// nothing was persisted yet) — that's normal, not an error.
-pub fn read_captures_file(
-    vault_root: &Path,
-    file_path: &str,
-) -> Result<Option<String>, String> {
+pub fn read_captures_file(vault_root: &Path, file_path: &str) -> Result<Option<String>, String> {
     let path = captures_path_for(vault_root, file_path)?;
     match fs::read_to_string(&path) {
         Ok(s) => Ok(Some(s)),
@@ -53,10 +50,7 @@ pub fn write_captures_file(
 
 /// Delete the captures cache for `file_path`. Returns `true` when
 /// a file was removed, `false` when there was nothing to delete.
-pub fn delete_captures_file(
-    vault_root: &Path,
-    file_path: &str,
-) -> Result<bool, String> {
+pub fn delete_captures_file(vault_root: &Path, file_path: &str) -> Result<bool, String> {
     let path = captures_path_for(vault_root, file_path)?;
     match fs::remove_file(&path) {
         Ok(()) => Ok(true),
@@ -124,7 +118,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = write_captures_file(dir.path(), "runbook.md", SAMPLE_JSON).unwrap();
         assert!(path.ends_with(".httui/captures/runbook.md.json"));
-        let read = read_captures_file(dir.path(), "runbook.md").unwrap().unwrap();
+        let read = read_captures_file(dir.path(), "runbook.md")
+            .unwrap()
+            .unwrap();
         assert_eq!(read, SAMPLE_JSON);
     }
 

--- a/httui-core/src/connection_uses.rs
+++ b/httui-core/src/connection_uses.rs
@@ -42,12 +42,7 @@ pub fn find_connection_uses(vault_root: &Path, connection_name: &str) -> Vec<Con
     out
 }
 
-fn walk(
-    vault_root: &Path,
-    dir: &Path,
-    connection_name: &str,
-    out: &mut Vec<ConnectionUse>,
-) {
+fn walk(vault_root: &Path, dir: &Path, connection_name: &str, out: &mut Vec<ConnectionUse>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -136,7 +131,11 @@ mod tests {
     #[test]
     fn empty_name_returns_empty() {
         let tmp = TempDir::new().unwrap();
-        write(tmp.path(), "a.md", "```db-postgres connection=x\nSELECT 1;\n```\n");
+        write(
+            tmp.path(),
+            "a.md",
+            "```db-postgres connection=x\nSELECT 1;\n```\n",
+        );
         assert!(find_connection_uses(tmp.path(), "").is_empty());
     }
 
@@ -168,16 +167,8 @@ mod tests {
     #[test]
     fn matches_across_files_sorted() {
         let tmp = TempDir::new().unwrap();
-        write(
-            tmp.path(),
-            "z.md",
-            "```db-postgres connection=p\n;\n```\n",
-        );
-        write(
-            tmp.path(),
-            "a.md",
-            "```db-postgres connection=p\n;\n```\n",
-        );
+        write(tmp.path(), "z.md", "```db-postgres connection=p\n;\n```\n");
+        write(tmp.path(), "a.md", "```db-postgres connection=p\n;\n```\n");
         let r = find_connection_uses(tmp.path(), "p");
         assert_eq!(r.len(), 2);
         assert_eq!(r[0].file, "a.md");
@@ -200,11 +191,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // HTTP blocks don't carry connection=; even if a body line
         // mentions it accidentally, we only match opener fences.
-        write(
-            tmp.path(),
-            "x.md",
-            "```http\nGET /api?connection=p\n```\n",
-        );
+        write(tmp.path(), "x.md", "```http\nGET /api?connection=p\n```\n");
         assert!(find_connection_uses(tmp.path(), "p").is_empty());
     }
 
@@ -229,11 +216,7 @@ mod tests {
             "node_modules/foo/x.md",
             "```db connection=p\n;\n```\n",
         );
-        write(
-            tmp.path(),
-            ".git/HEAD/x.md",
-            "```db connection=p\n;\n```\n",
-        );
+        write(tmp.path(), ".git/HEAD/x.md", "```db connection=p\n;\n```\n");
         write(tmp.path(), "ok.md", "```db connection=p\n;\n```\n");
         let r = find_connection_uses(tmp.path(), "p");
         assert_eq!(r.len(), 1);
@@ -243,11 +226,7 @@ mod tests {
     #[test]
     fn uses_posix_separators_in_output() {
         let tmp = TempDir::new().unwrap();
-        write(
-            tmp.path(),
-            "notes/sub/x.md",
-            "```db connection=p\n;\n```\n",
-        );
+        write(tmp.path(), "notes/sub/x.md", "```db connection=p\n;\n```\n");
         let r = find_connection_uses(tmp.path(), "p");
         assert_eq!(r.len(), 1);
         assert!(r[0].file.contains("notes/sub/x.md"));
@@ -262,10 +241,7 @@ mod tests {
 
     #[test]
     fn line_matches_helper_handles_edge_cases() {
-        assert!(line_matches_connection(
-            "```db connection=foo",
-            "foo"
-        ));
+        assert!(line_matches_connection("```db connection=foo", "foo"));
         assert!(line_matches_connection(
             "```db-postgres alias=a connection=foo limit=10",
             "foo"
@@ -274,9 +250,6 @@ mod tests {
         assert!(!line_matches_connection("not a fence", "foo"));
         assert!(!line_matches_connection("```http", "foo"));
         assert!(!line_matches_connection("```db", "foo"));
-        assert!(!line_matches_connection(
-            "  ```db connection=foo",
-            "foo"
-        )); // indented fence — outside our spec
+        assert!(!line_matches_connection("  ```db connection=foo", "foo")); // indented fence — outside our spec
     }
 }

--- a/httui-core/src/db/connections.rs
+++ b/httui-core/src/db/connections.rs
@@ -12,10 +12,10 @@ pub use super::pool_manager::{HostPortOverride, PoolManager, StatusEmitter};
 // `DatabasePool` enum + lifecycle helpers (`create_pool`, builders,
 // validators, sanitizer) moved to `db::pool` (Epic 20a Story 01 —
 // fourth split). Re-exported here so existing imports compile.
-pub use super::pool::DatabasePool;
-use super::pool::validate_sqlite_path;
 #[cfg(test)]
 use super::pool::validate_bind_values;
+use super::pool::validate_sqlite_path;
+pub use super::pool::DatabasePool;
 
 // --- Connection model ---
 
@@ -128,10 +128,10 @@ pub struct UpdateConnection {
 // Query error sanitization + location extraction moved to
 // `db::query_error` (Epic 20a Story 01 — second split). Re-exports
 // keep existing imports compiling.
+pub(crate) use super::query_error::sanitize_query_error;
 pub use super::query_error::{
     enrich_error_with_query, sanitize_query_error_rich, QueryErrorInfo, QueryErrorLocation,
 };
-pub(crate) use super::query_error::sanitize_query_error;
 
 // --- Row mapping ---
 
@@ -395,8 +395,8 @@ pub(crate) use super::pool_exec_sqlite::sqlite_row_to_json;
 // SQL scanner + statement splitter + placeholder helpers moved to
 // `db::sql_scanner` (Epic 20a Story 01 — third split). Re-exports
 // keep existing imports compiling.
-pub use super::sql_scanner::{count_placeholders, normalize_placeholders_to_pg, split_statements};
 pub(crate) use super::sql_scanner::contains_multiple_statements;
+pub use super::sql_scanner::{count_placeholders, normalize_placeholders_to_pg, split_statements};
 
 // --- Tests ---
 

--- a/httui-core/src/db/driver.rs
+++ b/httui-core/src/db/driver.rs
@@ -88,7 +88,9 @@ mod tests {
     fn from_str_rejects_non_db_drivers() {
         // HTTP / mongo / gRPC are valid Connection variants but not
         // pool-backed, so DbDriver::from_str must reject them.
-        for s in ["http", "mongo", "ws", "grpc", "graphql", "bigquery", "shell"] {
+        for s in [
+            "http", "mongo", "ws", "grpc", "graphql", "bigquery", "shell",
+        ] {
             let err = DbDriver::from_str(s).expect_err(s);
             assert!(err.contains("unsupported driver"));
         }

--- a/httui-core/src/db/keychain.rs
+++ b/httui-core/src/db/keychain.rs
@@ -75,7 +75,7 @@ pub fn store_secret(key: &str, value: &str) -> Result<(), String> {
     #[cfg(test)]
     {
         with_test_keychain(|m| m.insert(key.to_string(), value.to_string()));
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(test))]
     {
@@ -93,7 +93,7 @@ pub fn get_secret(key: &str) -> Result<Option<String>, String> {
     }
     #[cfg(test)]
     {
-        return Ok(with_test_keychain(|m| m.get(key).cloned()));
+        Ok(with_test_keychain(|m| m.get(key).cloned()))
     }
     #[cfg(not(test))]
     {
@@ -114,7 +114,7 @@ pub fn delete_secret(key: &str) -> Result<(), String> {
     #[cfg(test)]
     {
         with_test_keychain(|m| m.remove(key));
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(test))]
     {

--- a/httui-core/src/db/lookup.rs
+++ b/httui-core/src/db/lookup.rs
@@ -101,7 +101,9 @@ mod tests {
         // `Ok(None)`, so the trait impl mirrors the same shape.
         let dir = TempDir::new().unwrap();
         let store = ConnectionsStore::new(dir.path());
-        let res = ConnectionLookup::lookup(store.as_ref(), "missing").await.unwrap();
+        let res = ConnectionLookup::lookup(store.as_ref(), "missing")
+            .await
+            .unwrap();
         assert!(res.is_none());
     }
 }

--- a/httui-core/src/db/mod.rs
+++ b/httui-core/src/db/mod.rs
@@ -35,10 +35,8 @@ const MIGRATION_008_SQL: &str = include_str!("../../migrations/008_sqlite_port_n
 const MIGRATION_009_SQL: &str = include_str!("../../migrations/009_block_run_history.sql");
 const MIGRATION_010_SQL: &str = include_str!("../../migrations/010_block_settings.sql");
 const MIGRATION_011_SQL: &str = include_str!("../../migrations/011_block_examples.sql");
-const MIGRATION_012_SQL: &str =
-    include_str!("../../migrations/012_block_run_history_plan.sql");
-const MIGRATION_013_SQL: &str =
-    include_str!("../../migrations/013_schema_cache_drop_fk.sql");
+const MIGRATION_012_SQL: &str = include_str!("../../migrations/012_block_run_history_plan.sql");
+const MIGRATION_013_SQL: &str = include_str!("../../migrations/013_schema_cache_drop_fk.sql");
 
 pub async fn init_db(app_data_dir: &Path) -> Result<SqlitePool, sqlx::Error> {
     std::fs::create_dir_all(app_data_dir).ok();
@@ -251,12 +249,11 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     // at the SQL layer (DROP + RENAME), so guard at the Rust layer
     // by inspecting pragma_foreign_key_list — only re-run while the
     // FK is still present.
-    let fk_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM pragma_foreign_key_list('schema_cache')",
-    )
-    .fetch_one(pool)
-    .await
-    .unwrap_or(0);
+    let fk_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM pragma_foreign_key_list('schema_cache')")
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
     if fk_count > 0 {
         for statement in MIGRATION_013_SQL.split(';') {
             let trimmed = statement.trim();
@@ -395,10 +392,14 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
-        let result =
-            query_internal_db(&pool, "WITH cte AS (SELECT * FROM t) SELECT * FROM cte", 0, 10)
-                .await
-                .unwrap();
+        let result = query_internal_db(
+            &pool,
+            "WITH cte AS (SELECT * FROM t) SELECT * FROM cte",
+            0,
+            10,
+        )
+        .await
+        .unwrap();
         assert_eq!(result.rows.len(), 1);
     }
 

--- a/httui-core/src/db/pool.rs
+++ b/httui-core/src/db/pool.rs
@@ -398,8 +398,8 @@ pub(super) async fn create_pool(conn: &Connection) -> Result<DatabasePool, Strin
 
     // Boundary parse — surface the same "Unsupported driver: <name>"
     // shape the legacy match used to.
-    let drv =
-        DbDriver::from_str(&conn.driver).map_err(|_| format!("Unsupported driver: {}", conn.driver))?;
+    let drv = DbDriver::from_str(&conn.driver)
+        .map_err(|_| format!("Unsupported driver: {}", conn.driver))?;
     match drv {
         DbDriver::Postgres => {
             let opts = build_pg_connect_options(conn)?;

--- a/httui-core/src/db/pool_manager.rs
+++ b/httui-core/src/db/pool_manager.rs
@@ -424,9 +424,12 @@ mod tests {
         let p2 = memory_target_pool().await;
         let p3 = memory_target_pool().await;
 
-        mgr.insert_for_test("expired-1", "a", p1, stale, 60, 30_000).await;
-        mgr.insert_for_test("expired-2", "b", p2, stale, 60, 30_000).await;
-        mgr.insert_for_test("fresh", "c", p3, fresh, 60, 30_000).await;
+        mgr.insert_for_test("expired-1", "a", p1, stale, 60, 30_000)
+            .await;
+        mgr.insert_for_test("expired-2", "b", p2, stale, 60, 30_000)
+            .await;
+        mgr.insert_for_test("fresh", "c", p3, fresh, 60, 30_000)
+            .await;
         assert_eq!(mgr.cache_size().await, 3);
 
         mgr.cleanup_expired().await;

--- a/httui-core/src/db/schema_cache.rs
+++ b/httui-core/src/db/schema_cache.rs
@@ -26,8 +26,7 @@ pub const MYSQL_INTROSPECT_SQL: &str = r#"SELECT table_schema, table_name, colum
 
 /// SQLite introspection: tables + views (excluding sqlite_-prefixed
 /// internals) followed by `PRAGMA table_info(...)` per object.
-pub const SQLITE_OBJECTS_SQL: &str =
-    "SELECT name FROM sqlite_master \
+pub const SQLITE_OBJECTS_SQL: &str = "SELECT name FROM sqlite_master \
      WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'";
 
 #[derive(Debug, Clone, Serialize)]
@@ -402,25 +401,21 @@ mod tests {
 
     #[test]
     fn first_string_or_bytes_lossy_falls_back_to_bytes_decoded_lossily() {
-        let s: Result<String, sqlx::Error> =
-            Err(sqlx::Error::ColumnNotFound("x".into()));
+        let s: Result<String, sqlx::Error> = Err(sqlx::Error::ColumnNotFound("x".into()));
         let b: Result<Vec<u8>, sqlx::Error> = Ok(b"bytes".to_vec());
         assert_eq!(first_string_or_bytes_lossy(s, b).as_deref(), Some("bytes"));
     }
 
     #[test]
     fn first_string_or_bytes_lossy_returns_none_when_both_fail() {
-        let s: Result<String, sqlx::Error> =
-            Err(sqlx::Error::ColumnNotFound("x".into()));
-        let b: Result<Vec<u8>, sqlx::Error> =
-            Err(sqlx::Error::ColumnNotFound("x".into()));
+        let s: Result<String, sqlx::Error> = Err(sqlx::Error::ColumnNotFound("x".into()));
+        let b: Result<Vec<u8>, sqlx::Error> = Err(sqlx::Error::ColumnNotFound("x".into()));
         assert!(first_string_or_bytes_lossy(s, b).is_none());
     }
 
     #[test]
     fn first_string_or_bytes_lossy_decodes_invalid_utf8_with_replacement() {
-        let s: Result<String, sqlx::Error> =
-            Err(sqlx::Error::ColumnNotFound("x".into()));
+        let s: Result<String, sqlx::Error> = Err(sqlx::Error::ColumnNotFound("x".into()));
         // 0xFF is invalid UTF-8 — `from_utf8_lossy` substitutes the
         // U+FFFD replacement char.
         let b: Result<Vec<u8>, sqlx::Error> = Ok(vec![0xFF]);
@@ -467,13 +462,7 @@ mod tests {
 
     #[test]
     fn build_mysql_entry_allows_missing_schema_and_type() {
-        let e = build_mysql_entry(
-            None,
-            Some("t".into()),
-            Some("c".into()),
-            None,
-        )
-        .unwrap();
+        let e = build_mysql_entry(None, Some("t".into()), Some("c".into()), None).unwrap();
         assert!(e.schema_name.is_none());
         assert!(e.data_type.is_none());
     }

--- a/httui-core/src/db/schema_cache_remote.rs
+++ b/httui-core/src/db/schema_cache_remote.rs
@@ -34,7 +34,10 @@ pub async fn introspect_postgres(pool: &sqlx::PgPool) -> Result<Vec<SchemaEntry>
 }
 
 fn mysql_str(row: &sqlx::mysql::MySqlRow, col: &str) -> Option<String> {
-    first_string_or_bytes_lossy(row.try_get::<String, _>(col), row.try_get::<Vec<u8>, _>(col))
+    first_string_or_bytes_lossy(
+        row.try_get::<String, _>(col),
+        row.try_get::<Vec<u8>, _>(col),
+    )
 }
 
 pub async fn introspect_mysql(pool: &sqlx::MySqlPool) -> Result<Vec<SchemaEntry>, String> {

--- a/httui-core/src/dotenv.rs
+++ b/httui-core/src/dotenv.rs
@@ -158,10 +158,8 @@ static SECRET_KEY_RE: Lazy<Regex> = Lazy::new(|| {
     // Case-insensitive match against common secret-shaped key names.
     // Boundary on `_`/`-`/start/end so `STRIPE_KEY` matches but
     // `KEYBOARD_LAYOUT` doesn't.
-    Regex::new(
-        r"(?i)(^|[_-])(password|passwd|pwd|secret|key|token|auth|credential|apikey)([_-]|$)",
-    )
-    .expect("secret regex compiles")
+    Regex::new(r"(?i)(^|[_-])(password|passwd|pwd|secret|key|token|auth|credential|apikey)([_-]|$)")
+        .expect("secret regex compiles")
 });
 
 /// Apply the classifier to a single (key, value) pair.
@@ -355,7 +353,10 @@ mod tests {
     use super::*;
 
     fn first(content: &str) -> DotenvEntry {
-        parse_dotenv(content).into_iter().next().expect("at least one entry")
+        parse_dotenv(content)
+            .into_iter()
+            .next()
+            .expect("at least one entry")
     }
 
     #[test]
@@ -368,9 +369,7 @@ mod tests {
 
     #[test]
     fn skips_comments_and_blank_lines() {
-        let entries = parse_dotenv(
-            "# top comment\n\nHOST=h\n  # indented comment\nPORT=5432\n",
-        );
+        let entries = parse_dotenv("# top comment\n\nHOST=h\n  # indented comment\nPORT=5432\n");
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].key, "HOST");
         assert_eq!(entries[1].key, "PORT");
@@ -461,8 +460,14 @@ mod tests {
     #[test]
     fn classifies_secret_keys() {
         for key in [
-            "PASSWORD", "API_KEY", "APIKEY", "TOKEN",
-            "STRIPE_SECRET", "MY_AUTH", "DB_PWD", "X_CREDENTIAL",
+            "PASSWORD",
+            "API_KEY",
+            "APIKEY",
+            "TOKEN",
+            "STRIPE_SECRET",
+            "MY_AUTH",
+            "DB_PWD",
+            "X_CREDENTIAL",
             "STRIPE_KEY",
         ] {
             let raw = format!("{key}=value-doesnt-matter");

--- a/httui-core/src/explain/mongo.rs
+++ b/httui-core/src/explain/mongo.rs
@@ -40,7 +40,9 @@ use super::PlanNode;
 pub const COLLSCAN_WARN_DOCS: u64 = 10_000;
 
 pub fn parse_mongo_explain(json: &Value) -> Option<PlanNode> {
-    let winning = json.get("queryPlanner").and_then(|v| v.get("winningPlan"))?;
+    let winning = json
+        .get("queryPlanner")
+        .and_then(|v| v.get("winningPlan"))?;
     Some(parse_stage(winning, true))
 }
 

--- a/httui-core/src/explain/mysql.rs
+++ b/httui-core/src/explain/mysql.rs
@@ -54,7 +54,11 @@ fn parse_query_block(qb: &Value, root_cost: f64, is_root: bool) -> PlanNode {
     let cost = qb
         .get("cost_info")
         .and_then(|c| c.get("query_cost"))
-        .and_then(|v| v.as_str().map(|s| s.to_string()).or_else(|| v.as_f64().map(|f| format!("{f:.2}"))))
+        .and_then(|v| {
+            v.as_str()
+                .map(|s| s.to_string())
+                .or_else(|| v.as_f64().map(|f| format!("{f:.2}")))
+        })
         .unwrap_or_default();
     let total_cost = parse_cost_str(&cost);
     let pct = pct_of(total_cost, root_cost);
@@ -140,8 +144,7 @@ fn parse_table(table: &Value, root_cost: f64) -> PlanNode {
         "" => "Table",
         _ => access_type,
     };
-    let warn = (access_type == "ALL" && rows > FULL_SCAN_WARN_ROWS)
-        || pct > COST_SHARE_WARN;
+    let warn = (access_type == "ALL" && rows > FULL_SCAN_WARN_ROWS) || pct > COST_SHARE_WARN;
     PlanNode {
         op: op.to_string(),
         target: table_name.to_string(),
@@ -168,7 +171,7 @@ fn pct_of(value: f64, root: f64) -> u8 {
     if root <= 0.0 {
         return 0;
     }
-    ((value / root) * 100.0).round().min(100.0).max(0.0) as u8
+    ((value / root) * 100.0).round().clamp(0.0, 100.0) as u8
 }
 
 #[cfg(test)]

--- a/httui-core/src/explain/node.rs
+++ b/httui-core/src/explain/node.rs
@@ -52,11 +52,6 @@ impl PlanNode {
     /// Maximum depth (root = 1). Useful for the "tree handles 6+
     /// levels without horizontal scroll issues" acceptance test.
     pub fn depth(&self) -> usize {
-        1 + self
-            .children
-            .iter()
-            .map(|c| c.depth())
-            .max()
-            .unwrap_or(0)
+        1 + self.children.iter().map(|c| c.depth()).max().unwrap_or(0)
     }
 }

--- a/httui-core/src/explain/postgres.rs
+++ b/httui-core/src/explain/postgres.rs
@@ -66,10 +66,7 @@ fn parse_node(plan: &Value, root_total_cost: f64, is_root: bool) -> PlanNode {
         .get("Startup Cost")
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
-    let rows = plan
-        .get("Plan Rows")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let rows = plan.get("Plan Rows").and_then(|v| v.as_u64()).unwrap_or(0);
     let pct = if root_total_cost > 0.0 {
         ((total_cost / root_total_cost) * 100.0).round().min(100.0) as u8
     } else {
@@ -231,7 +228,13 @@ mod tests {
         // small Seq Scan plan is clean.
         assert!(!n.warn);
         // Direct check: at child level, 0% pct + 100 rows => no warn.
-        assert!(!super::compute_warn("Seq Scan", 100, 0, &Value::Null, false));
+        assert!(!super::compute_warn(
+            "Seq Scan",
+            100,
+            0,
+            &Value::Null,
+            false
+        ));
     }
 
     #[test]

--- a/httui-core/src/explain/prefix.rs
+++ b/httui-core/src/explain/prefix.rs
@@ -232,9 +232,7 @@ mod tests {
 
     #[test]
     fn explain_error_implements_std_error_trait() {
-        let err = ExplainError::Unsupported {
-            driver: "x".into(),
-        };
+        let err = ExplainError::Unsupported { driver: "x".into() };
         let _: &dyn std::error::Error = &err;
     }
 }

--- a/httui-core/src/frontmatter/mod.rs
+++ b/httui-core/src/frontmatter/mod.rs
@@ -31,6 +31,5 @@
 pub mod parser;
 
 pub use parser::{
-    assemble_with_body, parse_frontmatter, split_frontmatter, Frontmatter,
-    FrontmatterStatus, Split,
+    assemble_with_body, parse_frontmatter, split_frontmatter, Frontmatter, FrontmatterStatus, Split,
 };

--- a/httui-core/src/frontmatter/parser.rs
+++ b/httui-core/src/frontmatter/parser.rs
@@ -114,8 +114,7 @@ pub fn assemble_with_body(raw_yaml: &str, body: &str) -> String {
 
 fn parse_typed(raw_yaml: &str) -> Frontmatter {
     let mut fm = Frontmatter::default();
-    let mut iter = raw_yaml.lines().peekable();
-    while let Some(line) = iter.next() {
+    for line in raw_yaml.lines() {
         let trimmed = line.trim_end_matches(['\r', '\n']);
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -201,8 +200,7 @@ mod tests {
 
     #[test]
     fn split_handles_crlf_fences() {
-        let s =
-            split_frontmatter("---\r\ntitle: foo\r\n---\r\nbody\r\n").unwrap();
+        let s = split_frontmatter("---\r\ntitle: foo\r\n---\r\nbody\r\n").unwrap();
         assert!(s.raw_yaml.contains("title: foo"));
         assert!(s.body.starts_with("body"));
     }
@@ -247,23 +245,23 @@ mod tests {
 
     #[test]
     fn parse_unquotes_double_and_single_quotes() {
-        let (fm, _) =
-            parse_frontmatter("---\ntitle: \"Hi\"\nowner: 'bob'\n---\n").unwrap();
+        let (fm, _) = parse_frontmatter("---\ntitle: \"Hi\"\nowner: 'bob'\n---\n").unwrap();
         assert_eq!(fm.title.as_deref(), Some("Hi"));
         assert_eq!(fm.owner.as_deref(), Some("bob"));
     }
 
     #[test]
     fn parse_falls_back_to_extra_for_unknown_keys() {
-        let (fm, _) =
-            parse_frontmatter("---\ntitle: foo\ncustom_field: hello\n---\n").unwrap();
-        assert_eq!(fm.extra.get("custom_field").map(String::as_str), Some("hello"));
+        let (fm, _) = parse_frontmatter("---\ntitle: foo\ncustom_field: hello\n---\n").unwrap();
+        assert_eq!(
+            fm.extra.get("custom_field").map(String::as_str),
+            Some("hello")
+        );
     }
 
     #[test]
     fn parse_skips_empty_and_comment_lines() {
-        let input =
-            "---\n# A comment\n\ntitle: foo\n# another comment\n---\nbody\n";
+        let input = "---\n# A comment\n\ntitle: foo\n# another comment\n---\nbody\n";
         let (fm, _) = parse_frontmatter(input).unwrap();
         assert_eq!(fm.title.as_deref(), Some("foo"));
     }
@@ -272,18 +270,26 @@ mod tests {
     fn parse_skips_indented_lines_at_top_level() {
         // Indented children of `abstract:` / `preflight:` round-trip
         // via the raw region but are NOT picked up as typed keys.
-        let input =
-            "---\ntitle: foo\nabstract: |\n  hello\n  world\n---\nbody\n";
+        let input = "---\ntitle: foo\nabstract: |\n  hello\n  world\n---\nbody\n";
         let (fm, _) = parse_frontmatter(input).unwrap();
         assert_eq!(fm.title.as_deref(), Some("foo"));
-        assert!(fm.extra.is_empty() || fm.extra.get("abstract").is_some());
+        assert!(fm.extra.is_empty() || fm.extra.contains_key("abstract"));
     }
 
     #[test]
     fn parse_status_recognises_each_variant() {
-        assert_eq!(FrontmatterStatus::parse("draft"), Some(FrontmatterStatus::Draft));
-        assert_eq!(FrontmatterStatus::parse("active"), Some(FrontmatterStatus::Active));
-        assert_eq!(FrontmatterStatus::parse("archived"), Some(FrontmatterStatus::Archived));
+        assert_eq!(
+            FrontmatterStatus::parse("draft"),
+            Some(FrontmatterStatus::Draft)
+        );
+        assert_eq!(
+            FrontmatterStatus::parse("active"),
+            Some(FrontmatterStatus::Active)
+        );
+        assert_eq!(
+            FrontmatterStatus::parse("archived"),
+            Some(FrontmatterStatus::Archived)
+        );
         assert_eq!(FrontmatterStatus::parse("nope"), None);
     }
 
@@ -295,8 +301,7 @@ mod tests {
 
     #[test]
     fn parse_flow_list_handles_quoted_items() {
-        let (fm, _) =
-            parse_frontmatter("---\ntags: [\"hello world\", debug]\n---\n").unwrap();
+        let (fm, _) = parse_frontmatter("---\ntags: [\"hello world\", debug]\n---\n").unwrap();
         assert_eq!(fm.tags, vec!["hello world", "debug"]);
     }
 

--- a/httui-core/src/fs/mod.rs
+++ b/httui-core/src/fs/mod.rs
@@ -204,8 +204,14 @@ mod tests {
 
         let entries = list_workspace(root.to_str().unwrap()).unwrap();
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert!(!names.contains(&"envs"), "envs should be hidden, got: {names:?}");
-        assert!(names.contains(&"runbooks"), "runbooks should appear, got: {names:?}");
+        assert!(
+            !names.contains(&"envs"),
+            "envs should be hidden, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"runbooks"),
+            "runbooks should appear, got: {names:?}"
+        );
     }
 
     #[test]

--- a/httui-core/src/git/checkout.rs
+++ b/httui-core/src/git/checkout.rs
@@ -160,13 +160,11 @@ mod tests {
         commit_all(dir.path(), "base");
         // Branch off and write THEIRS.
         git_checkout_b(dir.path(), "feat/theirs").unwrap();
-        std::fs::write(dir.path().join("conflict.txt"), "from-theirs\n")
-            .unwrap();
+        std::fs::write(dir.path().join("conflict.txt"), "from-theirs\n").unwrap();
         commit_all(dir.path(), "theirs change");
         // Back to main and write OURS over the same line.
         git_checkout(dir.path(), "main").unwrap();
-        std::fs::write(dir.path().join("conflict.txt"), "from-ours\n")
-            .unwrap();
+        std::fs::write(dir.path().join("conflict.txt"), "from-ours\n").unwrap();
         commit_all(dir.path(), "ours change");
         // Attempt the merge — must fail with conflict.
         let merge = std::process::Command::new("git");
@@ -185,8 +183,7 @@ mod tests {
     #[test]
     fn checkout_conflict_ours_keeps_ours_version() {
         let dir = make_merge_conflict();
-        git_checkout_conflict_path(dir.path(), "conflict.txt", ConflictSide::Ours)
-            .unwrap();
+        git_checkout_conflict_path(dir.path(), "conflict.txt", ConflictSide::Ours).unwrap();
         let body = std::fs::read_to_string(dir.path().join("conflict.txt")).unwrap();
         assert_eq!(body.trim_end(), "from-ours");
     }
@@ -194,12 +191,7 @@ mod tests {
     #[test]
     fn checkout_conflict_theirs_keeps_theirs_version() {
         let dir = make_merge_conflict();
-        git_checkout_conflict_path(
-            dir.path(),
-            "conflict.txt",
-            ConflictSide::Theirs,
-        )
-        .unwrap();
+        git_checkout_conflict_path(dir.path(), "conflict.txt", ConflictSide::Theirs).unwrap();
         let body = std::fs::read_to_string(dir.path().join("conflict.txt")).unwrap();
         assert_eq!(body.trim_end(), "from-theirs");
     }
@@ -208,9 +200,7 @@ mod tests {
     fn checkout_conflict_rejects_empty_path() {
         let dir = TempDir::new().unwrap();
         init_repo(dir.path());
-        let err =
-            git_checkout_conflict_path(dir.path(), "  ", ConflictSide::Ours)
-                .unwrap_err();
+        let err = git_checkout_conflict_path(dir.path(), "  ", ConflictSide::Ours).unwrap_err();
         assert!(err.contains("empty"));
     }
 
@@ -224,12 +214,8 @@ mod tests {
         init_repo(dir.path());
         std::fs::write(dir.path().join("clean.txt"), "fine\n").unwrap();
         commit_all(dir.path(), "init");
-        let err = git_checkout_conflict_path(
-            dir.path(),
-            "ghost.txt",
-            ConflictSide::Ours,
-        )
-        .unwrap_err();
+        let err =
+            git_checkout_conflict_path(dir.path(), "ghost.txt", ConflictSide::Ours).unwrap_err();
         assert!(!err.is_empty(), "stderr should surface git's reason");
     }
 

--- a/httui-core/src/git/clone.rs
+++ b/httui-core/src/git/clone.rs
@@ -50,16 +50,10 @@ pub fn git_clone(url: &str, parent: Option<&Path>) -> Result<CloneOutcome, Strin
     };
 
     if !parent_dir.exists() {
-        return Err(format!(
-            "pasta pai '{}' não existe",
-            parent_dir.display()
-        ));
+        return Err(format!("pasta pai '{}' não existe", parent_dir.display()));
     }
     if !parent_dir.is_dir() {
-        return Err(format!(
-            "'{}' não é uma pasta",
-            parent_dir.display()
-        ));
+        return Err(format!("'{}' não é uma pasta", parent_dir.display()));
     }
 
     let dest = parent_dir.join(&name);
@@ -70,10 +64,7 @@ pub fn git_clone(url: &str, parent: Option<&Path>) -> Result<CloneOutcome, Strin
             .map(|mut it| it.next().is_none())
             .unwrap_or(false);
         if !is_empty {
-            return Err(format!(
-                "'{}' já existe e não está vazio",
-                dest.display()
-            ));
+            return Err(format!("'{}' já existe e não está vazio", dest.display()));
         }
     }
 
@@ -116,13 +107,8 @@ fn default_parent_dir() -> Result<PathBuf, String> {
 /// `/local/path/repo.git` → `repo`
 pub(crate) fn derive_repo_name(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');
-    let without_git = trimmed
-        .strip_suffix(".git")
-        .unwrap_or(trimmed);
-    let last = without_git
-        .rsplit(['/', ':'])
-        .next()
-        .unwrap_or("");
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let last = without_git.rsplit(['/', ':']).next().unwrap_or("");
     last.to_string()
 }
 
@@ -135,7 +121,10 @@ mod tests {
     fn make_bare_remote() -> TempDir {
         let dir = TempDir::new().unwrap();
         let mut cmd = Command::new("git");
-        cmd.arg("init").arg("--bare").arg(dir.path());
+        cmd.arg("init")
+            .arg("--bare")
+            .arg("--initial-branch=main")
+            .arg(dir.path());
         scrub_git_env(&mut cmd);
         let out = cmd.output().unwrap();
         assert!(out.status.success(), "init --bare failed");
@@ -147,10 +136,28 @@ mod tests {
 
         let work = TempDir::new().unwrap();
         for args in [
-            vec!["init", work.path().to_str().unwrap()],
-            vec!["-C", work.path().to_str().unwrap(), "config", "user.email", "t@t"],
-            vec!["-C", work.path().to_str().unwrap(), "config", "user.name", "t"],
-            vec!["-C", work.path().to_str().unwrap(), "config", "commit.gpgsign", "false"],
+            vec!["init", "-b", "main", work.path().to_str().unwrap()],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "user.email",
+                "t@t",
+            ],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "user.name",
+                "t",
+            ],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "commit.gpgsign",
+                "false",
+            ],
         ] {
             let mut c = Command::new("git");
             c.args(args);
@@ -161,8 +168,21 @@ mod tests {
         for args in [
             vec!["-C", work.path().to_str().unwrap(), "add", "-A"],
             vec!["-C", work.path().to_str().unwrap(), "commit", "-m", "init"],
-            vec!["-C", work.path().to_str().unwrap(), "remote", "add", "origin", bare.path().to_str().unwrap()],
-            vec!["-C", work.path().to_str().unwrap(), "push", "origin", "HEAD:main"],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "remote",
+                "add",
+                "origin",
+                bare.path().to_str().unwrap(),
+            ],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "push",
+                "origin",
+                "HEAD:main",
+            ],
         ] {
             let mut c = Command::new("git");
             c.args(args);
@@ -236,8 +256,7 @@ mod tests {
     fn parent_does_not_exist_returns_friendly_error() {
         let parent = TempDir::new().unwrap();
         let missing_parent = parent.path().join("missing");
-        let err =
-            git_clone("https://example.invalid/x.git", Some(&missing_parent)).unwrap_err();
+        let err = git_clone("https://example.invalid/x.git", Some(&missing_parent)).unwrap_err();
         assert!(err.contains("pasta pai"), "got: {err}");
     }
 
@@ -258,13 +277,12 @@ mod tests {
         let leaf = derive_repo_name(bare.path().to_str().unwrap());
         let expected_dest = parent.path().join(&leaf);
 
-        let outcome = git_clone(
-            bare.path().to_str().unwrap(),
-            Some(parent.path()),
-        )
-        .unwrap();
+        let outcome = git_clone(bare.path().to_str().unwrap(), Some(parent.path())).unwrap();
         assert_eq!(outcome.destination, expected_dest);
-        assert!(expected_dest.join(".git").is_dir(), ".git folder should exist");
+        assert!(
+            expected_dest.join(".git").is_dir(),
+            ".git folder should exist"
+        );
         assert!(
             expected_dest.join("README.md").is_file(),
             "seeded file should be present"
@@ -279,11 +297,7 @@ mod tests {
         let leaf_dir = parent.path().join(&leaf);
         std::fs::create_dir(&leaf_dir).unwrap();
 
-        let outcome = git_clone(
-            bare.path().to_str().unwrap(),
-            Some(parent.path()),
-        )
-        .unwrap();
+        let outcome = git_clone(bare.path().to_str().unwrap(), Some(parent.path())).unwrap();
         assert_eq!(outcome.destination, leaf_dir);
         assert!(leaf_dir.join(".git").is_dir());
     }

--- a/httui-core/src/git/conflict.rs
+++ b/httui-core/src/git/conflict.rs
@@ -31,10 +31,7 @@ pub struct ConflictVersions {
 /// path has no conflict stages at all (not unmerged / bad path) so
 /// the UI can distinguish "nothing to resolve" from "one side was
 /// an add".
-pub fn git_conflict_versions(
-    vault: &Path,
-    path: &str,
-) -> Result<ConflictVersions, String> {
+pub fn git_conflict_versions(vault: &Path, path: &str) -> Result<ConflictVersions, String> {
     let stage = |n: u8| -> String {
         let spec = format!(":{n}:{path}");
         run_git(vault, &["show", &spec]).unwrap_or_default()
@@ -109,8 +106,7 @@ mod tests {
         init_repo(dir.path());
         std::fs::write(dir.path().join("clean.txt"), "x\n").unwrap();
         commit_all(dir.path(), "clean");
-        let err =
-            git_conflict_versions(dir.path(), "clean.txt").unwrap_err();
+        let err = git_conflict_versions(dir.path(), "clean.txt").unwrap_err();
         assert!(err.contains("no conflict stages"), "got: {err}");
     }
 }

--- a/httui-core/src/git/log.rs
+++ b/httui-core/src/git/log.rs
@@ -54,20 +54,10 @@ pub fn git_log(
 /// or a chain when `--follow` walks renames. We pick the **last**
 /// (oldest) entry as the original author. Avoids `--reverse -n 1`,
 /// whose ordering interaction is git-version-dependent.
-pub fn git_first_commit_author(
-    vault: &Path,
-    path: &str,
-) -> Result<Option<CommitInfo>, String> {
+pub fn git_first_commit_author(vault: &Path, path: &str) -> Result<Option<CommitInfo>, String> {
     let raw = run_git(
         vault,
-        &[
-            "log",
-            "--follow",
-            "--diff-filter=A",
-            PRETTY,
-            "--",
-            path,
-        ],
+        &["log", "--follow", "--diff-filter=A", PRETTY, "--", path],
     )?;
     let parsed = parse_log(&raw)?;
     Ok(parsed.into_iter().last())

--- a/httui-core/src/git/mod.rs
+++ b/httui-core/src/git/mod.rs
@@ -23,8 +23,8 @@ pub mod status;
 pub mod sync;
 
 pub use checkout::{git_checkout, git_checkout_b, git_checkout_conflict_path, ConflictSide};
-pub use conflict::{git_conflict_versions, ConflictVersions};
 pub use clone::{git_clone, CloneOutcome};
+pub use conflict::{git_conflict_versions, ConflictVersions};
 pub use log::{git_first_commit_author, git_log, CommitInfo};
 pub use remote::{git_remote_list, Remote};
 pub use remote_host::{parse_remote_url, ParsedRemote, RemoteHost};
@@ -146,13 +146,16 @@ pub(crate) mod test_helpers {
     /// non-interactive identity, return the path. Caller keeps the
     /// `TempDir` alive.
     pub fn init_repo(path: &Path) {
-        let init = git().arg("init").arg(path).output().unwrap();
+        let init = git()
+            .args(["init", "-b", "main"])
+            .arg(path)
+            .output()
+            .unwrap();
         assert!(init.status.success(), "git init failed");
         for (k, v) in [
             ("user.email", "test@httui.local"),
             ("user.name", "Test"),
             ("commit.gpgsign", "false"),
-            ("init.defaultBranch", "main"),
         ] {
             let r = git()
                 .arg("-C")
@@ -223,8 +226,7 @@ mod tests {
     fn gitignored_returns_true_when_pattern_matches() {
         let dir = TempDir::new().unwrap();
         test_helpers::init_repo(dir.path());
-        std::fs::write(dir.path().join(".gitignore"), "node_modules/\n*.env\n")
-            .unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "node_modules/\n*.env\n").unwrap();
         // Files don't even need to exist — `git check-ignore` works
         // off the patterns alone.
         assert!(is_path_gitignored(dir.path(), "node_modules/foo/.env"));

--- a/httui-core/src/git/remote.rs
+++ b/httui-core/src/git/remote.rs
@@ -44,10 +44,7 @@ fn parse_remote_list(raw: &str) -> Vec<Remote> {
         if url.is_empty() {
             continue;
         }
-        if !out
-            .iter()
-            .any(|r| r.name == name && r.url == url)
-        {
+        if !out.iter().any(|r| r.name == name && r.url == url) {
             out.push(Remote {
                 name: name.to_string(),
                 url,

--- a/httui-core/src/git/status.rs
+++ b/httui-core/src/git/status.rs
@@ -313,7 +313,7 @@ mod tests {
         use std::process::Command;
         let remote = TempDir::new().unwrap();
         Command::new("git")
-            .args(["init", "--bare"])
+            .args(["init", "--bare", "--initial-branch=main"])
             .arg(remote.path())
             .output()
             .unwrap();

--- a/httui-core/src/git/sync.rs
+++ b/httui-core/src/git/sync.rs
@@ -165,7 +165,11 @@ mod tests {
         let remote = TempDir::new().unwrap();
         let mut init = Command::new("git");
         scrub_git_env(&mut init);
-        init.arg("init").arg("--bare").arg(remote.path()).output().unwrap();
+        init.arg("init")
+            .arg("--bare")
+            .arg(remote.path())
+            .output()
+            .unwrap();
         let local = TempDir::new().unwrap();
         init_repo(local.path());
         std::fs::write(local.path().join("a"), "x").unwrap();

--- a/httui-core/src/preflight/evaluator.rs
+++ b/httui-core/src/preflight/evaluator.rs
@@ -171,7 +171,9 @@ mod tests {
         let (envs, conns, branch) = ctx_with(None, &[], &[]);
         let ctx = make_ctx(&branch, &envs, &conns);
         let r = evaluate_preflight(
-            &[PreflightItem::Branch { name: "main".into() }],
+            &[PreflightItem::Branch {
+                name: "main".into(),
+            }],
             &ctx,
         );
         assert!(matches!(r[0], CheckResult::Skip { .. }));
@@ -182,7 +184,9 @@ mod tests {
         let (envs, conns, branch) = ctx_with(Some("main"), &[], &[]);
         let ctx = make_ctx(&branch, &envs, &conns);
         let r = evaluate_preflight(
-            &[PreflightItem::Branch { name: "main".into() }],
+            &[PreflightItem::Branch {
+                name: "main".into(),
+            }],
             &ctx,
         );
         assert_eq!(r[0], CheckResult::Pass);
@@ -193,7 +197,9 @@ mod tests {
         let (envs, conns, branch) = ctx_with(Some("feat/x"), &[], &[]);
         let ctx = make_ctx(&branch, &envs, &conns);
         let r = evaluate_preflight(
-            &[PreflightItem::Branch { name: "main".into() }],
+            &[PreflightItem::Branch {
+                name: "main".into(),
+            }],
             &ctx,
         );
         if let CheckResult::Fail { reason } = &r[0] {
@@ -208,12 +214,7 @@ mod tests {
     fn file_exists_skips_in_pure_layer() {
         let (envs, conns, branch) = ctx_with(None, &[], &[]);
         let ctx = make_ctx(&branch, &envs, &conns);
-        let r = evaluate_preflight(
-            &[PreflightItem::FileExists {
-                path: "x".into(),
-            }],
-            &ctx,
-        );
+        let r = evaluate_preflight(&[PreflightItem::FileExists { path: "x".into() }], &ctx);
         if let CheckResult::Skip { reason } = &r[0] {
             assert!(reason.contains("FS"));
         } else {
@@ -263,7 +264,9 @@ mod tests {
         let items = vec![
             PreflightItem::Connection { name: "c1".into() },
             PreflightItem::EnvVar { name: "A".into() },
-            PreflightItem::Branch { name: "main".into() },
+            PreflightItem::Branch {
+                name: "main".into(),
+            },
         ];
         let r = evaluate_preflight(&items, &ctx);
         assert_eq!(
@@ -276,10 +279,7 @@ mod tests {
     fn check_result_serializes_with_outcome_tag() {
         let pass = serde_json::to_string(&CheckResult::Pass).unwrap();
         assert!(pass.contains("\"outcome\":\"pass\""));
-        let fail = serde_json::to_string(&CheckResult::Fail {
-            reason: "x".into(),
-        })
-        .unwrap();
+        let fail = serde_json::to_string(&CheckResult::Fail { reason: "x".into() }).unwrap();
         assert!(fail.contains("\"outcome\":\"fail\""));
         assert!(fail.contains("\"reason\":\"x\""));
     }

--- a/httui-core/src/preflight/io_evaluator.rs
+++ b/httui-core/src/preflight/io_evaluator.rs
@@ -110,10 +110,7 @@ fn which_in_path(exe: &str, path_var: &std::ffi::OsStr) -> bool {
             for ext in windows_exe_exts() {
                 let mut candidate = dir.join(exe);
                 if !ext.is_empty() {
-                    let mut name = candidate
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_os_string();
+                    let mut name = candidate.file_name().unwrap_or_default().to_os_string();
                     name.push(ext);
                     candidate.set_file_name(name);
                 }
@@ -277,10 +274,7 @@ mod tests {
     fn which_in_path_fails_when_executable_not_under_supplied_path() {
         let dir = tempdir().unwrap(); // empty
         let path_var = dir.path().as_os_str();
-        let r = evaluate_command_with_path(
-            "definitely-not-installed-xyz",
-            path_var,
-        );
+        let r = evaluate_command_with_path("definitely-not-installed-xyz", path_var);
         if let CheckResult::Fail { reason } = &r {
             assert!(reason.contains("definitely-not-installed-xyz"));
             assert!(reason.contains("PATH"));
@@ -309,10 +303,7 @@ mod tests {
         path_str.push_str(sep);
         path_str.push_str(&dir.path().to_string_lossy());
         path_str.push_str(sep);
-        let r = evaluate_command_with_path(
-            "tool --version",
-            std::ffi::OsStr::new(&path_str),
-        );
+        let r = evaluate_command_with_path("tool --version", std::ffi::OsStr::new(&path_str));
         assert_eq!(r, CheckResult::Pass);
     }
 
@@ -323,7 +314,9 @@ mod tests {
         let conns = HashSet::new();
         let ctx = empty_ctx(&envs, &conns);
         let r = evaluate_preflight_with_io(
-            &[PreflightItem::Command { command: "   ".into() }],
+            &[PreflightItem::Command {
+                command: "   ".into(),
+            }],
             &ctx,
             dir.path(),
         );
@@ -378,7 +371,9 @@ mod tests {
             PreflightItem::EnvVar {
                 name: "API_TOKEN".into(),
             },
-            PreflightItem::Branch { name: "main".into() },
+            PreflightItem::Branch {
+                name: "main".into(),
+            },
             PreflightItem::Unknown {
                 key: "future".into(),
                 value: "x".into(),

--- a/httui-core/src/preflight/parser.rs
+++ b/httui-core/src/preflight/parser.rs
@@ -211,10 +211,7 @@ mod tests {
     fn parse_drops_lines_without_dash_marker() {
         let raw = "preflight:\n  not_a_list_item\n  - connection: ok\n";
         let items = parse_preflight(raw);
-        assert_eq!(
-            items,
-            vec![PreflightItem::Connection { name: "ok".into() }]
-        );
+        assert_eq!(items, vec![PreflightItem::Connection { name: "ok".into() }]);
     }
 
     #[test]
@@ -254,10 +251,7 @@ mod tests {
     fn parse_handles_tab_indentation() {
         let raw = "preflight:\n\t- connection: a\n";
         let items = parse_preflight(raw);
-        assert_eq!(
-            items,
-            vec![PreflightItem::Connection { name: "a".into() }]
-        );
+        assert_eq!(items, vec![PreflightItem::Connection { name: "a".into() }]);
     }
 
     #[test]
@@ -266,17 +260,12 @@ mod tests {
         // stops after the first one and ignores the rest.
         let raw = "preflight:\n  - connection: a\nowner: alice\npreflight:\n  - connection: b\n";
         let items = parse_preflight(raw);
-        assert_eq!(
-            items,
-            vec![PreflightItem::Connection { name: "a".into() }]
-        );
+        assert_eq!(items, vec![PreflightItem::Connection { name: "a".into() }]);
     }
 
     #[test]
     fn parse_serializes_kind_via_serde() {
-        let item = PreflightItem::Connection {
-            name: "db".into(),
-        };
+        let item = PreflightItem::Connection { name: "db".into() };
         let json = serde_json::to_string(&item).unwrap();
         assert!(json.contains("\"kind\":\"connection\""));
         assert!(json.contains("\"name\":\"db\""));

--- a/httui-core/src/run_bodies.rs
+++ b/httui-core/src/run_bodies.rs
@@ -61,8 +61,7 @@ pub fn write_run_body(
 ) -> Result<PathBuf, String> {
     let block_dir = block_dir_for(vault_root, file_path, alias)?;
     sanitize_id(run_id, "run_id")?;
-    fs::create_dir_all(&block_dir)
-        .map_err(|e| format!("create_dir_all failed: {e}"))?;
+    fs::create_dir_all(&block_dir).map_err(|e| format!("create_dir_all failed: {e}"))?;
 
     let filename = format!("{run_id}.{}", ext_for(kind));
     let final_path = block_dir.join(&filename);
@@ -78,10 +77,8 @@ pub fn write_run_body(
         body.to_vec()
     };
 
-    fs::write(&tmp_path, &payload)
-        .map_err(|e| format!("tmp write failed: {e}"))?;
-    fs::rename(&tmp_path, &final_path)
-        .map_err(|e| format!("rename failed: {e}"))?;
+    fs::write(&tmp_path, &payload).map_err(|e| format!("tmp write failed: {e}"))?;
+    fs::rename(&tmp_path, &final_path).map_err(|e| format!("rename failed: {e}"))?;
     Ok(final_path)
 }
 
@@ -131,9 +128,7 @@ pub fn list_run_bodies(
             None => continue,
         };
         // Ignore in-flight tmp files.
-        if stem.ends_with(".tmp") || path.extension().and_then(|s| s.to_str())
-            == Some("tmp")
-        {
+        if stem.ends_with(".tmp") || path.extension().and_then(|s| s.to_str()) == Some("tmp") {
             continue;
         }
         let ext = match path.extension().and_then(|s| s.to_str()) {
@@ -213,11 +208,9 @@ pub fn rename_alias_runs(
         ));
     }
     if let Some(parent) = new_dir.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("create_dir_all failed: {e}"))?;
+        fs::create_dir_all(parent).map_err(|e| format!("create_dir_all failed: {e}"))?;
     }
-    fs::rename(&old_dir, &new_dir)
-        .map_err(|e| format!("rename failed: {e}"))?;
+    fs::rename(&old_dir, &new_dir).map_err(|e| format!("rename failed: {e}"))?;
     Ok(true)
 }
 
@@ -240,11 +233,7 @@ fn ext_truncation_check(path: &Path, byte_size: u64) -> bool {
     bytes.ends_with(TRUNCATE_MARKER)
 }
 
-fn block_dir_for(
-    vault_root: &Path,
-    file_path: &str,
-    alias: &str,
-) -> Result<PathBuf, String> {
+fn block_dir_for(vault_root: &Path, file_path: &str, alias: &str) -> Result<PathBuf, String> {
     sanitize_id(alias, "alias")?;
     let rel = sanitize_file_path(file_path)?;
     let mut p = vault_root.to_path_buf();
@@ -313,9 +302,7 @@ mod tests {
             br#"{"id":42}"#,
         )
         .unwrap();
-        assert!(path.ends_with(
-            ".httui/runs/runbook.md/fetchUser/01H8XK00000000000000000000.json"
-        ));
+        assert!(path.ends_with(".httui/runs/runbook.md/fetchUser/01H8XK00000000000000000000.json"));
         let read = read_run_body(
             dir.path(),
             "runbook.md",
@@ -353,15 +340,8 @@ mod tests {
     fn body_over_cap_is_truncated_with_marker() {
         let dir = tempdir().unwrap();
         let big = vec![b'A'; MAX_RUN_BODY_BYTES + 1024];
-        let path = write_run_body(
-            dir.path(),
-            "x.md",
-            "a",
-            "r1",
-            RunBodyKind::Binary,
-            &big,
-        )
-        .unwrap();
+        let path =
+            write_run_body(dir.path(), "x.md", "a", "r1", RunBodyKind::Binary, &big).unwrap();
         let bytes = std::fs::read(&path).unwrap();
         assert_eq!(bytes.len(), MAX_RUN_BODY_BYTES);
         assert!(bytes.ends_with(TRUNCATE_MARKER));
@@ -371,15 +351,8 @@ mod tests {
     fn body_at_cap_is_not_truncated() {
         let dir = tempdir().unwrap();
         let exact = vec![b'A'; MAX_RUN_BODY_BYTES];
-        let path = write_run_body(
-            dir.path(),
-            "x.md",
-            "a",
-            "r1",
-            RunBodyKind::Binary,
-            &exact,
-        )
-        .unwrap();
+        let path =
+            write_run_body(dir.path(), "x.md", "a", "r1", RunBodyKind::Binary, &exact).unwrap();
         let bytes = std::fs::read(&path).unwrap();
         assert_eq!(bytes.len(), MAX_RUN_BODY_BYTES);
         assert!(!bytes.ends_with(TRUNCATE_MARKER));
@@ -389,15 +362,7 @@ mod tests {
     fn list_run_bodies_returns_newest_first() {
         let dir = tempdir().unwrap();
         for id in ["01a", "01b", "01c"] {
-            write_run_body(
-                dir.path(),
-                "x.md",
-                "a",
-                id,
-                RunBodyKind::Json,
-                b"{}",
-            )
-            .unwrap();
+            write_run_body(dir.path(), "x.md", "a", id, RunBodyKind::Json, b"{}").unwrap();
         }
         let entries = list_run_bodies(dir.path(), "x.md", "a").unwrap();
         let ids: Vec<&str> = entries.iter().map(|e| e.run_id.as_str()).collect();
@@ -414,19 +379,9 @@ mod tests {
     #[test]
     fn list_skips_non_recognized_extensions() {
         let dir = tempdir().unwrap();
-        write_run_body(
-            dir.path(),
-            "x.md",
-            "a",
-            "01a",
-            RunBodyKind::Json,
-            b"{}",
-        )
-        .unwrap();
+        write_run_body(dir.path(), "x.md", "a", "01a", RunBodyKind::Json, b"{}").unwrap();
         // Sneak in a stray file that should be ignored.
-        let block_dir = dir
-            .path()
-            .join(".httui/runs/x.md/a");
+        let block_dir = dir.path().join(".httui/runs/x.md/a");
         std::fs::write(block_dir.join("something.txt"), "noise").unwrap();
         let entries = list_run_bodies(dir.path(), "x.md", "a").unwrap();
         assert_eq!(entries.len(), 1);
@@ -437,15 +392,7 @@ mod tests {
     fn trim_keeps_newest_n_and_returns_count_deleted() {
         let dir = tempdir().unwrap();
         for id in ["01a", "01b", "01c", "01d", "01e"] {
-            write_run_body(
-                dir.path(),
-                "x.md",
-                "a",
-                id,
-                RunBodyKind::Json,
-                b"{}",
-            )
-            .unwrap();
+            write_run_body(dir.path(), "x.md", "a", id, RunBodyKind::Json, b"{}").unwrap();
         }
         let deleted = trim_run_bodies(dir.path(), "x.md", "a", 2).unwrap();
         assert_eq!(deleted, 3);
@@ -461,22 +408,11 @@ mod tests {
     fn trim_no_op_when_under_cap() {
         let dir = tempdir().unwrap();
         for id in ["01a", "01b"] {
-            write_run_body(
-                dir.path(),
-                "x.md",
-                "a",
-                id,
-                RunBodyKind::Json,
-                b"{}",
-            )
-            .unwrap();
+            write_run_body(dir.path(), "x.md", "a", id, RunBodyKind::Json, b"{}").unwrap();
         }
         let deleted = trim_run_bodies(dir.path(), "x.md", "a", 10).unwrap();
         assert_eq!(deleted, 0);
-        assert_eq!(
-            list_run_bodies(dir.path(), "x.md", "a").unwrap().len(),
-            2
-        );
+        assert_eq!(list_run_bodies(dir.path(), "x.md", "a").unwrap().len(), 2);
     }
 
     #[test]
@@ -534,15 +470,8 @@ mod tests {
     #[test]
     fn leading_slashes_stripped_from_file_path() {
         let dir = tempdir().unwrap();
-        let path = write_run_body(
-            dir.path(),
-            "/x.md",
-            "a",
-            "r1",
-            RunBodyKind::Json,
-            b"{}",
-        )
-        .unwrap();
+        let path =
+            write_run_body(dir.path(), "/x.md", "a", "r1", RunBodyKind::Json, b"{}").unwrap();
         assert!(path.starts_with(dir.path().join(".httui/runs/x.md/a")));
     }
 
@@ -590,15 +519,7 @@ mod tests {
     fn rename_alias_moves_existing_runs() {
         let dir = tempdir().unwrap();
         for run_id in ["r1", "r2", "r3"] {
-            write_run_body(
-                dir.path(),
-                "rb.md",
-                "old",
-                run_id,
-                RunBodyKind::Json,
-                b"{}",
-            )
-            .unwrap();
+            write_run_body(dir.path(), "rb.md", "old", run_id, RunBodyKind::Json, b"{}").unwrap();
         }
         let moved = rename_alias_runs(dir.path(), "rb.md", "old", "new").unwrap();
         assert!(moved);
@@ -617,34 +538,16 @@ mod tests {
     fn rename_alias_returns_false_when_source_missing() {
         let dir = tempdir().unwrap();
         // Nothing has run yet — no source dir.
-        let moved =
-            rename_alias_runs(dir.path(), "rb.md", "missing", "fresh").unwrap();
+        let moved = rename_alias_runs(dir.path(), "rb.md", "missing", "fresh").unwrap();
         assert!(!moved);
     }
 
     #[test]
     fn rename_alias_errors_when_destination_already_has_runs() {
         let dir = tempdir().unwrap();
-        write_run_body(
-            dir.path(),
-            "rb.md",
-            "src",
-            "r1",
-            RunBodyKind::Json,
-            b"{}",
-        )
-        .unwrap();
-        write_run_body(
-            dir.path(),
-            "rb.md",
-            "dst",
-            "r1",
-            RunBodyKind::Json,
-            b"{}",
-        )
-        .unwrap();
-        let err =
-            rename_alias_runs(dir.path(), "rb.md", "src", "dst").unwrap_err();
+        write_run_body(dir.path(), "rb.md", "src", "r1", RunBodyKind::Json, b"{}").unwrap();
+        write_run_body(dir.path(), "rb.md", "dst", "r1", RunBodyKind::Json, b"{}").unwrap();
+        let err = rename_alias_runs(dir.path(), "rb.md", "src", "dst").unwrap_err();
         assert!(err.contains("already"));
         // Source still in place — caller can resolve and retry.
         let from_src = list_run_bodies(dir.path(), "rb.md", "src").unwrap();
@@ -654,17 +557,14 @@ mod tests {
     #[test]
     fn rename_alias_rejects_invalid_alias_names() {
         let dir = tempdir().unwrap();
-        let err =
-            rename_alias_runs(dir.path(), "rb.md", "ok", "bad/slash")
-                .unwrap_err();
+        let err = rename_alias_runs(dir.path(), "rb.md", "ok", "bad/slash").unwrap_err();
         assert!(err.contains("invalid char"));
     }
 
     #[test]
     fn rename_alias_rejects_traversal_in_file_path() {
         let dir = tempdir().unwrap();
-        let err =
-            rename_alias_runs(dir.path(), "../escape.md", "a", "b").unwrap_err();
+        let err = rename_alias_runs(dir.path(), "../escape.md", "a", "b").unwrap_err();
         assert!(err.contains(".."));
     }
 }

--- a/httui-core/src/tag_index.rs
+++ b/httui-core/src/tag_index.rs
@@ -147,9 +147,7 @@ mod tests {
             .map(|t| (*t).to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        format!(
-            "---\ntitle: \"Doc\"\ntags: [{tags_csv}]\n---\n# body\n",
-        )
+        format!("---\ntitle: \"Doc\"\ntags: [{tags_csv}]\n---\n# body\n",)
     }
 
     #[test]
@@ -192,11 +190,7 @@ mod tests {
     #[test]
     fn skips_md_with_frontmatter_but_no_tags() {
         let dir = tempdir().unwrap();
-        write(
-            dir.path(),
-            "no-tags.md",
-            "---\ntitle: \"x\"\n---\n# body\n",
-        );
+        write(dir.path(), "no-tags.md", "---\ntitle: \"x\"\n---\n# body\n");
         let r = scan_vault_tags(dir.path());
         assert!(r.is_empty());
     }

--- a/httui-core/src/templates.rs
+++ b/httui-core/src/templates.rs
@@ -147,11 +147,7 @@ mod tests {
     }
 
     fn write_template(root: &Path, name: &str, body: &str) {
-        stdfs::write(
-            root.join(".httui").join("templates").join(name),
-            body,
-        )
-        .unwrap();
+        stdfs::write(root.join(".httui").join("templates").join(name), body).unwrap();
     }
 
     #[test]
@@ -197,11 +193,7 @@ mod tests {
     fn vault_falls_back_to_stem_when_frontmatter_missing() {
         let dir = tempdir().unwrap();
         mk_template_dir(dir.path());
-        write_template(
-            dir.path(),
-            "raw.md",
-            "# raw runbook\n\nno frontmatter\n",
-        );
+        write_template(dir.path(), "raw.md", "# raw runbook\n\nno frontmatter\n");
 
         let list = list_vault_templates(dir.path());
         assert_eq!(list.len(), 1);

--- a/httui-core/src/var_uses.rs
+++ b/httui-core/src/var_uses.rs
@@ -48,12 +48,7 @@ pub fn grep_var_uses(vault_path: &str, key: &str) -> Result<Vec<VarUseEntry>, St
     Ok(out)
 }
 
-fn walk(
-    dir: &Path,
-    root: &Path,
-    key: &str,
-    out: &mut Vec<VarUseEntry>,
-) -> Result<(), String> {
+fn walk(dir: &Path, root: &Path, key: &str, out: &mut Vec<VarUseEntry>) -> Result<(), String> {
     let read_dir = std::fs::read_dir(dir).map_err(|e| e.to_string())?;
     for entry in read_dir {
         let entry = entry.map_err(|e| e.to_string())?;
@@ -181,10 +176,7 @@ mod tests {
     #[test]
     fn matches_plain_double_brace() {
         let v = TempVault::new("plain");
-        v.write(
-            "runbook.md",
-            "url: {{API_BASE}}/users\nmethod: GET\n",
-        );
+        v.write("runbook.md", "url: {{API_BASE}}/users\nmethod: GET\n");
         let out = grep_var_uses(v.as_str(), "API_BASE").unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].file_path, "runbook.md");

--- a/httui-core/src/vault_config/connection_traits.rs
+++ b/httui-core/src/vault_config/connection_traits.rs
@@ -105,9 +105,19 @@ impl DbConnection for PostgresConfig {
     fn validate_fields(&self, name: &str, report: &mut Report) {
         let base = format!("[connections.{name}]");
         check_field(report, &format!("{base}.host"), "host", &self.host);
-        check_field(report, &format!("{base}.database"), "database", &self.database);
+        check_field(
+            report,
+            &format!("{base}.database"),
+            "database",
+            &self.database,
+        );
         check_field(report, &format!("{base}.user"), "user", &self.user);
-        check_field(report, &format!("{base}.password"), "password", &self.password);
+        check_field(
+            report,
+            &format!("{base}.password"),
+            "password",
+            &self.password,
+        );
     }
 }
 
@@ -136,9 +146,19 @@ impl DbConnection for MysqlConfig {
     fn validate_fields(&self, name: &str, report: &mut Report) {
         let base = format!("[connections.{name}]");
         check_field(report, &format!("{base}.host"), "host", &self.host);
-        check_field(report, &format!("{base}.database"), "database", &self.database);
+        check_field(
+            report,
+            &format!("{base}.database"),
+            "database",
+            &self.database,
+        );
         check_field(report, &format!("{base}.user"), "user", &self.user);
-        check_field(report, &format!("{base}.password"), "password", &self.password);
+        check_field(
+            report,
+            &format!("{base}.password"),
+            "password",
+            &self.password,
+        );
     }
 }
 
@@ -456,7 +476,18 @@ mod tests {
         // variant gets added but its arm is missing, this test still
         // compiles but exhaustiveness in `as_dyn` is enforced by the
         // compiler via the match. Keep this here as a sentinel.
-        for c in [pg(), mysql(), sqlite(), mongo(), http(), ws(), grpc(), graphql(), bigquery(), shell()] {
+        for c in [
+            pg(),
+            mysql(),
+            sqlite(),
+            mongo(),
+            http(),
+            ws(),
+            grpc(),
+            graphql(),
+            bigquery(),
+            shell(),
+        ] {
             let _ = c.as_dyn().driver();
         }
     }

--- a/httui-core/src/vault_config/connection_views.rs
+++ b/httui-core/src/vault_config/connection_views.rs
@@ -228,7 +228,10 @@ mod tests {
     #[test]
     fn database_name_of_includes_sqlite_path() {
         assert_eq!(database_name_of(&pg("")).as_deref(), Some("d"));
-        assert_eq!(database_name_of(&sqlite()).as_deref(), Some("/tmp/x.sqlite"));
+        assert_eq!(
+            database_name_of(&sqlite()).as_deref(),
+            Some("/tmp/x.sqlite")
+        );
         assert_eq!(database_name_of(&shell()), None);
     }
 

--- a/httui-core/src/vault_config/create.rs
+++ b/httui-core/src/vault_config/create.rs
@@ -35,10 +35,7 @@ pub struct CreateOutcome {
 /// Validate, mkdir, `git init`, scaffold. See module docs.
 pub fn create_new_vault(parent: &Path, name: &str) -> Result<CreateOutcome, String> {
     if !parent.exists() {
-        return Err(format!(
-            "pasta pai '{}' não existe",
-            parent.display()
-        ));
+        return Err(format!("pasta pai '{}' não existe", parent.display()));
     }
     if !parent.is_dir() {
         return Err(format!("'{}' não é uma pasta", parent.display()));
@@ -63,10 +60,7 @@ pub fn create_new_vault(parent: &Path, name: &str) -> Result<CreateOutcome, Stri
             .map(|mut it| it.next().is_none())
             .unwrap_or(false);
         if !is_empty {
-            return Err(format!(
-                "'{}' já existe e não está vazio",
-                dest.display()
-            ));
+            return Err(format!("'{}' já existe e não está vazio", dest.display()));
         }
     } else {
         std::fs::create_dir(&dest)
@@ -91,8 +85,7 @@ pub fn create_new_vault(parent: &Path, name: &str) -> Result<CreateOutcome, Stri
         });
     }
 
-    let scaffold = scaffold_new_vault(&dest)
-        .map_err(|e| format!("scaffold vault: {e}"))?;
+    let scaffold = scaffold_new_vault(&dest).map_err(|e| format!("scaffold vault: {e}"))?;
 
     Ok(CreateOutcome {
         destination: dest,
@@ -177,7 +170,11 @@ mod tests {
             "scaffold should have created .httui/",
         );
         assert!(
-            outcome.scaffold.created.iter().any(|f| f == "connections.toml"),
+            outcome
+                .scaffold
+                .created
+                .iter()
+                .any(|f| f == "connections.toml"),
             "scaffold report should list created files: {:?}",
             outcome.scaffold.created,
         );

--- a/httui-core/src/vault_config/environments_store.rs
+++ b/httui-core/src/vault_config/environments_store.rs
@@ -270,11 +270,7 @@ impl EnvironmentsStore {
     /// preserves `<name>.local.toml` overrides under the new key. If
     /// the renamed env was the active one, the active pointer is
     /// updated atomically.
-    pub async fn rename_env(
-        &self,
-        old_name: &str,
-        new_name: &str,
-    ) -> Result<(), String> {
+    pub async fn rename_env(&self, old_name: &str, new_name: &str) -> Result<(), String> {
         let new = new_name.trim();
         if new.is_empty() {
             return Err("environment name is required".to_string());
@@ -374,8 +370,7 @@ impl EnvironmentsStore {
             return Ok(Some(v.clone()));
         }
         if let Some(reference) = file.secrets.get(key) {
-            return resolve_value(reference)
-                .map_err(|e| format!("resolving secret '{key}': {e}"));
+            return resolve_value(reference).map_err(|e| format!("resolving secret '{key}': {e}"));
         }
         Ok(None)
     }
@@ -923,10 +918,7 @@ BASE_URL = "http://localhost"
             .await
             .unwrap();
 
-        let resolved = store
-            .resolve_var(&env_name, "ADMIN_TOKEN")
-            .await
-            .unwrap();
+        let resolved = store.resolve_var(&env_name, "ADMIN_TOKEN").await.unwrap();
         assert_eq!(resolved.as_deref(), Some("real-secret-value"));
 
         // Cleanup
@@ -980,9 +972,11 @@ BASE_URL = "http://localhost"
 
         // After delete, the var is gone AND the keychain entry is gone.
         assert!(store.list_vars(&env_name).await.unwrap().is_empty());
-        assert!(crate::db::keychain::get_secret(&env_var_key(&env_name, "TOKEN"))
-            .unwrap()
-            .is_none());
+        assert!(
+            crate::db::keychain::get_secret(&env_var_key(&env_name, "TOKEN"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1007,9 +1001,11 @@ BASE_URL = "http://localhost"
 
         // Every keychain entry from the deleted env is gone.
         for key in ["TOKEN_A", "TOKEN_B"] {
-            assert!(crate::db::keychain::get_secret(&env_var_key(&env_name, key))
-                .unwrap()
-                .is_none());
+            assert!(
+                crate::db::keychain::get_secret(&env_var_key(&env_name, key))
+                    .unwrap()
+                    .is_none()
+            );
         }
     }
 

--- a/httui-core/src/vault_config/mod.rs
+++ b/httui-core/src/vault_config/mod.rs
@@ -36,11 +36,11 @@ pub mod workspace_store;
 pub use connection_views::ConnectionPublic;
 pub use connections::{Connection, ConnectionsFile};
 pub use connections_store::{ConnectionsStore, CreateConnectionInput, UpdateConnectionInput};
-pub use error::{ConnectionsError, VaultConfigError};
 pub use environments_store::{
     EnvVariablePublic, EnvironmentPublic, EnvironmentsStore, SetVarInput,
 };
 pub use envs::{EnvFile, EnvMeta};
+pub use error::{ConnectionsError, VaultConfigError};
 pub use user::UserFile;
 pub use user_store::UserStore;
 pub use workspace::{

--- a/httui-core/src/vault_config/secret_resolver.rs
+++ b/httui-core/src/vault_config/secret_resolver.rs
@@ -91,7 +91,10 @@ mod tests {
 
     #[test]
     fn format_keychain_ref_wraps_key_in_braces() {
-        assert_eq!(format_keychain_ref("conn:pg:password"), "{{keychain:conn:pg:password}}");
+        assert_eq!(
+            format_keychain_ref("conn:pg:password"),
+            "{{keychain:conn:pg:password}}"
+        );
         assert_eq!(format_keychain_ref(""), "{{keychain:}}");
     }
 

--- a/httui-core/src/vault_config/user.rs
+++ b/httui-core/src/vault_config/user.rs
@@ -333,8 +333,7 @@ prompt_timeout_s = 30
 
     #[test]
     fn hide_archived_in_quick_open_round_trips() {
-        let raw =
-            "version = \"1\"\n[ui]\nhide_archived_in_quick_open = true\n";
+        let raw = "version = \"1\"\n[ui]\nhide_archived_in_quick_open = true\n";
         let f: UserFile = toml::from_str(raw).unwrap();
         assert!(f.ui.hide_archived_in_quick_open);
 

--- a/httui-core/src/vault_config/workspace.rs
+++ b/httui-core/src/vault_config/workspace.rs
@@ -216,20 +216,16 @@ auto_capture = false
     #[test]
     fn file_settings_is_default_recognises_default_value() {
         assert!(FileSettings::default().is_default());
-        assert!(
-            !FileSettings {
-                auto_capture: true,
-                docheader_compact: false,
-            }
-            .is_default()
-        );
-        assert!(
-            !FileSettings {
-                auto_capture: false,
-                docheader_compact: true,
-            }
-            .is_default()
-        );
+        assert!(!FileSettings {
+            auto_capture: true,
+            docheader_compact: false,
+        }
+        .is_default());
+        assert!(!FileSettings {
+            auto_capture: false,
+            docheader_compact: true,
+        }
+        .is_default());
     }
 
     #[test]

--- a/httui-core/src/vault_config/workspace_store.rs
+++ b/httui-core/src/vault_config/workspace_store.rs
@@ -135,9 +135,7 @@ impl WorkspaceStore {
     /// `.local.toml` sibling has that key, regardless of whether the
     /// value matches the base. This is the honest signal — the field
     /// *can* drift even when the values happen to coincide today.
-    pub async fn defaults_with_sources(
-        &self,
-    ) -> Result<WorkspaceDefaultsWithSources, String> {
+    pub async fn defaults_with_sources(&self) -> Result<WorkspaceDefaultsWithSources, String> {
         let merged = self.defaults().await?;
         let local_keys = read_local_defaults_keys(&self.path())?;
         let pick = |key: &str| -> Source {
@@ -193,11 +191,7 @@ impl WorkspaceStore {
             return Err("file_path must not be empty".to_string());
         }
         let mut file = self.load_base_only().await?;
-        let mut entry = file
-            .files
-            .get(file_path)
-            .cloned()
-            .unwrap_or_default();
+        let mut entry = file.files.get(file_path).cloned().unwrap_or_default();
         entry.auto_capture = auto_capture;
         if entry.is_default() {
             file.files.remove(file_path);
@@ -220,11 +214,7 @@ impl WorkspaceStore {
             return Err("file_path must not be empty".to_string());
         }
         let mut file = self.load_base_only().await?;
-        let mut entry = file
-            .files
-            .get(file_path)
-            .cloned()
-            .unwrap_or_default();
+        let mut entry = file.files.get(file_path).cloned().unwrap_or_default();
         entry.docheader_compact = compact;
         if entry.is_default() {
             file.files.remove(file_path);
@@ -261,8 +251,8 @@ fn read_local_defaults_keys(base: &std::path::Path) -> Result<BTreeSet<String>, 
     if !local.exists() {
         return Ok(BTreeSet::new());
     }
-    let text = std::fs::read_to_string(&local)
-        .map_err(|e| format!("read {}: {e}", local.display()))?;
+    let text =
+        std::fs::read_to_string(&local).map_err(|e| format!("read {}: {e}", local.display()))?;
     let value: toml::Value =
         toml::from_str(&text).map_err(|e| format!("parse {}: {e}", local.display()))?;
     let Some(defaults) = value.get("defaults").and_then(|v| v.as_table()) else {
@@ -486,10 +476,7 @@ mod tests {
             raw.contains("[files.\"rollout.md\"]"),
             "table header missing: {raw}"
         );
-        assert!(
-            raw.contains("auto_capture = true"),
-            "value missing: {raw}"
-        );
+        assert!(raw.contains("auto_capture = true"), "value missing: {raw}");
         let read_back = s.file_settings("rollout.md").await.unwrap();
         assert!(read_back.auto_capture);
     }

--- a/httui-desktop/src-tauri/src/captures_commands.rs
+++ b/httui-desktop/src-tauri/src/captures_commands.rs
@@ -5,9 +5,7 @@
 //! restores last-run values; `delete_captures_cache_cmd` runs when
 //! the user toggles auto-capture OFF.
 
-use httui_core::captures_cache::{
-    delete_captures_file, read_captures_file, write_captures_file,
-};
+use httui_core::captures_cache::{delete_captures_file, read_captures_file, write_captures_file};
 use std::path::PathBuf;
 
 #[tauri::command]
@@ -51,13 +49,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let r = read_captures_cache_cmd(
-            dir.path().to_string_lossy().into_owned(),
-            "x.md".into(),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let r = read_captures_cache_cmd(dir.path().to_string_lossy().into_owned(), "x.md".into())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(r, r#"{"a":{"k":"v"}}"#);
     }
 
@@ -71,19 +66,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let removed = delete_captures_cache_cmd(
-            dir.path().to_string_lossy().into_owned(),
-            "x.md".into(),
-        )
-        .await
-        .unwrap();
+        let removed =
+            delete_captures_cache_cmd(dir.path().to_string_lossy().into_owned(), "x.md".into())
+                .await
+                .unwrap();
         assert!(removed);
-        let r = read_captures_cache_cmd(
-            dir.path().to_string_lossy().into_owned(),
-            "x.md".into(),
-        )
-        .await
-        .unwrap();
+        let r = read_captures_cache_cmd(dir.path().to_string_lossy().into_owned(), "x.md".into())
+            .await
+            .unwrap();
         assert!(r.is_none());
     }
 

--- a/httui-desktop/src-tauri/src/commands/blocks.rs
+++ b/httui-desktop/src-tauri/src/commands/blocks.rs
@@ -48,10 +48,7 @@ impl Executor for SharedDbExecutor {
         self.0.validate(params).await
     }
 
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-    ) -> Result<BlockResult, ExecutorError> {
+    async fn execute(&self, params: serde_json::Value) -> Result<BlockResult, ExecutorError> {
         self.0.execute(params).await
     }
 }
@@ -72,10 +69,7 @@ impl Executor for SharedHttpExecutor {
         self.0.validate(params).await
     }
 
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-    ) -> Result<BlockResult, ExecutorError> {
+    async fn execute(&self, params: serde_json::Value) -> Result<BlockResult, ExecutorError> {
         self.0.execute(params).await
     }
 }

--- a/httui-desktop/src-tauri/src/commands/environments.rs
+++ b/httui-desktop/src-tauri/src/commands/environments.rs
@@ -181,10 +181,7 @@ pub async fn rename_environment(
     new_name: String,
 ) -> Result<Environment, String> {
     let stores = registry.for_active_vault(&pool).await?;
-    stores
-        .environments
-        .rename_env(&old_id, &new_name)
-        .await?;
+    stores.environments.rename_env(&old_id, &new_name).await?;
     let active = stores.environments.active_env().await?;
     let envs = stores.environments.list_envs().await?;
     let renamed = envs

--- a/httui-desktop/src-tauri/src/commands/files.rs
+++ b/httui-desktop/src-tauri/src/commands/files.rs
@@ -89,8 +89,7 @@ pub async fn delete_note(
         let _ = crate::block_history::purge_history_for_file(&pool, path_variant).await;
         let _ = crate::block_settings::purge_settings_for_file(&pool, path_variant).await;
         let _ = crate::block_examples::purge_examples_for_file(&pool, path_variant).await;
-        let _ =
-            crate::block_results::delete_block_results_for_file(&pool, path_variant).await;
+        let _ = crate::block_results::delete_block_results_for_file(&pool, path_variant).await;
     }
     Ok(())
 }
@@ -98,11 +97,7 @@ pub async fn delete_note(
 /// Rename / move a note within the vault. Errors if `new_path` already
 /// exists or escapes the vault.
 #[tauri::command]
-pub fn rename_note(
-    vault_path: String,
-    old_path: String,
-    new_path: String,
-) -> Result<(), String> {
+pub fn rename_note(vault_path: String, old_path: String, new_path: String) -> Result<(), String> {
     crate::fs::rename_note(&vault_path, &old_path, &new_path)
 }
 

--- a/httui-desktop/src-tauri/src/commands/settings.rs
+++ b/httui-desktop/src-tauri/src/commands/settings.rs
@@ -16,7 +16,10 @@ use httui_core::config;
 
 /// Read a single key from the `app_config` table.
 #[tauri::command]
-pub async fn get_config(pool: State<'_, SqlitePool>, key: String) -> Result<Option<String>, String> {
+pub async fn get_config(
+    pool: State<'_, SqlitePool>,
+    key: String,
+) -> Result<Option<String>, String> {
     config::get_config(&pool, &key)
         .await
         .map_err(|e| e.to_string())

--- a/httui-desktop/src-tauri/src/commands/vault_stores.rs
+++ b/httui-desktop/src-tauri/src/commands/vault_stores.rs
@@ -52,10 +52,7 @@ impl VaultStoreRegistry {
     /// existing SQLite-backed key). Returns an error if no active
     /// vault is set — callers should surface this as "open a vault
     /// first".
-    pub async fn for_active_vault(
-        &self,
-        pool: &SqlitePool,
-    ) -> Result<VaultStores, String> {
+    pub async fn for_active_vault(&self, pool: &SqlitePool) -> Result<VaultStores, String> {
         let vault_path = get_config(pool, "active_vault")
             .await
             .map_err(|e| format!("read active_vault: {e}"))?
@@ -189,10 +186,7 @@ mod tests {
         let registry = VaultStoreRegistry::new();
 
         let stores = registry.for_active_vault(&pool).await.unwrap();
-        let again = registry
-            .for_vault(v.path().to_path_buf())
-            .await
-            .unwrap();
+        let again = registry.for_vault(v.path().to_path_buf()).await.unwrap();
         // for_active_vault populated the cache — the second call hits it.
         assert!(Arc::ptr_eq(&stores.connections, &again.connections));
     }
@@ -201,7 +195,11 @@ mod tests {
     async fn for_active_vault_errors_when_unset() {
         let (_db_dir, pool) = pool_with_active_vault(None).await;
         let registry = VaultStoreRegistry::new();
-        let err = registry.for_active_vault(&pool).await.err().expect("expected an error");
+        let err = registry
+            .for_active_vault(&pool)
+            .await
+            .err()
+            .expect("expected an error");
         assert!(err.contains("No active vault"), "got: {err}");
     }
 
@@ -221,7 +219,10 @@ mod tests {
         let (_db_dir, pool) = pool_with_active_vault(None).await;
         let registry = VaultStoreRegistry::new();
         let lookup = VaultRegistryLookup::new(pool, registry);
-        let err = lookup.lookup("anything").await.err().expect("expected an error");
+        let err = lookup
+            .lookup("anything")
+            .await
+            .expect_err("expected an error");
         assert!(err.contains("No active vault"), "got: {err}");
     }
 }

--- a/httui-desktop/src-tauri/src/git_commands.rs
+++ b/httui-desktop/src-tauri/src/git_commands.rs
@@ -192,12 +192,14 @@ mod tests {
 
     fn init_with_commit(dir: &TempDir) {
         let p = dir.path();
-        let _ = Command::new("git").arg("init").arg(p).output();
+        let _ = Command::new("git")
+            .args(["init", "-b", "main"])
+            .arg(p)
+            .output();
         for (k, v) in [
             ("user.email", "t@t"),
             ("user.name", "t"),
             ("commit.gpgsign", "false"),
-            ("init.defaultBranch", "main"),
         ] {
             let _ = Command::new("git")
                 .arg("-C")
@@ -410,12 +412,15 @@ mod tests {
         // Set up a local bare remote with one seeded commit.
         let bare = TempDir::new().unwrap();
         let mut init = Command::new("git");
-        init.arg("init").arg("--bare").arg(bare.path());
+        init.arg("init")
+            .arg("--bare")
+            .arg("--initial-branch=main")
+            .arg(bare.path());
         let _ = init.output();
 
         let work = TempDir::new().unwrap();
         for args in [
-            vec!["init", work.path().to_str().unwrap()],
+            vec!["init", "-b", "main", work.path().to_str().unwrap()],
             vec![
                 "-C",
                 work.path().to_str().unwrap(),

--- a/httui-desktop/src-tauri/src/git_commands.rs
+++ b/httui-desktop/src-tauri/src/git_commands.rs
@@ -69,10 +69,7 @@ pub async fn git_checkout_cmd(vault_path: String, branch: String) -> Result<(), 
 /// `git checkout -b <new>` — create branch + switch. Forks from the
 /// current branch (git's default).
 #[tauri::command]
-pub async fn git_checkout_b_cmd(
-    vault_path: String,
-    new_branch: String,
-) -> Result<(), String> {
+pub async fn git_checkout_b_cmd(vault_path: String, new_branch: String) -> Result<(), String> {
     git_checkout_b(&PathBuf::from(vault_path), &new_branch)
 }
 
@@ -129,10 +126,7 @@ pub async fn git_commit_cmd(
 /// `git fetch [<remote>]`. Powers Story 05's `<GitSyncButtons>`
 /// fetch action. Returns the combined stdout+stderr for the toast.
 #[tauri::command]
-pub async fn git_fetch_cmd(
-    vault_path: String,
-    remote: Option<String>,
-) -> Result<String, String> {
+pub async fn git_fetch_cmd(vault_path: String, remote: Option<String>) -> Result<String, String> {
     git_fetch(&PathBuf::from(vault_path), remote.as_deref())
 }
 
@@ -181,10 +175,7 @@ pub async fn git_push_cmd(
 /// Returns the absolute path of the clone so the frontend can
 /// `switchVault` straight in.
 #[tauri::command]
-pub async fn clone_vault_cmd(
-    url: String,
-    parent: Option<String>,
-) -> Result<CloneOutcome, String> {
+pub async fn clone_vault_cmd(url: String, parent: Option<String>) -> Result<CloneOutcome, String> {
     let parent = parent.map(PathBuf::from);
     git_clone(&url, parent.as_deref())
 }
@@ -295,19 +286,13 @@ mod tests {
         let dir = TempDir::new().unwrap();
         init_with_commit(&dir);
         // Create + switch to feat/x.
-        git_checkout_b_cmd(
-            dir.path().to_string_lossy().into(),
-            "feat/x".into(),
-        )
-        .await
-        .unwrap();
+        git_checkout_b_cmd(dir.path().to_string_lossy().into(), "feat/x".into())
+            .await
+            .unwrap();
         // Switch back to main.
-        git_checkout_cmd(
-            dir.path().to_string_lossy().into(),
-            "main".into(),
-        )
-        .await
-        .unwrap();
+        git_checkout_cmd(dir.path().to_string_lossy().into(), "main".into())
+            .await
+            .unwrap();
         let head = Command::new("git")
             .arg("-C")
             .arg(dir.path())
@@ -322,18 +307,12 @@ mod tests {
         let dir = TempDir::new().unwrap();
         init_with_commit(&dir);
         std::fs::write(dir.path().join("new"), "x").unwrap();
-        stage_path_cmd(
-            dir.path().to_string_lossy().into(),
-            "new".into(),
-        )
-        .await
-        .unwrap();
-        unstage_path_cmd(
-            dir.path().to_string_lossy().into(),
-            "new".into(),
-        )
-        .await
-        .unwrap();
+        stage_path_cmd(dir.path().to_string_lossy().into(), "new".into())
+            .await
+            .unwrap();
+        unstage_path_cmd(dir.path().to_string_lossy().into(), "new".into())
+            .await
+            .unwrap();
         // After unstage, "new" should still be untracked.
         let s = Command::new("git")
             .arg("-C")
@@ -352,13 +331,9 @@ mod tests {
         stage_path_cmd(dir.path().to_string_lossy().into(), "b".into())
             .await
             .unwrap();
-        git_commit_cmd(
-            dir.path().to_string_lossy().into(),
-            "second".into(),
-            false,
-        )
-        .await
-        .unwrap();
+        git_commit_cmd(dir.path().to_string_lossy().into(), "second".into(), false)
+            .await
+            .unwrap();
         let l = git_log_cmd(dir.path().to_string_lossy().into(), 10, None)
             .await
             .unwrap();
@@ -387,21 +362,15 @@ mod tests {
     async fn first_commit_author_round_trip() {
         let dir = TempDir::new().unwrap();
         init_with_commit(&dir);
-        let info = git_first_commit_author_cmd(
-            dir.path().to_string_lossy().into(),
-            "a".into(),
-        )
-        .await
-        .unwrap()
-        .expect("`a` was added by init_with_commit");
+        let info = git_first_commit_author_cmd(dir.path().to_string_lossy().into(), "a".into())
+            .await
+            .unwrap()
+            .expect("`a` was added by init_with_commit");
         assert_eq!(info.subject, "init");
         // Path that was never committed → None.
-        let none = git_first_commit_author_cmd(
-            dir.path().to_string_lossy().into(),
-            "ghost".into(),
-        )
-        .await
-        .unwrap();
+        let none = git_first_commit_author_cmd(dir.path().to_string_lossy().into(), "ghost".into())
+            .await
+            .unwrap();
         assert!(none.is_none());
     }
 
@@ -414,34 +383,25 @@ mod tests {
         // The wrapper just must not panic.
         let _ = git_fetch_cmd(dir.path().to_string_lossy().into(), None).await;
         // pull/push without a remote always error.
-        assert!(git_pull_cmd(
-            dir.path().to_string_lossy().into(),
-            None,
-            None,
-            false,
-        )
-        .await
-        .is_err());
-        assert!(git_push_cmd(
-            dir.path().to_string_lossy().into(),
-            None,
-            None,
-            false,
-        )
-        .await
-        .is_err());
+        assert!(
+            git_pull_cmd(dir.path().to_string_lossy().into(), None, None, false,)
+                .await
+                .is_err()
+        );
+        assert!(
+            git_push_cmd(dir.path().to_string_lossy().into(), None, None, false,)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn clone_vault_cmd_rejects_empty_url() {
         let dir = TempDir::new().unwrap();
         let dest = dir.path().join("repo");
-        let err = clone_vault_cmd(
-            "".into(),
-            Some(dest.to_string_lossy().into()),
-        )
-        .await
-        .unwrap_err();
+        let err = clone_vault_cmd("".into(), Some(dest.to_string_lossy().into()))
+            .await
+            .unwrap_err();
         assert!(err.contains("vazia"), "got: {err}");
     }
 
@@ -456,9 +416,27 @@ mod tests {
         let work = TempDir::new().unwrap();
         for args in [
             vec!["init", work.path().to_str().unwrap()],
-            vec!["-C", work.path().to_str().unwrap(), "config", "user.email", "t@t"],
-            vec!["-C", work.path().to_str().unwrap(), "config", "user.name", "t"],
-            vec!["-C", work.path().to_str().unwrap(), "config", "commit.gpgsign", "false"],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "user.email",
+                "t@t",
+            ],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "user.name",
+                "t",
+            ],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "config",
+                "commit.gpgsign",
+                "false",
+            ],
         ] {
             let _ = Command::new("git").args(args).output();
         }
@@ -474,7 +452,13 @@ mod tests {
                 "origin",
                 bare.path().to_str().unwrap(),
             ],
-            vec!["-C", work.path().to_str().unwrap(), "push", "origin", "HEAD:main"],
+            vec![
+                "-C",
+                work.path().to_str().unwrap(),
+                "push",
+                "origin",
+                "HEAD:main",
+            ],
         ] {
             let _ = Command::new("git").args(args).output();
         }

--- a/httui-desktop/src-tauri/src/main.rs
+++ b/httui-desktop/src-tauri/src/main.rs
@@ -356,8 +356,7 @@ fn main() {
             // Per-vault store registry resolves ConnectionsStore +
             // EnvironmentsStore for the active vault (Epic 19 Story 02
             // Phase 1 — commit 037f470).
-            let store_registry =
-                httui_notes::commands::vault_stores::VaultStoreRegistry::new();
+            let store_registry = httui_notes::commands::vault_stores::VaultStoreRegistry::new();
 
             // Connection lookup wrapper threads the registry into the
             // pool manager so pool builds resolve connections from the
@@ -408,9 +407,9 @@ fn main() {
             app.manage(http_executor.clone());
 
             let mut executor_registry = httui_notes::executor::ExecutorRegistry::new();
-            executor_registry.register(Box::new(httui_notes::commands::blocks::SharedHttpExecutor(
-                http_executor,
-            )));
+            executor_registry.register(Box::new(
+                httui_notes::commands::blocks::SharedHttpExecutor(http_executor),
+            ));
             executor_registry.register(Box::new(httui_notes::commands::blocks::SharedDbExecutor(
                 db_executor,
             )));

--- a/httui-desktop/src-tauri/src/preflight_commands.rs
+++ b/httui-desktop/src-tauri/src/preflight_commands.rs
@@ -304,11 +304,7 @@ mod tests {
     fn connection_fails_when_name_not_declared() {
         let dir = tempdir().unwrap();
         let f = dir.path().join("note.md");
-        fs::write(
-            &f,
-            "---\npreflight:\n  - connection: payments-db\n---\n",
-        )
-        .unwrap();
+        fs::write(&f, "---\npreflight:\n  - connection: payments-db\n---\n").unwrap();
         let (envs, conns) = empty_ctx();
         let r = evaluate_preflight_for_paths(
             &f.to_string_lossy(),
@@ -325,11 +321,7 @@ mod tests {
     fn connection_passes_when_name_in_context() {
         let dir = tempdir().unwrap();
         let f = dir.path().join("note.md");
-        fs::write(
-            &f,
-            "---\npreflight:\n  - connection: payments-db\n---\n",
-        )
-        .unwrap();
+        fs::write(&f, "---\npreflight:\n  - connection: payments-db\n---\n").unwrap();
         let mut conns = HashSet::new();
         conns.insert("payments-db".to_string());
         let envs = HashSet::new();

--- a/httui-desktop/src-tauri/src/run_body_commands.rs
+++ b/httui-desktop/src-tauri/src/run_body_commands.rs
@@ -46,12 +46,7 @@ pub async fn read_run_body_cmd(
     alias: String,
     run_id: String,
 ) -> Result<Option<Vec<u8>>, String> {
-    read_run_body(
-        &PathBuf::from(vault_path),
-        &file_path,
-        &alias,
-        &run_id,
-    )
+    read_run_body(&PathBuf::from(vault_path), &file_path, &alias, &run_id)
 }
 
 #[tauri::command]
@@ -70,12 +65,7 @@ pub async fn trim_run_bodies_cmd(
     alias: String,
     keep_n: usize,
 ) -> Result<usize, String> {
-    trim_run_bodies(
-        &PathBuf::from(vault_path),
-        &file_path,
-        &alias,
-        keep_n,
-    )
+    trim_run_bodies(&PathBuf::from(vault_path), &file_path, &alias, keep_n)
 }
 
 /// Move every cached run body for `(file_path, old_alias)` to

--- a/httui-desktop/src-tauri/src/templates_commands.rs
+++ b/httui-desktop/src-tauri/src/templates_commands.rs
@@ -4,9 +4,7 @@
 //! local templates and uses the returned `body` field directly when
 //! the user picks one.
 
-use httui_core::templates::{
-    list_builtin_templates, list_vault_templates, Template,
-};
+use httui_core::templates::{list_builtin_templates, list_vault_templates, Template};
 use std::path::PathBuf;
 
 /// Combined `list_builtin_templates() + list_vault_templates(vault)`

--- a/httui-desktop/src-tauri/src/vault_config_commands.rs
+++ b/httui-desktop/src-tauri/src/vault_config_commands.rs
@@ -92,9 +92,7 @@ pub async fn set_file_docheader_compact(
     compact: bool,
 ) -> Result<(), String> {
     let store = WorkspaceStore::new(vault_path);
-    store
-        .set_file_docheader_compact(&file_path, compact)
-        .await
+    store.set_file_docheader_compact(&file_path, compact).await
 }
 
 #[tauri::command]
@@ -169,10 +167,7 @@ pub async fn save_secret_cmd(keychain_key: String, value: String) -> Result<(), 
 /// name is the user's input; the backend rejects empty/path-traversal
 /// inputs and refuses to overwrite an existing non-empty folder.
 #[tauri::command]
-pub async fn create_vault_cmd(
-    parent_path: String,
-    name: String,
-) -> Result<CreateOutcome, String> {
+pub async fn create_vault_cmd(parent_path: String, name: String) -> Result<CreateOutcome, String> {
     let parent = PathBuf::from(parent_path);
     create_new_vault(&parent, &name)
 }
@@ -185,9 +180,7 @@ pub async fn create_vault_cmd(
 /// initialised. Frontend gates the banner on this AND the
 /// `mvp_migration_dismissed` user pref.
 #[tauri::command]
-pub async fn detect_vault_migration(
-    vault_path: String,
-) -> Result<MigrationCandidate, String> {
+pub async fn detect_vault_migration(vault_path: String) -> Result<MigrationCandidate, String> {
     Ok(detect_migration_candidate(&PathBuf::from(vault_path)))
 }
 
@@ -402,9 +395,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_secret_cmd_rejects_empty_key() {
-        let err = save_secret_cmd("  ".into(), "v".into())
-            .await
-            .unwrap_err();
+        let err = save_secret_cmd("  ".into(), "v".into()).await.unwrap_err();
         assert!(err.contains("keychain_key"), "got: {err}");
     }
 

--- a/httui-desktop/src/components/atoms/Tabbar.tsx
+++ b/httui-desktop/src/components/atoms/Tabbar.tsx
@@ -19,12 +19,7 @@ export type TabbarProps = Omit<StackProps, "children" | "onSelect"> & {
   onSelect: (id: string) => void;
 };
 
-export function Tabbar({
-  tabs,
-  activeId,
-  onSelect,
-  ...rest
-}: TabbarProps) {
+export function Tabbar({ tabs, activeId, onSelect, ...rest }: TabbarProps) {
   return (
     <HStack
       data-atom="tabbar"

--- a/httui-desktop/src/components/atoms/__tests__/Btn.test.tsx
+++ b/httui-desktop/src/components/atoms/__tests__/Btn.test.tsx
@@ -35,9 +35,12 @@ describe("Btn atom", () => {
       </Btn>,
     );
     const btn = screen.getByRole("button", { name: "Disabled" });
-    await userEvent.setup().click(btn).catch(() => {
-      // some chakra builds throw on disabled click; we still expect 0 calls
-    });
+    await userEvent
+      .setup()
+      .click(btn)
+      .catch(() => {
+        // some chakra builds throw on disabled click; we still expect 0 calls
+      });
     expect(onClick).not.toHaveBeenCalled();
   });
 

--- a/httui-desktop/src/components/atoms/__tests__/Input.test.tsx
+++ b/httui-desktop/src/components/atoms/__tests__/Input.test.tsx
@@ -41,9 +41,7 @@ describe("Input atom", () => {
 
   it("respects the disabled prop", async () => {
     const onChange = vi.fn();
-    renderWithProviders(
-      <Input aria-label="d" disabled onChange={onChange} />,
-    );
+    renderWithProviders(<Input aria-label="d" disabled onChange={onChange} />);
     const node = screen.getByLabelText("d") as HTMLInputElement;
     expect(node.disabled).toBe(true);
   });

--- a/httui-desktop/src/components/blocks/assertions/AssertionsBadge.tsx
+++ b/httui-desktop/src/components/blocks/assertions/AssertionsBadge.tsx
@@ -5,7 +5,7 @@
 // are no assertions to evaluate (the consumer can short-circuit on
 // `total === 0` without an outer guard).
 
-import { Box } from "@chakra-ui/react";
+import { chakra } from "@chakra-ui/react";
 
 import type { AssertionResult } from "@/lib/blocks/assertions";
 
@@ -36,10 +36,10 @@ export function AssertionsBadge({
   const label = result === null ? `0/${total}` : `${passed}/${total}`;
 
   const interactive = !!onClick;
+  const Comp = interactive ? chakra.button : chakra.span;
 
   return (
-    <Box
-      as={interactive ? "button" : "span"}
+    <Comp
       type={interactive ? "button" : undefined}
       data-testid="assertions-badge"
       data-pass={allPass || undefined}
@@ -65,6 +65,6 @@ export function AssertionsBadge({
       }
     >
       ✓ {label}
-    </Box>
+    </Comp>
   );
 }

--- a/httui-desktop/src/components/blocks/assertions/RunAllReport.tsx
+++ b/httui-desktop/src/components/blocks/assertions/RunAllReport.tsx
@@ -4,7 +4,7 @@
 // output. Mounted at the bottom of the run-all stream when the runs
 // finish (or stop on first failure when shift-click was NOT held).
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 
 import type { RunAllAssertionSummary } from "@/lib/blocks/assertions-aggregate";
 
@@ -87,9 +87,9 @@ function FailedBlockRow({
   onJump?: (a: string) => void;
 }) {
   const interactive = !!onJump;
+  const Comp = interactive ? chakra.button : chakra.div;
   return (
-    <Box
-      as={interactive ? "button" : "div"}
+    <Comp
       type={interactive ? "button" : undefined}
       data-testid={`run-all-report-failed-block-${alias}`}
       onClick={interactive ? () => onJump?.(alias) : undefined}
@@ -104,6 +104,6 @@ function FailedBlockRow({
       _hover={interactive ? { textDecoration: "underline" } : undefined}
     >
       ✗ {alias}
-    </Box>
+    </Comp>
   );
 }

--- a/httui-desktop/src/components/blocks/captures/CapturesFooter.tsx
+++ b/httui-desktop/src/components/blocks/captures/CapturesFooter.tsx
@@ -6,7 +6,7 @@
 // presentational consumer — the consumer feeds it the
 // `Record<key, CaptureEntry>` from `useCaptureStore.getBlockCaptures`.
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Text, chakra } from "@chakra-ui/react";
 import { useState } from "react";
 
 import type { CaptureEntry } from "@/stores/captureStore";
@@ -42,12 +42,12 @@ export function CapturesFooter({
       borderTopColor="border"
       bg="bg.muted"
     >
-      <Flex
-        as="button"
+      <chakra.button
         type="button"
         data-testid="captures-footer-summary"
         onClick={() => setOpen((v) => !v)}
-        align="center"
+        display="flex"
+        alignItems="center"
         gap={2}
         px={4}
         py={2}
@@ -79,7 +79,7 @@ export function CapturesFooter({
         >
           {open ? "▾" : "▸"}
         </Text>
-      </Flex>
+      </chakra.button>
 
       {open && (
         <Box data-testid="captures-footer-list">
@@ -116,14 +116,15 @@ function CaptureRow({
 
   const interactive = !!onCopy;
 
+  const Comp = interactive ? chakra.button : chakra.div;
   return (
-    <Flex
-      as={interactive ? "button" : "div"}
+    <Comp
       type={interactive ? "button" : undefined}
       data-testid={`captures-footer-row-${name}`}
       data-secret={entry.isSecret || undefined}
       onClick={interactive ? () => onCopy?.(name, stringValue) : undefined}
-      align="baseline"
+      display="flex"
+      alignItems="baseline"
       gap={2}
       px={4}
       py={1}
@@ -176,6 +177,6 @@ function CaptureRow({
           🔒
         </Text>
       )}
-    </Flex>
+    </Comp>
   );
 }

--- a/httui-desktop/src/components/blocks/db/ExplainPlan.tsx
+++ b/httui-desktop/src/components/blocks/db/ExplainPlan.tsx
@@ -31,12 +31,7 @@ export function ExplainPlan({
 }: ExplainPlanProps) {
   if (unsupported) {
     return (
-      <Box
-        data-testid="explain-plan"
-        data-state="unsupported"
-        px={3}
-        py={3}
-      >
+      <Box data-testid="explain-plan" data-state="unsupported" px={3} py={3}>
         <Text fontSize="11px" color="fg.subtle">
           EXPLAIN unavailable for{" "}
           {driverLabel ? <strong>{driverLabel}</strong> : "this driver"}.
@@ -198,11 +193,7 @@ function CostBar({ pct, warn }: { pct: number; warn: boolean }) {
       borderRadius="3px"
       overflow="hidden"
     >
-      <Box
-        h="100%"
-        w={`${clamped}%`}
-        bg={warn ? "error" : "brand.fg"}
-      />
+      <Box h="100%" w={`${clamped}%`} bg={warn ? "error" : "brand.fg"} />
     </Box>
   );
 }

--- a/httui-desktop/src/components/blocks/db/__tests__/DbExplainSection.test.tsx
+++ b/httui-desktop/src/components/blocks/db/__tests__/DbExplainSection.test.tsx
@@ -23,31 +23,29 @@ describe("DbExplainSection", () => {
       <DbExplainSection plan={undefined} />,
     );
     expect(container.firstChild).toBeNull();
-    expect(
-      screen.queryByTestId("db-explain-section"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("db-explain-section")).not.toBeInTheDocument();
   });
 
   it("renders the header with default sub-label and the loading ExplainPlan when plan is null", () => {
     renderWithProviders(<DbExplainSection plan={null} />);
-    expect(
-      screen.getByTestId("db-explain-section-label").textContent,
-    ).toBe("EXPLAIN ANALYZE");
-    expect(
-      screen.getByTestId("db-explain-section-sub").textContent,
-    ).toBe("buffers · timing");
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("loading");
+    expect(screen.getByTestId("db-explain-section-label").textContent).toBe(
+      "EXPLAIN ANALYZE",
+    );
+    expect(screen.getByTestId("db-explain-section-sub").textContent).toBe(
+      "buffers · timing",
+    );
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "loading",
+    );
   });
 
   it("renders a custom subLabel when supplied", () => {
     renderWithProviders(
       <DbExplainSection plan={null} subLabel="cost · timing" />,
     );
-    expect(
-      screen.getByTestId("db-explain-section-sub").textContent,
-    ).toBe("cost · timing");
+    expect(screen.getByTestId("db-explain-section-sub").textContent).toBe(
+      "cost · timing",
+    );
   });
 
   it("renders the ready ExplainPlan and the summary annotation when plan is a node", () => {
@@ -57,9 +55,9 @@ describe("DbExplainSection", () => {
         summary="uses idx_route_provider"
       />,
     );
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("ready");
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "ready",
+    );
     const summary = screen.getByTestId("db-explain-section-summary");
     expect(summary.textContent).toBe("uses idx_route_provider");
     expect(summary.getAttribute("title")).toBe("uses idx_route_provider");
@@ -77,28 +75,22 @@ describe("DbExplainSection", () => {
 
   it("renders the unsupported state with driver label even when plan is undefined", () => {
     renderWithProviders(
-      <DbExplainSection
-        plan={undefined}
-        unsupported
-        driverLabel="SQLite"
-      />,
+      <DbExplainSection plan={undefined} unsupported driverLabel="SQLite" />,
     );
     // Section is visible (the unsupported branch overrides the hide rule).
     expect(screen.getByTestId("db-explain-section")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("unsupported");
-    expect(screen.getByTestId("explain-plan").textContent).toMatch(
-      /SQLite/,
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "unsupported",
     );
+    expect(screen.getByTestId("explain-plan").textContent).toMatch(/SQLite/);
   });
 
   it("forwards unsupported state when plan is null too (consumer sets both during a transition)", () => {
     renderWithProviders(
       <DbExplainSection plan={null} unsupported driverLabel="BigQuery" />,
     );
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("unsupported");
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "unsupported",
+    );
   });
 });

--- a/httui-desktop/src/components/blocks/db/__tests__/ExplainPlan.test.tsx
+++ b/httui-desktop/src/components/blocks/db/__tests__/ExplainPlan.test.tsx
@@ -33,7 +33,9 @@ describe("formatRows", () => {
 
 describe("ExplainPlan", () => {
   it("renders the unsupported state with optional driver label", () => {
-    renderWithProviders(<ExplainPlan plan={null} unsupported driverLabel="SQLite" />);
+    renderWithProviders(
+      <ExplainPlan plan={null} unsupported driverLabel="SQLite" />,
+    );
     const root = screen.getByTestId("explain-plan");
     expect(root.getAttribute("data-state")).toBe("unsupported");
     expect(root.textContent).toMatch(/SQLite/);
@@ -41,16 +43,16 @@ describe("ExplainPlan", () => {
 
   it("renders the loading state when plan is null", () => {
     renderWithProviders(<ExplainPlan plan={null} />);
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("loading");
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "loading",
+    );
   });
 
   it("renders a single-node plan with op + cost + rows", () => {
     renderWithProviders(<ExplainPlan plan={node()} />);
-    expect(
-      screen.getByTestId("explain-plan").getAttribute("data-state"),
-    ).toBe("ready");
+    expect(screen.getByTestId("explain-plan").getAttribute("data-state")).toBe(
+      "ready",
+    );
     expect(screen.getByTestId("explain-plan-op").textContent).toBe("Limit");
     expect(screen.getByTestId("explain-plan-cost").textContent).toBe(
       "0.42..18.7",
@@ -113,9 +115,7 @@ describe("ExplainPlan", () => {
 
   it("hides the target text when target is empty", () => {
     renderWithProviders(<ExplainPlan plan={node({ target: "" })} />);
-    expect(
-      screen.queryByTestId("explain-plan-target"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("explain-plan-target")).not.toBeInTheDocument();
   });
 
   it("flags the last child via data-last", () => {

--- a/httui-desktop/src/components/blocks/preflight/PreflightCheckPopover.tsx
+++ b/httui-desktop/src/components/blocks/preflight/PreflightCheckPopover.tsx
@@ -245,10 +245,7 @@ interface KindPickerProps {
 
 function KindPicker({ onSelect }: KindPickerProps) {
   return (
-    <Stack
-      data-testid="preflight-check-popover-kind-picker"
-      gap={1}
-    >
+    <Stack data-testid="preflight-check-popover-kind-picker" gap={1}>
       {KIND_OPTIONS.map((opt) => (
         <Box
           key={opt.kind}

--- a/httui-desktop/src/components/blocks/preflight/PreflightPills.tsx
+++ b/httui-desktop/src/components/blocks/preflight/PreflightPills.tsx
@@ -139,8 +139,7 @@ export function PreflightPills({
               onSelectFailure={onSelectFailure}
               onEdit={
                 canEdit
-                  ? (target) =>
-                      openEdit(idx, item.kind!, item.value!, target)
+                  ? (target) => openEdit(idx, item.kind!, item.value!, target)
                   : undefined
               }
             />
@@ -215,7 +214,9 @@ function Pill({
    *  in the title attribute as a hover hint. */
   onEdit?: (target: HTMLElement) => void;
 }) {
-  const kind: PillKind = forceRunning ? "running" : pillKindFromResult(item.result);
+  const kind: PillKind = forceRunning
+    ? "running"
+    : pillKindFromResult(item.result);
   const editable = !!onEdit;
   const isFailWithSuggestion =
     !editable && kind === "fail" && !!onSelectFailure;
@@ -266,12 +267,7 @@ function Pill({
         >
           {pillGlyph(kind)}
         </Text>
-        <Text
-          as="span"
-          fontFamily="mono"
-          fontSize="11px"
-          color="fg.muted"
-        >
+        <Text as="span" fontFamily="mono" fontSize="11px" color="fg.muted">
           {item.label}
         </Text>
       </Flex>

--- a/httui-desktop/src/components/blocks/preflight/__tests__/PreflightCheckPopover.test.tsx
+++ b/httui-desktop/src/components/blocks/preflight/__tests__/PreflightCheckPopover.test.tsx
@@ -197,9 +197,7 @@ describe("PreflightCheckPopover (V6 cenário 9 builder)", () => {
       renderWithProviders(
         <PreflightCheckPopover onSave={vi.fn()} onClose={onClose} />,
       );
-      await user.click(
-        screen.getByTestId("preflight-check-popover-overlay"),
-      );
+      await user.click(screen.getByTestId("preflight-check-popover-overlay"));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 

--- a/httui-desktop/src/components/blocks/preflight/__tests__/PreflightPills.test.tsx
+++ b/httui-desktop/src/components/blocks/preflight/__tests__/PreflightPills.test.tsx
@@ -31,18 +31,15 @@ function skip(id: string, reason: string): PreflightPillItem {
 describe("PreflightPills", () => {
   it("renders nothing when items is empty", () => {
     const { container } = renderWithProviders(<PreflightPills items={[]} />);
-    expect(container.querySelector('[data-testid="preflight-pills"]'))
-      .toBeNull();
+    expect(
+      container.querySelector('[data-testid="preflight-pills"]'),
+    ).toBeNull();
   });
 
   it("renders one pill per item with the right data-kind", () => {
     renderWithProviders(
       <PreflightPills
-        items={[
-          pass("a"),
-          fail("b", "missing"),
-          skip("c", "irrelevant"),
-        ]}
+        items={[pass("a"), fail("b", "missing"), skip("c", "irrelevant")]}
       />,
     );
     expect(
@@ -61,27 +58,16 @@ describe("PreflightPills", () => {
 
   it("renders the canvas glyphs (✓ ✗ –)", () => {
     renderWithProviders(
-      <PreflightPills
-        items={[pass("a"), fail("b", "x"), skip("c", "y")]}
-      />,
+      <PreflightPills items={[pass("a"), fail("b", "x"), skip("c", "y")]} />,
     );
-    expect(screen.getByTestId("preflight-pill-a-glyph").textContent).toBe(
-      "✓",
-    );
-    expect(screen.getByTestId("preflight-pill-b-glyph").textContent).toBe(
-      "✗",
-    );
-    expect(screen.getByTestId("preflight-pill-c-glyph").textContent).toBe(
-      "–",
-    );
+    expect(screen.getByTestId("preflight-pill-a-glyph").textContent).toBe("✓");
+    expect(screen.getByTestId("preflight-pill-b-glyph").textContent).toBe("✗");
+    expect(screen.getByTestId("preflight-pill-c-glyph").textContent).toBe("–");
   });
 
   it("flips all pills to 'running' when rechecking is true", () => {
     renderWithProviders(
-      <PreflightPills
-        items={[pass("a"), fail("b", "x")]}
-        rechecking
-      />,
+      <PreflightPills items={[pass("a"), fail("b", "x")]} rechecking />,
     );
     expect(
       screen.getByTestId("preflight-pill-a").getAttribute("data-kind"),
@@ -89,9 +75,7 @@ describe("PreflightPills", () => {
     expect(
       screen.getByTestId("preflight-pill-b").getAttribute("data-kind"),
     ).toBe("running");
-    expect(screen.getByTestId("preflight-pill-a-glyph").textContent).toBe(
-      "◌",
-    );
+    expect(screen.getByTestId("preflight-pill-a-glyph").textContent).toBe("◌");
   });
 
   it("makes failed pills actionable only when onSelectFailure is provided", async () => {
@@ -113,9 +97,7 @@ describe("PreflightPills", () => {
   });
 
   it("renders failed pills as inert spans without the callback", () => {
-    renderWithProviders(
-      <PreflightPills items={[fail("b", "missing")]} />,
-    );
+    renderWithProviders(<PreflightPills items={[fail("b", "missing")]} />);
     const pill = screen.getByTestId("preflight-pill-b");
     expect(pill.getAttribute("data-actionable")).toBeNull();
     expect(pill.tagName).toBe("SPAN");
@@ -145,11 +127,7 @@ describe("PreflightPills", () => {
 
   it("disables Re-check + flips its label while rechecking", () => {
     renderWithProviders(
-      <PreflightPills
-        items={[pass("a")]}
-        onRecheck={() => {}}
-        rechecking
-      />,
+      <PreflightPills items={[pass("a")]} onRecheck={() => {}} rechecking />,
     );
     const btn = screen.getByTestId(
       "preflight-pills-recheck",
@@ -172,25 +150,19 @@ describe("PreflightPills", () => {
         onSelectFailure={() => {}}
       />,
     );
-    expect(
-      screen.getByTestId("preflight-pill-b").getAttribute("title"),
-    ).toBe("Connection x not found");
+    expect(screen.getByTestId("preflight-pill-b").getAttribute("title")).toBe(
+      "Connection x not found",
+    );
   });
 
   describe("builder (V6 cenário 9)", () => {
     it("renders + Add check button when onAddCheck is wired", () => {
-      renderWithProviders(
-        <PreflightPills items={[]} onAddCheck={() => {}} />,
-      );
-      expect(
-        screen.getByTestId("preflight-pills-add"),
-      ).toBeInTheDocument();
+      renderWithProviders(<PreflightPills items={[]} onAddCheck={() => {}} />);
+      expect(screen.getByTestId("preflight-pills-add")).toBeInTheDocument();
     });
 
     it("does not render + Add check when onAddCheck is omitted", () => {
-      renderWithProviders(
-        <PreflightPills items={[fail("a", "x")]} />,
-      );
+      renderWithProviders(<PreflightPills items={[fail("a", "x")]} />);
       expect(
         screen.queryByTestId("preflight-pills-add"),
       ).not.toBeInTheDocument();
@@ -198,9 +170,7 @@ describe("PreflightPills", () => {
 
     it("clicking + Add check opens the popover at the kind picker", async () => {
       const user = userEvent.setup();
-      renderWithProviders(
-        <PreflightPills items={[]} onAddCheck={() => {}} />,
-      );
+      renderWithProviders(<PreflightPills items={[]} onAddCheck={() => {}} />);
       await user.click(screen.getByTestId("preflight-pills-add"));
       expect(
         screen.getByTestId("preflight-check-popover-kind-picker"),
@@ -209,9 +179,7 @@ describe("PreflightPills", () => {
 
     it("Add → kind picker opens with all six options", async () => {
       const user = userEvent.setup();
-      renderWithProviders(
-        <PreflightPills items={[]} onAddCheck={() => {}} />,
-      );
+      renderWithProviders(<PreflightPills items={[]} onAddCheck={() => {}} />);
       await user.click(screen.getByTestId("preflight-pills-add"));
       expect(
         screen.getByTestId("preflight-check-popover-kind-command"),
@@ -297,9 +265,7 @@ describe("PreflightPills", () => {
         />,
       );
       await user.click(screen.getByTestId("preflight-pill-p0"));
-      await user.click(
-        screen.getByTestId("preflight-check-popover-remove"),
-      );
+      await user.click(screen.getByTestId("preflight-check-popover-remove"));
       expect(onRemoveCheck).toHaveBeenCalledWith(0);
     });
 

--- a/httui-desktop/src/components/blocks/preflight/__tests__/preflight-suggestions.test.ts
+++ b/httui-desktop/src/components/blocks/preflight/__tests__/preflight-suggestions.test.ts
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { defaultSuggestionProvider } from "@/components/blocks/preflight/preflight-suggestions";
 import { useEnvironmentStore } from "@/stores/environment";
-import {
-  clearTauriMocks,
-  mockTauriCommand,
-} from "@/test/mocks/tauri";
+import { clearTauriMocks, mockTauriCommand } from "@/test/mocks/tauri";
 
 describe("defaultSuggestionProvider", () => {
   beforeEach(() => {

--- a/httui-desktop/src/components/blocks/preflight/__tests__/preflight-types.test.ts
+++ b/httui-desktop/src/components/blocks/preflight/__tests__/preflight-types.test.ts
@@ -8,9 +8,7 @@ import {
 
 describe("pillKindFromResult", () => {
   it("maps each outcome 1:1 to a pill kind", () => {
-    expect(pillKindFromResult({ outcome: "pass" } as CheckResult)).toBe(
-      "pass",
-    );
+    expect(pillKindFromResult({ outcome: "pass" } as CheckResult)).toBe("pass");
     expect(
       pillKindFromResult({ outcome: "fail", reason: "x" } as CheckResult),
     ).toBe("fail");

--- a/httui-desktop/src/components/blocks/preflight/__tests__/run-all-gate.test.ts
+++ b/httui-desktop/src/components/blocks/preflight/__tests__/run-all-gate.test.ts
@@ -62,9 +62,7 @@ describe("evaluatePreflightGate", () => {
     });
     expect(d.block).toBe(false);
     expect(d.failedCount).toBe(2);
-    expect(d.auditNote).toBe(
-      "2 failed pre-flight, ran anyway via shift",
-    );
+    expect(d.auditNote).toBe("2 failed pre-flight, ran anyway via shift");
   });
 
   it("agrees plural in the override audit note", () => {

--- a/httui-desktop/src/components/blocks/preflight/preflight-suggestions.ts
+++ b/httui-desktop/src/components/blocks/preflight/preflight-suggestions.ts
@@ -40,7 +40,6 @@ export const defaultSuggestionProvider: SuggestionProvider = async (kind) => {
     case "branch":
     case "file_exists":
     case "command":
-    case "unknown" as PreflightCheckKind:
       return [];
   }
 };

--- a/httui-desktop/src/components/blocks/run-diff/RunDiffPanel.tsx
+++ b/httui-desktop/src/components/blocks/run-diff/RunDiffPanel.tsx
@@ -7,7 +7,7 @@
 // supplies the diff (already computed) so this component has no
 // effects.
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 import { useState } from "react";
 
 import type {
@@ -78,8 +78,7 @@ function TabBtn({
 }) {
   const active = current === value;
   return (
-    <Box
-      as="button"
+    <chakra.button
       type="button"
       data-testid={`run-diff-tab-${value}`}
       data-active={active || undefined}
@@ -102,7 +101,7 @@ function TabBtn({
           ({count})
         </Text>
       )}
-    </Box>
+    </chakra.button>
   );
 }
 

--- a/httui-desktop/src/components/editor/DocHeaderWidgetPortal.tsx
+++ b/httui-desktop/src/components/editor/DocHeaderWidgetPortal.tsx
@@ -96,7 +96,9 @@ export function DocHeaderWidgetPortal({
         onAddTag={view ? callbacks.onAddTag : undefined}
         onRemoveTag={view ? callbacks.onRemoveTag : undefined}
         onChecklistSave={view ? callbacks.onChecklistSave : undefined}
-        onTitleNavigateToBody={view ? callbacks.onTitleNavigateToBody : undefined}
+        onTitleNavigateToBody={
+          view ? callbacks.onTitleNavigateToBody : undefined
+        }
         onAddPreflightCheck={view ? callbacks.onAddPreflightCheck : undefined}
         onEditPreflightCheck={view ? callbacks.onEditPreflightCheck : undefined}
         onRemovePreflightCheck={

--- a/httui-desktop/src/components/editor/RefPopover.tsx
+++ b/httui-desktop/src/components/editor/RefPopover.tsx
@@ -304,11 +304,7 @@ function RefUsesSection({
           : `Used in ${count} block${count === 1 ? "" : "s"}`}
         {count > 0 && (
           <Box as="span" ml={2} color="fg.subtle" display="inline-flex">
-            {showUses ? (
-              <LuChevronUp size={12} />
-            ) : (
-              <LuChevronDown size={12} />
-            )}
+            {showUses ? <LuChevronUp size={12} /> : <LuChevronDown size={12} />}
           </Box>
         )}
       </Btn>

--- a/httui-desktop/src/components/editor/__tests__/DocHeaderWidgetPortal.test.tsx
+++ b/httui-desktop/src/components/editor/__tests__/DocHeaderWidgetPortal.test.tsx
@@ -15,7 +15,10 @@ const { getDocHeaderEntries, returnFocusToBody } = cmDocHeader;
 // Bypass typing for the parts of `EditorView` we don't need for these
 // portal-only tests. The portal only ever calls `view.state.doc.toString`
 // (in the editable callbacks) plus passes the view to `dispatchDocReplace`.
-type FakeView = { state: { doc: { toString: () => string } }; dispatch: ReturnType<typeof vi.fn> };
+type FakeView = {
+  state: { doc: { toString: () => string } };
+  dispatch: ReturnType<typeof vi.fn>;
+};
 
 function makeFakeView(content: string): FakeView {
   return {

--- a/httui-desktop/src/components/editor/__tests__/RefPopover.test.tsx
+++ b/httui-desktop/src/components/editor/__tests__/RefPopover.test.tsx
@@ -34,7 +34,11 @@ afterEach(() => clearTauriMocks());
 describe("RefPopover — env variable", () => {
   it("shows the per-env value", async () => {
     renderWithProviders(
-      <RefPopover state={mkState("api_base")} vaultPath="/v" onClose={() => {}} />,
+      <RefPopover
+        state={mkState("api_base")}
+        vaultPath="/v"
+        onClose={() => {}}
+      />,
     );
     expect(
       (await screen.findByTestId("ref-popover-value")).textContent,
@@ -44,7 +48,11 @@ describe("RefPopover — env variable", () => {
   it("Set writes a session override and renders the TEMPORARY chip", async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <RefPopover state={mkState("api_base")} vaultPath="/v" onClose={() => {}} />,
+      <RefPopover
+        state={mkState("api_base")}
+        vaultPath="/v"
+        onClose={() => {}}
+      />,
     );
     await user.type(
       screen.getByTestId("ref-popover-override-input"),
@@ -61,7 +69,11 @@ describe("RefPopover — env variable", () => {
     const user = userEvent.setup();
     useSessionOverrideStore.getState().setOverride("local", "api_base", "ov");
     renderWithProviders(
-      <RefPopover state={mkState("api_base")} vaultPath="/v" onClose={() => {}} />,
+      <RefPopover
+        state={mkState("api_base")}
+        vaultPath="/v"
+        onClose={() => {}}
+      />,
     );
     await user.click(screen.getByTestId("temporary-chip"));
     expect(
@@ -72,7 +84,11 @@ describe("RefPopover — env variable", () => {
   it("lists the blocks the variable is used in", async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <RefPopover state={mkState("api_base")} vaultPath="/v" onClose={() => {}} />,
+      <RefPopover
+        state={mkState("api_base")}
+        vaultPath="/v"
+        onClose={() => {}}
+      />,
     );
     const usesBtn = await screen.findByTestId("ref-popover-uses");
     expect(usesBtn.textContent).toContain("Used in 2 blocks");
@@ -84,7 +100,11 @@ describe("RefPopover — env variable", () => {
     const onClose = vi.fn();
     const user = userEvent.setup();
     renderWithProviders(
-      <RefPopover state={mkState("api_base")} vaultPath="/v" onClose={onClose} />,
+      <RefPopover
+        state={mkState("api_base")}
+        vaultPath="/v"
+        onClose={onClose}
+      />,
     );
     await user.click(screen.getByTestId("ref-popover-close"));
     expect(onClose).toHaveBeenCalled();

--- a/httui-desktop/src/components/editor/__tests__/doc-header-callbacks.test.ts
+++ b/httui-desktop/src/components/editor/__tests__/doc-header-callbacks.test.ts
@@ -13,9 +13,7 @@ function makeFakeView(content: string): EditorView {
   } as unknown as EditorView;
 }
 
-function makeEntry(
-  over: Partial<DocHeaderEntry> = {},
-): DocHeaderEntry {
+function makeEntry(over: Partial<DocHeaderEntry> = {}): DocHeaderEntry {
   return {
     id: "i1",
     container: document.createElement("div"),
@@ -35,9 +33,9 @@ function makeDeps(): CallbackDeps & {
   flushSave: ReturnType<typeof vi.fn>;
 } {
   return {
-    dispatchDocReplace: vi.fn(),
-    returnFocusToBody: vi.fn(),
-    flushSave: vi.fn(),
+    dispatchDocReplace: vi.fn<(view: EditorView, next: string) => void>(),
+    returnFocusToBody: vi.fn<(instanceId: string) => void>(),
+    flushSave: vi.fn<() => void>(),
   };
 }
 
@@ -199,7 +197,7 @@ describe("buildDocHeaderCallbacks", () => {
 
     it("onChecklistSave rewrites the tasks list", () => {
       const deps = makeDeps();
-      const view = makeFakeView("---\ntasks: [\"[ ] one\"]\n---\n");
+      const view = makeFakeView('---\ntasks: ["[ ] one"]\n---\n');
       const entry = makeEntry({ view });
       const cb = buildDocHeaderCallbacks(entry, "i1", deps);
       cb.onChecklistSave([

--- a/httui-desktop/src/components/editor/__tests__/editor-theme.test.ts
+++ b/httui-desktop/src/components/editor/__tests__/editor-theme.test.ts
@@ -12,9 +12,8 @@ describe("editorTheme", () => {
   });
 
   it("is a stable single-instance reference (Emotion caching guarantee)", async () => {
-    const reimport = (
-      await import("@/components/editor/editor-theme")
-    ).editorTheme;
+    const reimport = (await import("@/components/editor/editor-theme"))
+      .editorTheme;
     expect(reimport).toBe(editorTheme);
   });
 });

--- a/httui-desktop/src/components/editor/__tests__/markdown-extensions.test.ts
+++ b/httui-desktop/src/components/editor/__tests__/markdown-extensions.test.ts
@@ -74,19 +74,23 @@ vi.mock("@/lib/blocks/cm-references", () => ({
   createMarkdownReferenceTooltip: vi.fn(() => ({ refTooltip: true })),
 }));
 
-import { wikilinks, createWikilinkCompletion } from "@/lib/codemirror/cm-wikilinks";
 import {
-  createDbBlockCompletionSource,
-} from "@/lib/codemirror/cm-db-block";
-import {
-  createHttpBlockCompletionSource,
-} from "@/lib/codemirror/cm-http-block";
+  wikilinks,
+  createWikilinkCompletion,
+} from "@/lib/codemirror/cm-wikilinks";
+import { createDbBlockCompletionSource } from "@/lib/codemirror/cm-db-block";
+import { createHttpBlockCompletionSource } from "@/lib/codemirror/cm-http-block";
 import { createMarkdownReferenceTooltip } from "@/lib/blocks/cm-references";
 import {
   buildExtensions,
   flattenFiles,
 } from "@/components/editor/markdown-extensions";
+import type {
+  BuildExtensionsParams,
+  DocHeaderHandleLike,
+} from "@/components/editor/markdown-extensions";
 import type { FileEntry } from "@/lib/tauri/commands";
+import type { Extension } from "@codemirror/state";
 
 const folderEntry: FileEntry = {
   name: "folder",
@@ -165,15 +169,17 @@ describe("markdown-extensions", () => {
   });
 
   describe("buildExtensions", () => {
-    function makeParams(overrides: Partial<{ docHeader: unknown }> = {}) {
+    function makeParams(
+      overrides: Partial<{
+        docHeader: DocHeaderHandleLike | null;
+        entriesRef: { current: FileEntry[] };
+      }> = {},
+    ): BuildExtensionsParams {
       return {
         filePath: "current.md",
-        entriesRef: { current: [folderEntry] },
+        entriesRef: overrides.entriesRef ?? { current: [folderEntry] },
         handleFileSelectRef: { current: vi.fn() },
-        docHeaderHandle: (overrides.docHeader as
-          | { extension: unknown; instanceId: string }
-          | null
-          | undefined) ?? null,
+        docHeaderHandle: overrides.docHeader ?? null,
         getActiveVariables: () => ({ FOO: "bar" }),
       };
     }
@@ -190,7 +196,11 @@ describe("markdown-extensions", () => {
     });
 
     it("includes the docHeader extension when a handle is provided", () => {
-      const docExt = { docHeaderExt: true };
+      // CM6 modules are fully mocked here; the docHeader extension is an
+      // opaque pass-through value. Cast the fake through `Extension` so the
+      // handle matches `DocHeaderHandleLike` while keeping object identity
+      // for the `toContain` assertion below.
+      const docExt = { docHeaderExt: true } as unknown as Extension;
       const ext = buildExtensions(
         makeParams({ docHeader: { extension: docExt, instanceId: "id-1" } }),
       );
@@ -241,7 +251,8 @@ describe("markdown-extensions", () => {
     });
 
     it("wikilinks.getFiles re-evaluates entriesRef each call", () => {
-      const params = makeParams();
+      const entriesRef: { current: FileEntry[] } = { current: [folderEntry] };
+      const params = makeParams({ entriesRef });
       buildExtensions(params);
       const cfg = vi.mocked(wikilinks).mock.calls.at(-1)![0] as {
         getFiles: () => Array<{ name: string; path: string }>;
@@ -249,34 +260,34 @@ describe("markdown-extensions", () => {
       const initial = cfg.getFiles();
       expect(initial.length).toBe(2);
       // Mutate entries; getFiles should reflect the change.
-      params.entriesRef.current = [];
+      entriesRef.current = [];
       expect(cfg.getFiles()).toEqual([]);
     });
 
     it("createWikilinkCompletion gets a getFiles closure that walks entriesRef", () => {
       const params = makeParams();
       buildExtensions(params);
-      const getFiles = vi.mocked(createWikilinkCompletion).mock.calls.at(
-        -1,
-      )![0] as () => Array<{ name: string; path: string }>;
+      const getFiles = vi
+        .mocked(createWikilinkCompletion)
+        .mock.calls.at(-1)![0] as () => Array<{ name: string; path: string }>;
       expect(getFiles().map((f) => f.path)).toContain("folder/leaf.md");
     });
 
     it("createDbBlockCompletionSource gets a closure returning the filePath", () => {
       const params = makeParams();
       buildExtensions(params);
-      const getter = vi.mocked(createDbBlockCompletionSource).mock.calls.at(
-        -1,
-      )![0] as () => string;
+      const getter = vi
+        .mocked(createDbBlockCompletionSource)
+        .mock.calls.at(-1)![0] as () => string;
       expect(getter()).toBe("current.md");
     });
 
     it("createHttpBlockCompletionSource gets a closure returning the filePath", () => {
       const params = makeParams();
       buildExtensions(params);
-      const getter = vi.mocked(createHttpBlockCompletionSource).mock.calls.at(
-        -1,
-      )![0] as () => string;
+      const getter = vi
+        .mocked(createHttpBlockCompletionSource)
+        .mock.calls.at(-1)![0] as () => string;
       expect(getter()).toBe("current.md");
     });
 

--- a/httui-desktop/src/components/editor/editor-theme.ts
+++ b/httui-desktop/src/components/editor/editor-theme.ts
@@ -484,7 +484,7 @@ export const editorTheme = EditorView.theme(
     // H1 typography per canvas spec (epic 40 / story 04):
     // 2.25rem weight 600. H2 keeps the line-default size — it inherits
     // weight 600 from `tags.heading` in MarkdownEditor's highlight style.
-    ".cm-numbered-heading[data-heading-level=\"1\"]": {
+    '.cm-numbered-heading[data-heading-level="1"]': {
       fontSize: "2.25rem",
       fontWeight: 600,
       lineHeight: 1.05,

--- a/httui-desktop/src/components/editor/markdown-extensions.ts
+++ b/httui-desktop/src/components/editor/markdown-extensions.ts
@@ -9,10 +9,7 @@
 import { EditorView, keymap } from "@codemirror/view";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages as cmLanguages } from "@codemirror/language-data";
-import {
-  syntaxHighlighting,
-  bracketMatching,
-} from "@codemirror/language";
+import { syntaxHighlighting, bracketMatching } from "@codemirror/language";
 import {
   defaultKeymap,
   history,
@@ -63,10 +60,7 @@ import {
 import { refClickExtension } from "@/lib/blocks/cm-ref-popover";
 
 import type { FileEntry } from "@/lib/tauri/commands";
-import {
-  vimCompartment,
-  docLineNavKeymap,
-} from "./markdown-vim-motions";
+import { vimCompartment, docLineNavKeymap } from "./markdown-vim-motions";
 import {
   dbSqlLanguages,
   markdownHighlightStyle,
@@ -159,9 +153,7 @@ export function buildExtensions(params: BuildExtensionsParams) {
         const files = flattenFiles(entriesRef.current);
         const match = files.find(
           (f) =>
-            f.path === target ||
-            f.name === target ||
-            f.name === `${target}.md`,
+            f.path === target || f.name === target || f.name === `${target}.md`,
         );
         if (match) handleFileSelectRef.current(match.path);
       },

--- a/httui-desktop/src/components/layout/AddBlockMenu.tsx
+++ b/httui-desktop/src/components/layout/AddBlockMenu.tsx
@@ -82,16 +82,14 @@ export const BLOCK_TEMPLATES: Readonly<Record<BlockKind, BlockTemplate>> = {
     kind: "websocket",
     label: "WebSocket",
     executable: false,
-    insert:
-      "```ws alias=ws1 executable=false\nwss://example.com/socket\n```\n",
+    insert: "```ws alias=ws1 executable=false\nwss://example.com/socket\n```\n",
     cursorOffset: -6,
   },
   graphql: {
     kind: "graphql",
     label: "GraphQL",
     executable: false,
-    insert:
-      "```graphql alias=q1 executable=false\nquery {\n  \n}\n```\n",
+    insert: "```graphql alias=q1 executable=false\nquery {\n  \n}\n```\n",
     cursorOffset: -8,
   },
   shell: {

--- a/httui-desktop/src/components/layout/BranchMenu.tsx
+++ b/httui-desktop/src/components/layout/BranchMenu.tsx
@@ -135,8 +135,8 @@ export function BranchMenu({
                 color="fg.subtle"
                 data-testid="branch-menu-placeholder"
               >
-                Trocar de branch chega na V10. Por agora veja a branch
-                ativa aqui — comandos vão pro Git panel.
+                Trocar de branch chega na V10. Por agora veja a branch ativa
+                aqui — comandos vão pro Git panel.
               </Box>
             )}
           </Menu.Content>

--- a/httui-desktop/src/components/layout/EmptyVaultScreen.tsx
+++ b/httui-desktop/src/components/layout/EmptyVaultScreen.tsx
@@ -138,7 +138,11 @@ export function EmptyVaultScreen() {
           return;
         }
         await scaffoldVault(picked);
-        await writeNote(picked, PASTE_URL_RUNBOOK_PATH, buildRunbookFromUrl(url));
+        await writeNote(
+          picked,
+          PASTE_URL_RUNBOOK_PATH,
+          buildRunbookFromUrl(url),
+        );
         await switchVault(picked);
       } catch (err) {
         setFlow({

--- a/httui-desktop/src/components/layout/EnvMenu.tsx
+++ b/httui-desktop/src/components/layout/EnvMenu.tsx
@@ -186,11 +186,7 @@ export function EnvMenu({
                   borderRadius="3px"
                 >
                   <HStack gap={2} w="100%">
-                    <Box
-                      w="14px"
-                      display="inline-flex"
-                      justifyContent="center"
-                    >
+                    <Box w="14px" display="inline-flex" justifyContent="center">
                       <LuCopy size={12} />
                     </Box>
                     <Box

--- a/httui-desktop/src/components/layout/PendingSecretsModal.tsx
+++ b/httui-desktop/src/components/layout/PendingSecretsModal.tsx
@@ -98,10 +98,10 @@ function PendingSecretsModalContent() {
             Secrets pendentes
           </Heading>
           <Text fontSize="13px" color="fg.muted" mb={5}>
-            Este vault referencia secrets que ainda não estão no seu
-            keychain. Preencha cada um abaixo. Você pode pular agora e
-            preencher depois — o app não conseguirá executar blocos
-            que dependam dos secrets pulados.
+            Este vault referencia secrets que ainda não estão no seu keychain.
+            Preencha cada um abaixo. Você pode pular agora e preencher depois —
+            o app não conseguirá executar blocos que dependam dos secrets
+            pulados.
           </Text>
 
           <Stack gap={3} data-testid="pending-secrets-list">

--- a/httui-desktop/src/components/layout/ShareMenu.tsx
+++ b/httui-desktop/src/components/layout/ShareMenu.tsx
@@ -18,7 +18,10 @@ export interface ShareMenuProps {
   variant?: "statusbar" | "toolbar";
 }
 
-export function ShareMenu({ vaultPath, variant = "statusbar" }: ShareMenuProps) {
+export function ShareMenu({
+  vaultPath,
+  variant = "statusbar",
+}: ShareMenuProps) {
   const { options, copy, open } = useShareRepoUrl(vaultPath);
 
   return (
@@ -55,11 +58,7 @@ export function ShareMenu({ vaultPath, variant = "statusbar" }: ShareMenuProps) 
             shadow="none"
             p={0}
           >
-            <SharePopover
-              remotes={options}
-              onCopy={copy}
-              onOpen={open}
-            />
+            <SharePopover remotes={options} onCopy={copy} onOpen={open} />
           </Menu.Content>
         </Menu.Positioner>
       </Portal>

--- a/httui-desktop/src/components/layout/StatusBar.tsx
+++ b/httui-desktop/src/components/layout/StatusBar.tsx
@@ -54,9 +54,7 @@ export function StatusBar({
   const { status: gitState } = useGitStatus(vaultPath);
   const branchActions = useGitBranchActions(vaultPath);
   const activeConnection = useWorkspaceStore((s) => s.activeConnection);
-  const pendingSecretsCount = usePendingSecretsStore(
-    (s) => s.pending.length,
-  );
+  const pendingSecretsCount = usePendingSecretsStore((s) => s.pending.length);
   const pendingModalOpen = usePendingSecretsStore((s) => s.modalOpen);
   const reopenPendingSecrets = usePendingSecretsStore((s) => s.reopen);
 
@@ -112,9 +110,7 @@ export function StatusBar({
             data-testid="status-conn"
           >
             <Dot
-              variant={
-                activeConnection.status === "connected" ? "ok" : "err"
-              }
+              variant={activeConnection.status === "connected" ? "ok" : "err"}
             />
             <Text>{activeConnection.name}</Text>
           </Box>

--- a/httui-desktop/src/components/layout/__tests__/AddBlockMenu.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/AddBlockMenu.test.tsx
@@ -41,9 +41,7 @@ describe("AddBlockMenu", () => {
       "shell",
     ];
     for (const kind of expectedKinds) {
-      expect(
-        screen.getByText(BLOCK_TEMPLATES[kind].label),
-      ).toBeInTheDocument();
+      expect(screen.getByText(BLOCK_TEMPLATES[kind].label)).toBeInTheDocument();
     }
   });
 

--- a/httui-desktop/src/components/layout/__tests__/BranchMenu.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/BranchMenu.test.tsx
@@ -21,9 +21,7 @@ describe("BranchMenu", () => {
     expect(
       screen.getByRole("button", { name: /Branch feat\/login/ }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("status-branch").textContent).toBe(
-      "feat/login",
-    );
+    expect(screen.getByTestId("status-branch").textContent).toBe("feat/login");
   });
 
   it("hides the counts cell when every category is zero", () => {
@@ -51,9 +49,7 @@ describe("BranchMenu", () => {
   });
 
   it("only renders nonzero categories", () => {
-    renderWithProviders(
-      <BranchMenu branch="main" added={2} />,
-    );
+    renderWithProviders(<BranchMenu branch="main" added={2} />);
     const counts = screen.getByTestId("status-changes");
     expect(counts.textContent).toContain("+2");
     expect(counts.textContent).not.toContain("↑");
@@ -68,13 +64,11 @@ describe("BranchMenu", () => {
 
     await user.click(screen.getByRole("button", { name: /Branch main/ }));
 
-    expect(
-      screen.getByTestId("branch-menu-placeholder"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("branch-menu-placeholder")).toBeInTheDocument();
     // Mentions V10 so users know what's coming.
-    expect(
-      screen.getByTestId("branch-menu-placeholder").textContent,
-    ).toMatch(/V10/);
+    expect(screen.getByTestId("branch-menu-placeholder").textContent).toMatch(
+      /V10/,
+    );
   });
 
   describe("switcher mode (V10 cenário 4)", () => {
@@ -122,9 +116,7 @@ describe("BranchMenu", () => {
         />,
       );
       await user.click(screen.getByRole("button", { name: /Branch main/ }));
-      await user.click(
-        screen.getByTestId("git-branch-picker-row-feat/x"),
-      );
+      await user.click(screen.getByTestId("git-branch-picker-row-feat/x"));
       expect(onSelectBranch).toHaveBeenCalledWith(BRANCHES[1]);
     });
   });

--- a/httui-desktop/src/components/layout/__tests__/EnvMenu.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/EnvMenu.test.tsx
@@ -48,9 +48,7 @@ describe("EnvMenu", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: /Environment local/ }),
-    );
+    await user.click(screen.getByRole("button", { name: /Environment local/ }));
 
     const items = screen.getAllByRole("menuitem");
     expect(items).toHaveLength(2);
@@ -69,9 +67,7 @@ describe("EnvMenu", () => {
     );
     await user.click(screen.getByRole("button", { name: /Environment prod/ }));
     const items = screen.getAllByRole("menuitem");
-    const active = items.find(
-      (i) => i.getAttribute("data-active") === "true",
-    );
+    const active = items.find((i) => i.getAttribute("data-active") === "true");
     expect(active?.getAttribute("data-env-id")).toBe("b");
   });
 
@@ -85,9 +81,7 @@ describe("EnvMenu", () => {
         onSwitch={onSwitch}
       />,
     );
-    await user.click(
-      screen.getByRole("button", { name: /Environment local/ }),
-    );
+    await user.click(screen.getByRole("button", { name: /Environment local/ }));
     await user.click(screen.getByText("prod"));
     expect(onSwitch).toHaveBeenCalledWith("b");
   });
@@ -101,7 +95,9 @@ describe("EnvMenu", () => {
         onSwitch={() => {}}
       />,
     );
-    await user.click(screen.getByRole("button", { name: /Environment no env/ }));
+    await user.click(
+      screen.getByRole("button", { name: /Environment no env/ }),
+    );
     expect(screen.getByText("No environments")).toBeInTheDocument();
   });
 });

--- a/httui-desktop/src/components/layout/__tests__/EnvSwitcher.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/EnvSwitcher.test.tsx
@@ -60,10 +60,7 @@ describe("EnvSwitcher", () => {
     await user.click(screen.getByTestId("status-env"));
     await user.click(await screen.findByTestId("env-menu-clone"));
     await screen.findByTestId("clone-environment-form");
-    await user.type(
-      screen.getByTestId("clone-environment-name"),
-      "local-copy",
-    );
+    await user.type(screen.getByTestId("clone-environment-name"), "local-copy");
     await user.click(screen.getByTestId("clone-environment-save"));
     expect(duplicateEnvironment).toHaveBeenCalledWith("a", "local-copy");
   });

--- a/httui-desktop/src/components/layout/__tests__/PendingSecretsModal.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/PendingSecretsModal.test.tsx
@@ -61,9 +61,7 @@ describe("PendingSecretsModal", () => {
 
     renderWithProviders(<PendingSecretsModal />);
 
-    const rowA = screen.getByTestId(
-      `pending-secret-row-${REF_A.keychain_key}`,
-    );
+    const rowA = screen.getByTestId(`pending-secret-row-${REF_A.keychain_key}`);
     const input = rowA.querySelector(
       '[data-testid="pending-secret-input"]',
     ) as HTMLInputElement;
@@ -119,16 +117,13 @@ describe("PendingSecretsModal", () => {
     });
 
     renderWithProviders(<PendingSecretsModal />);
-    await user.type(
-      screen.getByTestId("pending-secret-input"),
-      "topsecret",
-    );
+    await user.type(screen.getByTestId("pending-secret-input"), "topsecret");
     await user.click(screen.getByTestId("pending-secret-save"));
 
     await waitFor(() =>
-      expect(
-        screen.getByTestId("pending-secret-error").textContent,
-      ).toContain("keychain locked"),
+      expect(screen.getByTestId("pending-secret-error").textContent).toContain(
+        "keychain locked",
+      ),
     );
     // Row stayed because save failed.
     expect(
@@ -141,9 +136,7 @@ describe("PendingSecretsModal", () => {
     usePendingSecretsStore.getState().setPending([REF_A, REF_B]);
     renderWithProviders(<PendingSecretsModal />);
 
-    const rowA = screen.getByTestId(
-      `pending-secret-row-${REF_A.keychain_key}`,
-    );
+    const rowA = screen.getByTestId(`pending-secret-row-${REF_A.keychain_key}`);
     const skipBtn = rowA.querySelector(
       '[data-testid="pending-secret-skip"]',
     ) as HTMLButtonElement;
@@ -167,17 +160,13 @@ describe("PendingSecretsModal", () => {
     renderWithProviders(<PendingSecretsModal />);
 
     // Skip both rows.
-    const rowA = screen.getByTestId(
-      `pending-secret-row-${REF_A.keychain_key}`,
-    );
+    const rowA = screen.getByTestId(`pending-secret-row-${REF_A.keychain_key}`);
     await user.click(
       rowA.querySelector(
         '[data-testid="pending-secret-skip"]',
       ) as HTMLButtonElement,
     );
-    const rowB = screen.getByTestId(
-      `pending-secret-row-${REF_B.keychain_key}`,
-    );
+    const rowB = screen.getByTestId(`pending-secret-row-${REF_B.keychain_key}`);
     await user.click(
       rowB.querySelector(
         '[data-testid="pending-secret-skip"]',
@@ -262,10 +251,7 @@ describe("PendingSecretsModal", () => {
     mockTauriCommand("save_secret_cmd", () => null);
 
     renderWithProviders(<PendingSecretsModal />);
-    await user.type(
-      screen.getByTestId("pending-secret-input"),
-      "topsecret",
-    );
+    await user.type(screen.getByTestId("pending-secret-input"), "topsecret");
     await user.click(screen.getByTestId("pending-secret-save"));
 
     await waitFor(() =>

--- a/httui-desktop/src/components/layout/__tests__/ShareMenu.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/ShareMenu.test.tsx
@@ -40,9 +40,7 @@ describe("ShareMenu", () => {
     expect(
       screen.getByTestId("share-popover-remote-HTTPS"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("share-popover-remote-Web"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("share-popover-remote-Web")).toBeInTheDocument();
   });
 
   it("shows the empty state when no remote is configured", async () => {

--- a/httui-desktop/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/Sidebar.test.tsx
@@ -3,10 +3,7 @@ import { renderWithWorkspace, screen } from "@/test/render";
 
 import { Sidebar } from "@/components/layout/Sidebar";
 import { useEnvironmentStore } from "@/stores/environment";
-import {
-  mockTauriCommand,
-  clearTauriMocks,
-} from "@/test/mocks/tauri";
+import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
 
 beforeEach(() => {
   clearTauriMocks();

--- a/httui-desktop/src/components/layout/__tests__/StatusBar.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/StatusBar.test.tsx
@@ -201,9 +201,9 @@ describe("StatusBar — pending secrets badge", () => {
     usePendingSecretsStore.getState().setPending([PENDING_REF]);
     usePendingSecretsStore.getState().dismiss();
     renderWithProviders(<StatusBar />);
-    expect(
-      screen.getByTestId("status-pending-secrets").textContent,
-    ).toContain("1 secret pendente");
+    expect(screen.getByTestId("status-pending-secrets").textContent).toContain(
+      "1 secret pendente",
+    );
   });
 
   it("shows pluralized label for 2+ pending refs", () => {
@@ -218,9 +218,9 @@ describe("StatusBar — pending secrets badge", () => {
     ]);
     usePendingSecretsStore.getState().dismiss();
     renderWithProviders(<StatusBar />);
-    expect(
-      screen.getByTestId("status-pending-secrets").textContent,
-    ).toContain("2 secrets pendentes");
+    expect(screen.getByTestId("status-pending-secrets").textContent).toContain(
+      "2 secrets pendentes",
+    );
   });
 
   it("clicking the badge reopens the modal", async () => {

--- a/httui-desktop/src/components/layout/__tests__/TopBar.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/TopBar.test.tsx
@@ -122,7 +122,9 @@ describe("TopBar", () => {
     it("chat button calls onToggleChat", async () => {
       const user = userEvent.setup();
       const onToggleChat = vi.fn();
-      renderWithWorkspace(<TopBar {...baseProps} onToggleChat={onToggleChat} />);
+      renderWithWorkspace(
+        <TopBar {...baseProps} onToggleChat={onToggleChat} />,
+      );
       await user.click(screen.getByRole("button", { name: /open chat/i }));
       expect(onToggleChat).toHaveBeenCalledTimes(1);
     });
@@ -161,9 +163,7 @@ describe("TopBar", () => {
       const user = userEvent.setup();
       const onSearch = vi.fn();
       renderWithWorkspace(<TopBar {...baseProps} onSearch={onSearch} />);
-      await user.click(
-        screen.getByLabelText("Search blocks, vars, schema"),
-      );
+      await user.click(screen.getByLabelText("Search blocks, vars, schema"));
       expect(onSearch).toHaveBeenCalledTimes(1);
     });
 
@@ -172,9 +172,7 @@ describe("TopBar", () => {
       const dispatch = vi.spyOn(window, "dispatchEvent");
       renderWithWorkspace(<TopBar {...baseProps} />);
 
-      await user.click(
-        screen.getByLabelText("Search blocks, vars, schema"),
-      );
+      await user.click(screen.getByLabelText("Search blocks, vars, schema"));
 
       const calls = dispatch.mock.calls.filter(
         (c) => (c[0] as KeyboardEvent).key === "p",

--- a/httui-desktop/src/components/layout/__tests__/VariablesPanel.test.tsx
+++ b/httui-desktop/src/components/layout/__tests__/VariablesPanel.test.tsx
@@ -13,11 +13,7 @@ const mkEnv = (id: string, name: string) => ({
   created_at: "2026-01-01T00:00:00Z",
 });
 
-const mkVar = (
-  key: string,
-  value: string,
-  isSecret = false,
-): EnvVariable => ({
+const mkVar = (key: string, value: string, isSecret = false): EnvVariable => ({
   id: `var-${key}`,
   environment_id: "env-1",
   key,
@@ -93,12 +89,8 @@ describe("VariablesPanel", () => {
     expect(screen.queryByText("supersecret")).toBeNull();
     expect(screen.getByText("••••••••")).toBeInTheDocument();
     // LuKey icon present for the secret row only.
-    expect(
-      screen.getByTestId("var-key-icon-DB_PASSWORD"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("var-key-icon-API_URL"),
-    ).toBeNull();
+    expect(screen.getByTestId("var-key-icon-DB_PASSWORD")).toBeInTheDocument();
+    expect(screen.queryByTestId("var-key-icon-API_URL")).toBeNull();
   });
 
   it("clicking the edit button opens the manager", async () => {
@@ -116,9 +108,7 @@ describe("VariablesPanel", () => {
 
   it("re-fetches when activeEnvironment changes", async () => {
     const loadVariables = vi.fn(async (envId: string) =>
-      envId === "env-1"
-        ? [mkVar("ONE", "1")]
-        : [mkVar("TWO", "2")],
+      envId === "env-1" ? [mkVar("ONE", "1")] : [mkVar("TWO", "2")],
     );
     useEnvironmentStore.setState({
       activeEnvironment: mkEnv("env-1", "local"),

--- a/httui-desktop/src/components/layout/connections/ConnectionDetailCredentials.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionDetailCredentials.tsx
@@ -10,14 +10,7 @@
 // behavior with vi.fn() promises.
 
 import { useEffect, useState } from "react";
-import {
-  Box,
-  Flex,
-  HStack,
-  Stack,
-  Text,
-  chakra,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, Stack, Text, chakra } from "@chakra-ui/react";
 
 import { LuKey } from "react-icons/lu";
 
@@ -106,9 +99,7 @@ export function ConnectionDetailCredentials({
       const input: UpdateConnectionInput = {
         host: draft.host,
         port:
-          draft.port.trim().length === 0
-            ? undefined
-            : Number(draft.port) || 0,
+          draft.port.trim().length === 0 ? undefined : Number(draft.port) || 0,
         database_name: draft.database,
         username: draft.username,
       };
@@ -152,11 +143,7 @@ export function ConnectionDetailCredentials({
   }
 
   return (
-    <Stack
-      data-testid="connection-credentials"
-      gap={3}
-      align="stretch"
-    >
+    <Stack data-testid="connection-credentials" gap={3} align="stretch">
       <Flex justify="space-between" align="center">
         <Text
           fontFamily="mono"
@@ -199,11 +186,7 @@ export function ConnectionDetailCredentials({
       </Flex>
 
       {!editing ? (
-        <Stack
-          gap={2}
-          data-testid="credentials-readonly"
-          fontSize="12px"
-        >
+        <Stack gap={2} data-testid="credentials-readonly" fontSize="12px">
           <SummaryRow label="Host" value={connection.host ?? "—"} />
           <SummaryRow
             label="Port"
@@ -217,11 +200,7 @@ export function ConnectionDetailCredentials({
           <SummaryRow label="Password" value={PASSWORD_MASK} mono />
         </Stack>
       ) : (
-        <Stack
-          gap={2}
-          data-testid="credentials-editing"
-          fontSize="12px"
-        >
+        <Stack gap={2} data-testid="credentials-editing" fontSize="12px">
           <EditField
             label="Host"
             testId="credentials-host"
@@ -277,8 +256,8 @@ export function ConnectionDetailCredentials({
         ) : (
           <Stack gap={2}>
             <Text fontSize="11px" color="fg.muted">
-              Enter the new password — it will be written to the OS
-              keychain. The vault file only stores a{" "}
+              Enter the new password — it will be written to the OS keychain.
+              The vault file only stores a{" "}
               <Box as="code" fontFamily="mono">
                 {"{{keychain:…}}"}
               </Box>{" "}

--- a/httui-desktop/src/components/layout/connections/ConnectionDetailFooter.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionDetailFooter.tsx
@@ -238,13 +238,7 @@ function TestResultBanner({ result }: { result: TestResult }) {
       fontSize="11px"
     >
       <Flex align="center" gap={2}>
-        <Box
-          h="6px"
-          w="6px"
-          borderRadius="full"
-          bg="red.solid"
-          aria-hidden
-        />
+        <Box h="6px" w="6px" borderRadius="full" bg="red.solid" aria-hidden />
         <Text fontWeight={500}>Failed</Text>
         <Text fontFamily="mono" color="red.fg" truncate>
           {result.message}

--- a/httui-desktop/src/components/layout/connections/ConnectionDetailSchemaPreview.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionDetailSchemaPreview.tsx
@@ -48,11 +48,7 @@ export function ConnectionDetailSchemaPreview({
   onRefresh,
 }: ConnectionDetailSchemaPreviewProps) {
   return (
-    <Stack
-      data-testid="connection-schema-preview"
-      gap={3}
-      align="stretch"
-    >
+    <Stack data-testid="connection-schema-preview" gap={3} align="stretch">
       <Flex justify="space-between" align="center">
         <Text
           fontFamily="mono"
@@ -77,31 +73,19 @@ export function ConnectionDetailSchemaPreview({
       </Flex>
 
       {error !== null && (
-        <Text
-          data-testid="schema-error"
-          fontSize="11px"
-          color="red.fg"
-        >
+        <Text data-testid="schema-error" fontSize="11px" color="red.fg">
           {error}
         </Text>
       )}
 
       {loading && schema === null && (
-        <Text
-          data-testid="schema-loading"
-          fontSize="11px"
-          color="fg.subtle"
-        >
+        <Text data-testid="schema-loading" fontSize="11px" color="fg.subtle">
           Loading schema…
         </Text>
       )}
 
       {!loading && error === null && schema === null && (
-        <Text
-          data-testid="schema-empty"
-          fontSize="11px"
-          color="fg.subtle"
-        >
+        <Text data-testid="schema-empty" fontSize="11px" color="fg.subtle">
           Pick "Refresh" to introspect this connection's schema.
         </Text>
       )}
@@ -119,10 +103,7 @@ export function ConnectionDetailSchemaPreview({
             All tables ({schema.tables.length})
           </Text>
           {schema.tables.map((t) => (
-            <TableNode
-              key={`${t.schema ?? ""}\0${t.name}`}
-              table={t}
-            />
+            <TableNode key={`${t.schema ?? ""}\0${t.name}`} table={t} />
           ))}
         </Stack>
       )}
@@ -130,24 +111,12 @@ export function ConnectionDetailSchemaPreview({
   );
 }
 
-function HotTablesSection({
-  hotTables,
-}: {
-  hotTables: HotTableEntry[];
-}) {
+function HotTablesSection({ hotTables }: { hotTables: HotTableEntry[] }) {
   if (hotTables.length === 0) return null;
   const top = hotTables.slice(0, HOT_TABLES_LIMIT);
   return (
-    <Stack
-      data-testid="schema-hot-tables"
-      gap={1}
-      align="stretch"
-    >
-      <Text
-        fontSize="11px"
-        color="fg.subtle"
-        fontFamily="mono"
-      >
+    <Stack data-testid="schema-hot-tables" gap={1} align="stretch">
+      <Text fontSize="11px" color="fg.subtle" fontFamily="mono">
         Hot tables (most queried)
       </Text>
       {top.map((t) => (
@@ -165,7 +134,12 @@ function HotTablesSection({
           <Text fontFamily="mono" fontSize="11px" color="fg" truncate>
             {t.tableName}
           </Text>
-          <Text fontFamily="mono" fontSize="11px" color="fg.subtle" flexShrink={0}>
+          <Text
+            fontFamily="mono"
+            fontSize="11px"
+            color="fg.subtle"
+            flexShrink={0}
+          >
             {t.hits} hits
           </Text>
         </Flex>
@@ -178,10 +152,7 @@ function TableNode({ table }: { table: SchemaTable }) {
   const [open, setOpen] = useState(false);
   const display = table.schema ? `${table.schema}.${table.name}` : table.name;
   return (
-    <Box
-      data-testid={`schema-table-${display}`}
-      borderRadius="4px"
-    >
+    <Box data-testid={`schema-table-${display}`} borderRadius="4px">
       <TableHeader
         type="button"
         data-testid={`schema-table-toggle-${display}`}
@@ -231,12 +202,7 @@ function TableNode({ table }: { table: SchemaTable }) {
           pb={1}
         >
           {table.columns.map((c) => (
-            <HStack
-              key={c.name}
-              gap={2}
-              fontFamily="mono"
-              fontSize="11px"
-            >
+            <HStack key={c.name} gap={2} fontFamily="mono" fontSize="11px">
               <Text color="fg" flex={1} truncate>
                 {c.name}
               </Text>

--- a/httui-desktop/src/components/layout/connections/ConnectionDetailUsedIn.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionDetailUsedIn.tsx
@@ -29,11 +29,7 @@ export function ConnectionDetailUsedIn({
   onOpen,
 }: ConnectionDetailUsedInProps) {
   return (
-    <Stack
-      data-testid="connection-used-in"
-      gap={2}
-      align="stretch"
-    >
+    <Stack data-testid="connection-used-in" gap={2} align="stretch">
       <Flex justify="space-between" align="center">
         <Text
           fontFamily="mono"
@@ -56,31 +52,19 @@ export function ConnectionDetailUsedIn({
       </Flex>
 
       {loading && usages.length === 0 && (
-        <Text
-          data-testid="used-in-loading"
-          fontSize="11px"
-          color="fg.subtle"
-        >
+        <Text data-testid="used-in-loading" fontSize="11px" color="fg.subtle">
           Searching vault…
         </Text>
       )}
 
       {!loading && usages.length === 0 && (
-        <Text
-          data-testid="used-in-empty"
-          fontSize="11px"
-          color="fg.subtle"
-        >
+        <Text data-testid="used-in-empty" fontSize="11px" color="fg.subtle">
           Not referenced in any runbook yet.
         </Text>
       )}
 
       {usages.length > 0 && (
-        <Stack
-          gap={0.5}
-          align="stretch"
-          data-testid="used-in-list"
-        >
+        <Stack gap={0.5} align="stretch" data-testid="used-in-list">
           {usages.map((u, i) => (
             <UsageButton
               key={`${u.filePath}:${u.line}:${i}`}

--- a/httui-desktop/src/components/layout/connections/ConnectionListRow.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionListRow.tsx
@@ -124,7 +124,11 @@ export function ConnectionListRow({
       border="none"
       _hover={{ bg: selected ? "brand.subtle" : "bg.muted" }}
     >
-      {item.kind ? <ConnectionKindIcon kind={item.kind} size={22} /> : fallbackIcon()}
+      {item.kind ? (
+        <ConnectionKindIcon kind={item.kind} size={22} />
+      ) : (
+        fallbackIcon()
+      )}
 
       <HStack gap={2} minW={0}>
         <Text
@@ -153,21 +157,11 @@ export function ConnectionListRow({
         )}
       </HStack>
 
-      <Text
-        fontFamily="mono"
-        fontSize="10px"
-        color="fg.subtle"
-        truncate
-      >
+      <Text fontFamily="mono" fontSize="10px" color="fg.subtle" truncate>
         {item.host ?? "—"}
       </Text>
 
-      <Text
-        fontFamily="mono"
-        fontSize="11px"
-        color="fg.muted"
-        truncate
-      >
+      <Text fontFamily="mono" fontSize="11px" color="fg.muted" truncate>
         {item.env ?? "—"}
       </Text>
 
@@ -210,19 +204,13 @@ export function ConnectionListRow({
               <Menu.Positioner>
                 <Menu.Content>
                   {onEdit && (
-                    <Menu.Item
-                      value="edit"
-                      onSelect={() => onEdit(item.id)}
-                    >
+                    <Menu.Item value="edit" onSelect={() => onEdit(item.id)}>
                       <LuPencil />
                       Edit
                     </Menu.Item>
                   )}
                   {onTest && (
-                    <Menu.Item
-                      value="test"
-                      onSelect={() => onTest(item.id)}
-                    >
+                    <Menu.Item value="test" onSelect={() => onTest(item.id)}>
                       <LuPlay />
                       Test
                     </Menu.Item>

--- a/httui-desktop/src/components/layout/connections/ConnectionQuickEdit.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionQuickEdit.tsx
@@ -62,9 +62,7 @@ export function ConnectionQuickEdit({
   const override = useConnectionSessionOverrideStore((s) =>
     s.getOverride(conn.id),
   );
-  const setOverride = useConnectionSessionOverrideStore(
-    (s) => s.setOverride,
-  );
+  const setOverride = useConnectionSessionOverrideStore((s) => s.setOverride);
   const clearOverride = useConnectionSessionOverrideStore(
     (s) => s.clearOverride,
   );
@@ -198,11 +196,7 @@ export function ConnectionQuickEdit({
 
       {/* Test + Duplicate */}
       <HStack gap={2}>
-        <Btn
-          variant="ghost"
-          data-testid="conn-quickedit-test"
-          onClick={onTest}
-        >
+        <Btn variant="ghost" data-testid="conn-quickedit-test" onClick={onTest}>
           <LuPlugZap size={13} />
           Test
         </Btn>
@@ -223,11 +217,7 @@ export function ConnectionQuickEdit({
         borderTopColor="border"
         justify="space-between"
       >
-        <Btn
-          variant="ghost"
-          data-testid="conn-quickedit-edit"
-          onClick={onEdit}
-        >
+        <Btn variant="ghost" data-testid="conn-quickedit-edit" onClick={onEdit}>
           <LuPencil size={13} />
           Edit…
         </Btn>

--- a/httui-desktop/src/components/layout/connections/ConnectionsDetailPanel.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsDetailPanel.tsx
@@ -104,8 +104,8 @@ export function ConnectionsDetailPanel({
             Nothing selected
           </Text>
           <Text fontSize="11px" color="fg.subtle" textAlign="center">
-            Pick a connection on the left to see credentials,
-            schema preview, and where it's used.
+            Pick a connection on the left to see credentials, schema preview,
+            and where it's used.
           </Text>
         </Stack>
       ) : selectedConnection ? (
@@ -145,8 +145,8 @@ export function ConnectionsDetailPanel({
             {selectedConnectionName}
           </Text>
           <Text fontSize="11px" color="fg.subtle">
-            Detail sections (credentials / schema / used in runbooks)
-            land in the Story 02-04 slices.
+            Detail sections (credentials / schema / used in runbooks) land in
+            the Story 02-04 slices.
           </Text>
         </Stack>
       )}

--- a/httui-desktop/src/components/layout/connections/ConnectionsKindSidebar.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsKindSidebar.tsx
@@ -116,12 +116,7 @@ export function ConnectionsKindSidebar({
                     flexShrink={0}
                     aria-hidden
                   />
-                  <Text
-                    flex={1}
-                    fontFamily="mono"
-                    fontSize="12px"
-                    color="fg"
-                  >
+                  <Text flex={1} fontFamily="mono" fontSize="12px" color="fg">
                     {e.name}
                   </Text>
                   <Text

--- a/httui-desktop/src/components/layout/connections/ConnectionsList.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsList.tsx
@@ -180,118 +180,118 @@ export function ConnectionsList() {
             const isProd = PROD_PATTERN.test(conn.name);
             const hasOverride = conn.id in overrides;
             return (
-            <Popover.Root
-              key={conn.id}
-              lazyMount
-              unmountOnExit
-              positioning={{ placement: "right-start", gutter: 6 }}
-            >
-              <Popover.Trigger asChild>
-                <Flex
-                  data-testid={`sidebar-connection-${conn.id}`}
-                  data-status={ping?.status ?? "idle"}
-                  data-prod={isProd ? "true" : "false"}
-                  data-temporary={hasOverride ? "true" : "false"}
-                  align="center"
-                  gap={2}
-                  px={2}
-                  py={1}
-                  mx={1}
-                  rounded="md"
-                  cursor="pointer"
-                  _hover={{ bg: "bg.subtle" }}
-                  fontSize="sm"
-                >
-                  <LuDatabase size={14} />
-                  <Text flex={1} truncate fontFamily="mono" fontSize="xs">
-                    {conn.name}
-                  </Text>
-                  {hasOverride && (
-                    <Box flexShrink={0}>
-                      <TemporaryChip />
-                    </Box>
-                  )}
-                  {isProd && (
-                    <Text
-                      data-testid={`sidebar-connection-${conn.id}-prod`}
-                      fontSize="2xs"
-                      fontWeight={700}
-                      letterSpacing="0.06em"
-                      px="4px"
-                      py="1px"
-                      color="red.fg"
-                      bg="red.subtle"
-                      borderRadius="3px"
-                      flexShrink={0}
-                    >
-                      PROD
-                    </Text>
-                  )}
-                  <Badge
-                    size="sm"
-                    variant="subtle"
-                    colorPalette={DRIVER_COLORS[conn.driver] ?? "gray"}
-                    fontFamily="mono"
-                    fontSize="2xs"
+              <Popover.Root
+                key={conn.id}
+                lazyMount
+                unmountOnExit
+                positioning={{ placement: "right-start", gutter: 6 }}
+              >
+                <Popover.Trigger asChild>
+                  <Flex
+                    data-testid={`sidebar-connection-${conn.id}`}
+                    data-status={ping?.status ?? "idle"}
+                    data-prod={isProd ? "true" : "false"}
+                    data-temporary={hasOverride ? "true" : "false"}
+                    align="center"
+                    gap={2}
+                    px={2}
+                    py={1}
+                    mx={1}
+                    rounded="md"
+                    cursor="pointer"
+                    _hover={{ bg: "bg.subtle" }}
+                    fontSize="sm"
                   >
-                    {DRIVER_LABELS[conn.driver] ?? conn.driver}
-                  </Badge>
-                  <Flex align="center" gap={1} flexShrink={0}>
-                    {testing === conn.id ? (
-                      <Spinner size="xs" />
-                    ) : (
-                      <Box
-                        data-testid={`sidebar-connection-${conn.id}-dot`}
-                        w={2}
-                        h={2}
-                        rounded="full"
-                        bg={
-                          ping?.status === "ok"
-                            ? "green.500"
-                            : ping?.status === "err"
-                              ? "red.500"
-                              : "gray.500"
-                        }
-                      />
+                    <LuDatabase size={14} />
+                    <Text flex={1} truncate fontFamily="mono" fontSize="xs">
+                      {conn.name}
+                    </Text>
+                    {hasOverride && (
+                      <Box flexShrink={0}>
+                        <TemporaryChip />
+                      </Box>
                     )}
-                    {ping?.latencyMs != null && (
+                    {isProd && (
                       <Text
-                        data-testid={`sidebar-connection-${conn.id}-latency`}
-                        fontFamily="mono"
+                        data-testid={`sidebar-connection-${conn.id}-prod`}
                         fontSize="2xs"
-                        color="fg.subtle"
+                        fontWeight={700}
+                        letterSpacing="0.06em"
+                        px="4px"
+                        py="1px"
+                        color="red.fg"
+                        bg="red.subtle"
+                        borderRadius="3px"
+                        flexShrink={0}
                       >
-                        {ping.latencyMs}ms
+                        PROD
                       </Text>
                     )}
+                    <Badge
+                      size="sm"
+                      variant="subtle"
+                      colorPalette={DRIVER_COLORS[conn.driver] ?? "gray"}
+                      fontFamily="mono"
+                      fontSize="2xs"
+                    >
+                      {DRIVER_LABELS[conn.driver] ?? conn.driver}
+                    </Badge>
+                    <Flex align="center" gap={1} flexShrink={0}>
+                      {testing === conn.id ? (
+                        <Spinner size="xs" />
+                      ) : (
+                        <Box
+                          data-testid={`sidebar-connection-${conn.id}-dot`}
+                          w={2}
+                          h={2}
+                          rounded="full"
+                          bg={
+                            ping?.status === "ok"
+                              ? "green.500"
+                              : ping?.status === "err"
+                                ? "red.500"
+                                : "gray.500"
+                          }
+                        />
+                      )}
+                      {ping?.latencyMs != null && (
+                        <Text
+                          data-testid={`sidebar-connection-${conn.id}-latency`}
+                          fontFamily="mono"
+                          fontSize="2xs"
+                          color="fg.subtle"
+                        >
+                          {ping.latencyMs}ms
+                        </Text>
+                      )}
+                    </Flex>
                   </Flex>
-                </Flex>
-              </Popover.Trigger>
-              <Portal>
-                <Popover.Positioner>
-                  <Popover.Content
-                    width="auto"
-                    bg="transparent"
-                    borderWidth={0}
-                    boxShadow="none"
-                  >
-                    <ConnectionQuickEdit
-                      conn={conn}
-                      pingStatus={ping?.status ?? "idle"}
-                      pingLatencyMs={ping?.latencyMs ?? null}
-                      onTest={() => handleTest(conn.id)}
-                      onEdit={() => {
-                        setEditingConn(conn);
-                        setShowForm(true);
-                      }}
-                      onDelete={() => handleDelete(conn.id)}
-                      onDuplicate={() => handleDuplicate(conn)}
-                      onChanged={() => refresh()}
-                    />
-                  </Popover.Content>
-                </Popover.Positioner>
-              </Portal>
-            </Popover.Root>
+                </Popover.Trigger>
+                <Portal>
+                  <Popover.Positioner>
+                    <Popover.Content
+                      width="auto"
+                      bg="transparent"
+                      borderWidth={0}
+                      boxShadow="none"
+                    >
+                      <ConnectionQuickEdit
+                        conn={conn}
+                        pingStatus={ping?.status ?? "idle"}
+                        pingLatencyMs={ping?.latencyMs ?? null}
+                        onTest={() => handleTest(conn.id)}
+                        onEdit={() => {
+                          setEditingConn(conn);
+                          setShowForm(true);
+                        }}
+                        onDelete={() => handleDelete(conn.id)}
+                        onDuplicate={() => handleDuplicate(conn)}
+                        onChanged={() => refresh()}
+                      />
+                    </Popover.Content>
+                  </Popover.Positioner>
+                </Portal>
+              </Popover.Root>
             );
           })}
         </Box>

--- a/httui-desktop/src/components/layout/connections/ConnectionsListPanel.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsListPanel.tsx
@@ -12,10 +12,7 @@ import { LuPlus } from "react-icons/lu";
 
 import { Btn, Input } from "@/components/atoms";
 import { MasterDetailListHeader } from "@/components/layout/shared";
-import {
-  ConnectionListRow,
-  type ListRowItem,
-} from "./ConnectionListRow";
+import { ConnectionListRow, type ListRowItem } from "./ConnectionListRow";
 
 export interface ListStatusCounts {
   total: number;
@@ -146,7 +143,6 @@ export function ConnectionsListPanel({
           </Text>
         </Flex>
       )}
-
     </Stack>
   );
 }

--- a/httui-desktop/src/components/layout/connections/ConnectionsPage.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsPage.tsx
@@ -124,9 +124,7 @@ export function ConnectionsPage({
   selectedId: selectedIdProp,
   onSelectId,
 }: ConnectionsPageProps) {
-  const [selectedKind, setSelectedKind] = useState<ConnectionKind | null>(
-    null,
-  );
+  const [selectedKind, setSelectedKind] = useState<ConnectionKind | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [internalSelectedId, setInternalSelectedId] = useState<string | null>(
     null,
@@ -174,12 +172,7 @@ export function ConnectionsPage({
   );
 
   return (
-    <Flex
-      data-testid="connections-page"
-      h="full"
-      w="full"
-      overflow="hidden"
-    >
+    <Flex data-testid="connections-page" h="full" w="full" overflow="hidden">
       <ConnectionsKindSidebar
         countsByKind={countsByKind}
         selectedKind={selectedKind}
@@ -219,22 +212,22 @@ export function ConnectionsPage({
         }
         schema={
           selectedConnection
-            ? schemaByConnection?.[selectedConnection.id]?.schema ?? null
+            ? (schemaByConnection?.[selectedConnection.id]?.schema ?? null)
             : null
         }
         schemaLoading={
           selectedConnection
-            ? schemaByConnection?.[selectedConnection.id]?.loading ?? false
+            ? (schemaByConnection?.[selectedConnection.id]?.loading ?? false)
             : false
         }
         schemaError={
           selectedConnection
-            ? schemaByConnection?.[selectedConnection.id]?.error ?? null
+            ? (schemaByConnection?.[selectedConnection.id]?.error ?? null)
             : null
         }
         hotTables={
           selectedConnection
-            ? hotTablesByConnection?.[selectedConnection.id] ?? []
+            ? (hotTablesByConnection?.[selectedConnection.id] ?? [])
             : []
         }
         onRefreshSchema={
@@ -244,12 +237,12 @@ export function ConnectionsPage({
         }
         usages={
           selectedConnection
-            ? usagesByConnection?.[selectedConnection.id] ?? []
+            ? (usagesByConnection?.[selectedConnection.id] ?? [])
             : []
         }
         usagesLoading={
           selectedConnection
-            ? usagesLoadingByConnection?.[selectedConnection.id] ?? false
+            ? (usagesLoadingByConnection?.[selectedConnection.id] ?? false)
             : false
         }
         onOpenUsage={onOpenUsage}

--- a/httui-desktop/src/components/layout/connections/ConnectionsPageContainer.tsx
+++ b/httui-desktop/src/components/layout/connections/ConnectionsPageContainer.tsx
@@ -65,14 +65,11 @@ export function ConnectionsPageContainer({
     let cancelled = false;
     let unlisten: (() => void) | null = null;
     void (async () => {
-      const fn = await listen<{ category: string }>(
-        "config-changed",
-        (e) => {
-          if (e.payload.category === "connections") {
-            void reload();
-          }
-        },
-      );
+      const fn = await listen<{ category: string }>("config-changed", (e) => {
+        if (e.payload.category === "connections") {
+          void reload();
+        }
+      });
       if (cancelled) {
         fn();
       } else {
@@ -182,7 +179,7 @@ export function ConnectionsPageContainer({
   }, [schemaByConn]);
 
   const editing = editingId
-    ? connections.find((c) => c.id === editingId) ?? null
+    ? (connections.find((c) => c.id === editingId) ?? null)
     : null;
   const modalOpen = newOpen || Boolean(editing);
 

--- a/httui-desktop/src/components/layout/connections/NewConnectionFormTab.tsx
+++ b/httui-desktop/src/components/layout/connections/NewConnectionFormTab.tsx
@@ -13,7 +13,15 @@
 //
 // Pure presentational: form value + slots lifted to the consumer.
 
-import { Box, Flex, Grid, HStack, IconButton, Text, chakra } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Grid,
+  HStack,
+  IconButton,
+  Text,
+  chakra,
+} from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { LuFolderOpen, LuKey } from "react-icons/lu";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
@@ -48,9 +56,7 @@ export const EMPTY_POSTGRES_VALUE: PostgresFormValue = {
 
 /** Per-kind defaults for the network-shape form. Keeps port + sample
  * placeholders honest when the user switches between drivers. */
-export function emptyFormValueForKind(
-  kind: ConnectionKind,
-): PostgresFormValue {
+export function emptyFormValueForKind(kind: ConnectionKind): PostgresFormValue {
   switch (kind) {
     case "mysql":
       return { ...EMPTY_POSTGRES_VALUE, port: "3306" };
@@ -167,11 +173,7 @@ export function NewConnectionFormTab({
   }
 
   return (
-    <Flex
-      data-testid="new-connection-form-tab"
-      direction="column"
-      gap={4}
-    >
+    <Flex data-testid="new-connection-form-tab" direction="column" gap={4}>
       <Field label="Name">
         <Input
           data-testid="new-connection-field-name"

--- a/httui-desktop/src/components/layout/connections/NewConnectionModal.tsx
+++ b/httui-desktop/src/components/layout/connections/NewConnectionModal.tsx
@@ -121,10 +121,8 @@ export function NewConnectionModal({
   editingName,
 }: NewConnectionModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
-  const [internalKind, setInternalKind] =
-    useState<ConnectionKind>(initialKind);
-  const [internalTab, setInternalTab] =
-    useState<NewConnectionTabId>("form");
+  const [internalKind, setInternalKind] = useState<ConnectionKind>(initialKind);
+  const [internalTab, setInternalTab] = useState<NewConnectionTabId>("form");
   const selectedKind = kindProp ?? internalKind;
   const activeTab = activeTabProp ?? internalTab;
   const setSelectedKind = (next: ConnectionKind) => {
@@ -261,10 +259,7 @@ export function NewConnectionModal({
                 />
               </>
             ) : (
-              <ComingSoonState
-                kindLabel={meta.label}
-                onCancel={onCancel}
-              />
+              <ComingSoonState kindLabel={meta.label} onCancel={onCancel} />
             )}
           </Flex>
         </Box>
@@ -413,8 +408,8 @@ function ComingSoonState({
         {kindLabel} — coming soon
       </Text>
       <Text fontSize="13px" color="fg.muted" maxW="360px">
-        Support for {kindLabel} connections lands in a future release.
-        Pick another kind on the left or close this dialog.
+        Support for {kindLabel} connections lands in a future release. Pick
+        another kind on the left or close this dialog.
       </Text>
       <Box mt={2}>
         <Btn variant="ghost" onClick={onCancel}>

--- a/httui-desktop/src/components/layout/connections/NewConnectionSshTab.tsx
+++ b/httui-desktop/src/components/layout/connections/NewConnectionSshTab.tsx
@@ -10,11 +10,7 @@ import { Box, Flex, Text } from "@chakra-ui/react";
 
 export function NewConnectionSshTab() {
   return (
-    <Flex
-      data-testid="new-connection-ssh-tab"
-      direction="column"
-      gap={3}
-    >
+    <Flex data-testid="new-connection-ssh-tab" direction="column" gap={3}>
       <Box
         data-testid="new-connection-ssh-coming-soon"
         bg="bg.muted"
@@ -28,10 +24,9 @@ export function NewConnectionSshTab() {
           SSH tunnel — coming soon
         </Text>
         <Text fontSize="12px" color="fg.muted" mt={1}>
-          The native assistant (host, port, jump-host, key file) ships
-          in a future release. For v1, open a local tunnel
-          (<Mono>ssh -L</Mono>) and point the connection at{" "}
-          <Mono>localhost:&lt;local-port&gt;</Mono>.
+          The native assistant (host, port, jump-host, key file) ships in a
+          future release. For v1, open a local tunnel (<Mono>ssh -L</Mono>) and
+          point the connection at <Mono>localhost:&lt;local-port&gt;</Mono>.
         </Text>
       </Box>
 
@@ -53,9 +48,9 @@ export function NewConnectionSshTab() {
       </Box>
 
       <Text fontSize="11px" color="fg.subtle">
-        When native SSH lands, existing connections won't need
-        migration — the tunnel becomes just another connection detail
-        and the rest of the form stays the same.
+        When native SSH lands, existing connections won't need migration — the
+        tunnel becomes just another connection detail and the rest of the form
+        stays the same.
       </Text>
     </Flex>
   );

--- a/httui-desktop/src/components/layout/connections/NewConnectionSslTab.tsx
+++ b/httui-desktop/src/components/layout/connections/NewConnectionSslTab.tsx
@@ -7,7 +7,15 @@
 // the secondary patch surface when a connection string carries
 // ?sslmode=...&sslrootcert=... params.
 
-import { Box, Flex, Grid, HStack, IconButton, Text, chakra } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Grid,
+  HStack,
+  IconButton,
+  Text,
+  chakra,
+} from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { LuFolderOpen } from "react-icons/lu";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
@@ -71,11 +79,7 @@ export function NewConnectionSslTab({
   }
 
   return (
-    <Flex
-      data-testid="new-connection-ssl-tab"
-      direction="column"
-      gap={4}
-    >
+    <Flex data-testid="new-connection-ssl-tab" direction="column" gap={4}>
       <Field label="sslmode" hint="Choose how the client negotiates TLS.">
         <ModeSelect
           value={value.mode}
@@ -131,9 +135,9 @@ export function NewConnectionSslTab({
         px={3}
         py={2}
       >
-        Absolute paths resolve from the app disk at connection time.
-        Relative paths resolve from the vault. In `verify-full`, the
-        cert host must match the configured host.
+        Absolute paths resolve from the app disk at connection time. Relative
+        paths resolve from the vault. In `verify-full`, the cert host must match
+        the configured host.
       </Box>
     </Flex>
   );

--- a/httui-desktop/src/components/layout/connections/NewConnectionStringTab.tsx
+++ b/httui-desktop/src/components/layout/connections/NewConnectionStringTab.tsx
@@ -51,9 +51,9 @@ export function NewConnectionStringTab({
   kind,
 }: NewConnectionStringTabProps) {
   const [text, setText] = useState(initial);
-  const [result, setResult] = useState<
-    ConnectionStringParseResult | null
-  >(null);
+  const [result, setResult] = useState<ConnectionStringParseResult | null>(
+    null,
+  );
 
   function handleParse() {
     const parsed = parseConnectionString(text);
@@ -66,11 +66,7 @@ export function NewConnectionStringTab({
   const isMysql = kind === "mysql";
 
   return (
-    <Flex
-      data-testid="new-connection-string-tab"
-      direction="column"
-      gap={3}
-    >
+    <Flex data-testid="new-connection-string-tab" direction="column" gap={3}>
       <Text fontSize="11px" color="fg.muted">
         {isMysql ? (
           <>
@@ -79,10 +75,9 @@ export function NewConnectionStringTab({
           </>
         ) : (
           <>
-            Paste a <Mono>postgres://</Mono> or{" "}
-            <Mono>postgresql://</Mono> URL. Form fields and the{" "}
-            <Mono>sslmode</Mono> /<Mono>sslrootcert</Mono> params are
-            filled from the URL.
+            Paste a <Mono>postgres://</Mono> or <Mono>postgresql://</Mono> URL.
+            Form fields and the <Mono>sslmode</Mono> /<Mono>sslrootcert</Mono>{" "}
+            params are filled from the URL.
           </>
         )}
       </Text>

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailCredentials.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailCredentials.test.tsx
@@ -59,20 +59,25 @@ describe("ConnectionDetailCredentials — read mode", () => {
   it("shows '—' for null fields", () => {
     renderWithProviders(
       <ConnectionDetailCredentials
-        connection={conn({ host: null, port: null, username: null, database_name: null })}
+        connection={conn({
+          host: null,
+          port: null,
+          username: null,
+          database_name: null,
+        })}
         onSave={vi.fn()}
         onRotatePassword={vi.fn()}
       />,
     );
-    expect(
-      screen.getByTestId("credentials-row-host").textContent,
-    ).toContain("—");
-    expect(
-      screen.getByTestId("credentials-row-port").textContent,
-    ).toContain("—");
-    expect(
-      screen.getByTestId("credentials-row-user").textContent,
-    ).toContain("—");
+    expect(screen.getByTestId("credentials-row-host").textContent).toContain(
+      "—",
+    );
+    expect(screen.getByTestId("credentials-row-port").textContent).toContain(
+      "—",
+    );
+    expect(screen.getByTestId("credentials-row-user").textContent).toContain(
+      "—",
+    );
     expect(
       screen.getByTestId("credentials-row-database").textContent,
     ).toContain("—");
@@ -88,13 +93,9 @@ describe("ConnectionDetailCredentials — edit mode", () => {
         onRotatePassword={vi.fn()}
       />,
     );
-    expect(
-      screen.queryByTestId("credentials-editing"),
-    ).toBeNull();
+    expect(screen.queryByTestId("credentials-editing")).toBeNull();
     await userEvent.setup().click(screen.getByTestId("credentials-edit"));
-    expect(
-      screen.getByTestId("credentials-editing"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-editing")).toBeInTheDocument();
     expect(screen.getByTestId("credentials-save")).toBeInTheDocument();
     expect(screen.getByTestId("credentials-cancel")).toBeInTheDocument();
   });
@@ -116,9 +117,9 @@ describe("ConnectionDetailCredentials — edit mode", () => {
     expect(host.value).toBe("other.local");
     await user.click(screen.getByTestId("credentials-cancel"));
     expect(onSave).not.toHaveBeenCalled();
-    expect(
-      screen.getByTestId("credentials-readonly").textContent,
-    ).toContain("db.local");
+    expect(screen.getByTestId("credentials-readonly").textContent).toContain(
+      "db.local",
+    );
   });
 
   it("Save dispatches onSave with the edited fields and exits edit mode", async () => {
@@ -141,9 +142,7 @@ describe("ConnectionDetailCredentials — edit mode", () => {
     );
     // Wait microtask for the promise to settle and the button toggle.
     await new Promise((r) => setTimeout(r, 10));
-    expect(
-      screen.queryByTestId("credentials-editing"),
-    ).toBeNull();
+    expect(screen.queryByTestId("credentials-editing")).toBeNull();
   });
 
   it("surfaces the save error and stays in edit mode on failure", async () => {
@@ -159,12 +158,10 @@ describe("ConnectionDetailCredentials — edit mode", () => {
     await user.click(screen.getByTestId("credentials-edit"));
     await user.click(screen.getByTestId("credentials-save"));
     await new Promise((r) => setTimeout(r, 10));
-    expect(
-      screen.getByTestId("credentials-save-error").textContent,
-    ).toContain("conflict");
-    expect(
-      screen.getByTestId("credentials-editing"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-save-error").textContent).toContain(
+      "conflict",
+    );
+    expect(screen.getByTestId("credentials-editing")).toBeInTheDocument();
   });
 
   it("blank port → input.port is undefined in the save payload", async () => {
@@ -196,13 +193,9 @@ describe("ConnectionDetailCredentials — rotate password", () => {
         onRotatePassword={vi.fn()}
       />,
     );
-    expect(
-      screen.queryByTestId("credentials-rotate-input"),
-    ).toBeNull();
+    expect(screen.queryByTestId("credentials-rotate-input")).toBeNull();
     await userEvent.setup().click(screen.getByTestId("credentials-rotate"));
-    expect(
-      screen.getByTestId("credentials-rotate-input"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-rotate-input")).toBeInTheDocument();
   });
 
   it("rejects empty new password", async () => {
@@ -241,9 +234,7 @@ describe("ConnectionDetailCredentials — rotate password", () => {
     await user.click(screen.getByTestId("credentials-rotate-save"));
     expect(onRotatePassword).toHaveBeenCalledWith("new-secret");
     await new Promise((r) => setTimeout(r, 10));
-    expect(
-      screen.queryByTestId("credentials-rotate-input"),
-    ).toBeNull();
+    expect(screen.queryByTestId("credentials-rotate-input")).toBeNull();
   });
 
   it("Cancel closes the rotate section without dispatching", async () => {
@@ -257,15 +248,10 @@ describe("ConnectionDetailCredentials — rotate password", () => {
     );
     const user = userEvent.setup();
     await user.click(screen.getByTestId("credentials-rotate"));
-    await user.type(
-      screen.getByTestId("credentials-rotate-input"),
-      "secret",
-    );
+    await user.type(screen.getByTestId("credentials-rotate-input"), "secret");
     await user.click(screen.getByTestId("credentials-rotate-cancel"));
     expect(onRotatePassword).not.toHaveBeenCalled();
-    expect(
-      screen.queryByTestId("credentials-rotate-input"),
-    ).toBeNull();
+    expect(screen.queryByTestId("credentials-rotate-input")).toBeNull();
   });
 
   it("surfaces rotate error and stays open on failure", async () => {
@@ -281,18 +267,13 @@ describe("ConnectionDetailCredentials — rotate password", () => {
     );
     const user = userEvent.setup();
     await user.click(screen.getByTestId("credentials-rotate"));
-    await user.type(
-      screen.getByTestId("credentials-rotate-input"),
-      "x",
-    );
+    await user.type(screen.getByTestId("credentials-rotate-input"), "x");
     await user.click(screen.getByTestId("credentials-rotate-save"));
     await new Promise((r) => setTimeout(r, 10));
     expect(
       screen.getByTestId("credentials-rotate-error").textContent,
     ).toContain("keychain locked");
-    expect(
-      screen.getByTestId("credentials-rotate-input"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-rotate-input")).toBeInTheDocument();
   });
 });
 
@@ -307,9 +288,7 @@ describe("ConnectionDetailCredentials — connection switching", () => {
     );
     const user = userEvent.setup();
     await user.click(screen.getByTestId("credentials-edit"));
-    expect(
-      screen.getByTestId("credentials-editing"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-editing")).toBeInTheDocument();
     rerender(
       <ConnectionDetailCredentials
         connection={conn({ id: "b", name: "beta", host: "b.local" })}
@@ -317,11 +296,9 @@ describe("ConnectionDetailCredentials — connection switching", () => {
         onRotatePassword={vi.fn()}
       />,
     );
-    expect(
-      screen.queryByTestId("credentials-editing"),
-    ).toBeNull();
-    expect(
-      screen.getByTestId("credentials-readonly").textContent,
-    ).toContain("b.local");
+    expect(screen.queryByTestId("credentials-editing")).toBeNull();
+    expect(screen.getByTestId("credentials-readonly").textContent).toContain(
+      "b.local",
+    );
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailFooter.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailFooter.test.tsx
@@ -41,9 +41,7 @@ describe("ConnectionDetailFooter — Test action", () => {
     await user.click(screen.getByTestId("footer-test"));
     await flush();
     expect(onTest).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId("footer-test-ok").textContent).toContain(
-      "47ms",
-    );
+    expect(screen.getByTestId("footer-test-ok").textContent).toContain("47ms");
   });
 
   it("Test → err banner with the message from onTest", async () => {
@@ -92,9 +90,9 @@ describe("ConnectionDetailFooter — Duplicate action", () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId("footer-duplicate"));
     await flush();
-    expect(
-      screen.getByTestId("footer-duplicate-error").textContent,
-    ).toContain("name taken");
+    expect(screen.getByTestId("footer-duplicate-error").textContent).toContain(
+      "name taken",
+    );
   });
 });
 
@@ -152,9 +150,7 @@ describe("ConnectionDetailFooter — Delete action (two-step confirm)", () => {
     // Wait past the reset window
     await new Promise((r) => setTimeout(r, 120));
     await flush();
-    expect(screen.getByTestId("footer-delete").textContent).toContain(
-      "Delete",
-    );
+    expect(screen.getByTestId("footer-delete").textContent).toContain("Delete");
     expect(screen.getByTestId("footer-delete").textContent).not.toContain(
       "Click again",
     );
@@ -174,8 +170,8 @@ describe("ConnectionDetailFooter — Delete action (two-step confirm)", () => {
     await user.click(screen.getByTestId("footer-delete"));
     await user.click(screen.getByTestId("footer-delete"));
     await flush();
-    expect(
-      screen.getByTestId("footer-delete-error").textContent,
-    ).toContain("in use");
+    expect(screen.getByTestId("footer-delete-error").textContent).toContain(
+      "in use",
+    );
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailSchemaPreview.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailSchemaPreview.test.tsx
@@ -8,7 +8,9 @@ import {
 } from "@/components/layout/connections/ConnectionDetailSchemaPreview";
 import type { ConnectionSchema } from "@/stores/schemaCache";
 
-function schemaOf(...names: { schema?: string | null; name: string; cols?: number }[]): ConnectionSchema {
+function schemaOf(
+  ...names: { schema?: string | null; name: string; cols?: number }[]
+): ConnectionSchema {
   return {
     fetchedAt: 0,
     tables: names.map((t) => ({
@@ -110,9 +112,9 @@ describe("ConnectionDetailSchemaPreview — tables tree", () => {
         hotTables={[]}
       />,
     );
-    expect(
-      screen.getByTestId("schema-tables-count").textContent,
-    ).toContain("3");
+    expect(screen.getByTestId("schema-tables-count").textContent).toContain(
+      "3",
+    );
   });
 
   it("clicking the toggle expands columns", async () => {
@@ -124,9 +126,7 @@ describe("ConnectionDetailSchemaPreview — tables tree", () => {
         hotTables={[]}
       />,
     );
-    expect(
-      screen.queryByTestId("schema-table-cols-public.users"),
-    ).toBeNull();
+    expect(screen.queryByTestId("schema-table-cols-public.users")).toBeNull();
     await userEvent
       .setup()
       .click(screen.getByTestId("schema-table-toggle-public.users"));
@@ -144,18 +144,14 @@ describe("ConnectionDetailSchemaPreview — tables tree", () => {
         hotTables={[]}
       />,
     );
-    const toggle = screen.getByTestId(
-      "schema-table-toggle-public.users",
-    );
+    const toggle = screen.getByTestId("schema-table-toggle-public.users");
     const user = userEvent.setup();
     await user.click(toggle);
     expect(
       screen.getByTestId("schema-table-cols-public.users"),
     ).toBeInTheDocument();
     await user.click(toggle);
-    expect(
-      screen.queryByTestId("schema-table-cols-public.users"),
-    ).toBeNull();
+    expect(screen.queryByTestId("schema-table-cols-public.users")).toBeNull();
   });
 });
 
@@ -184,12 +180,12 @@ describe("ConnectionDetailSchemaPreview — hot tables", () => {
         ]}
       />,
     );
-    expect(
-      screen.getByTestId("schema-hot-row-users").textContent,
-    ).toContain("12");
-    expect(
-      screen.getByTestId("schema-hot-row-orders").textContent,
-    ).toContain("7");
+    expect(screen.getByTestId("schema-hot-row-users").textContent).toContain(
+      "12",
+    );
+    expect(screen.getByTestId("schema-hot-row-orders").textContent).toContain(
+      "7",
+    );
   });
 
   it(`caps the hot list at HOT_TABLES_LIMIT (${HOT_TABLES_LIMIT})`, () => {
@@ -207,9 +203,7 @@ describe("ConnectionDetailSchemaPreview — hot tables", () => {
     );
     // First HOT_TABLES_LIMIT visible, the rest hidden
     for (let i = 0; i < HOT_TABLES_LIMIT; i++) {
-      expect(
-        screen.getByTestId(`schema-hot-row-t${i}`),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId(`schema-hot-row-t${i}`)).toBeInTheDocument();
     }
     expect(
       screen.queryByTestId(`schema-hot-row-t${HOT_TABLES_LIMIT}`),
@@ -255,8 +249,8 @@ describe("ConnectionDetailSchemaPreview — refresh button", () => {
         onRefresh={() => {}}
       />,
     );
-    expect(
-      screen.getByTestId("schema-refresh").textContent,
-    ).toContain("Loading");
+    expect(screen.getByTestId("schema-refresh").textContent).toContain(
+      "Loading",
+    );
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailUsedIn.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionDetailUsedIn.test.tsx
@@ -29,10 +29,7 @@ describe("ConnectionDetailUsedIn", () => {
   it("renders one row per usage with file path and :line", () => {
     renderWithProviders(
       <ConnectionDetailUsedIn
-        usages={[
-          usage("runbooks/a.md", 12),
-          usage("runbooks/b.md", 7, null),
-        ]}
+        usages={[usage("runbooks/a.md", 12), usage("runbooks/b.md", 7, null)]}
       />,
     );
     expect(screen.getByTestId("used-in-count").textContent).toBe("2");
@@ -49,9 +46,9 @@ describe("ConnectionDetailUsedIn", () => {
         usages={[usage("a.md", 1, "SELECT count(*) FROM orders;")]}
       />,
     );
-    expect(
-      screen.getByTestId("used-in-row-0-preview").textContent,
-    ).toContain("orders");
+    expect(screen.getByTestId("used-in-row-0-preview").textContent).toContain(
+      "orders",
+    );
   });
 
   it("hides the preview slot when null", () => {

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionListRow.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionListRow.test.tsx
@@ -135,6 +135,95 @@ describe("ConnectionListRow", () => {
     expect(screen.queryByTestId("connection-row-c1-more")).toBeNull();
   });
 
+  it("selecting Edit from the actions menu invokes onEdit with the id", async () => {
+    const onEdit = vi.fn();
+    renderWithProviders(
+      <ConnectionListRow
+        item={item()}
+        selected={false}
+        onSelect={vi.fn()}
+        onEdit={onEdit}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("connection-row-c1-more"));
+    await user.click(await screen.findByText("Edit"));
+    expect(onEdit).toHaveBeenCalledWith("c1");
+  });
+
+  it("selecting Test from the actions menu invokes onTest with the id", async () => {
+    const onTest = vi.fn();
+    renderWithProviders(
+      <ConnectionListRow
+        item={item()}
+        selected={false}
+        onSelect={vi.fn()}
+        onTest={onTest}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("connection-row-c1-more"));
+    await user.click(await screen.findByText("Test"));
+    expect(onTest).toHaveBeenCalledWith("c1");
+  });
+
+  it("selecting Duplicate from the actions menu invokes onDuplicate with the id", async () => {
+    const onDuplicate = vi.fn();
+    renderWithProviders(
+      <ConnectionListRow
+        item={item()}
+        selected={false}
+        onSelect={vi.fn()}
+        onDuplicate={onDuplicate}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("connection-row-c1-more"));
+    await user.click(await screen.findByText("Duplicate"));
+    expect(onDuplicate).toHaveBeenCalledWith("c1");
+  });
+
+  it("selecting Delete from the actions menu invokes onDelete with the id", async () => {
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConnectionListRow
+        item={item()}
+        selected={false}
+        onSelect={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("connection-row-c1-more"));
+    await user.click(await screen.findByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith("c1");
+  });
+
+  it("renders all four actions together and each fires its own handler", async () => {
+    const onEdit = vi.fn();
+    const onTest = vi.fn();
+    const onDuplicate = vi.fn();
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConnectionListRow
+        item={item({ id: "c9", status: "down", latencyMs: null })}
+        selected={false}
+        onSelect={vi.fn()}
+        onEdit={onEdit}
+        onTest={onTest}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("connection-row-c9-more"));
+    await user.click(await screen.findByText("Duplicate"));
+    expect(onDuplicate).toHaveBeenCalledWith("c9");
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onTest).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
   it("marks selected via data-selected", () => {
     renderWithProviders(
       <ConnectionListRow item={item()} selected={true} onSelect={() => {}} />,

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionListRow.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionListRow.test.tsx
@@ -25,11 +25,7 @@ function item(overrides: Partial<ListRowItem> = {}): ListRowItem {
 describe("ConnectionListRow", () => {
   it("renders the kind icon for postgres", () => {
     renderWithProviders(
-      <ConnectionListRow
-        item={item()}
-        selected={false}
-        onSelect={() => {}}
-      />,
+      <ConnectionListRow item={item()} selected={false} onSelect={() => {}} />,
     );
     const row = screen.getByTestId("connection-row-c1");
     expect(row.querySelector('[data-kind="postgres"]')).toBeTruthy();
@@ -63,11 +59,7 @@ describe("ConnectionListRow", () => {
 
   it("hides the PROD chip when isProd is false", () => {
     renderWithProviders(
-      <ConnectionListRow
-        item={item()}
-        selected={false}
-        onSelect={() => {}}
-      />,
+      <ConnectionListRow item={item()} selected={false} onSelect={() => {}} />,
     );
     expect(screen.queryByTestId("connection-row-c1-prod")).toBeNull();
   });
@@ -114,11 +106,7 @@ describe("ConnectionListRow", () => {
   it("clicking the row dispatches onSelect with the id", async () => {
     const onSelect = vi.fn();
     renderWithProviders(
-      <ConnectionListRow
-        item={item()}
-        selected={false}
-        onSelect={onSelect}
-      />,
+      <ConnectionListRow item={item()} selected={false} onSelect={onSelect} />,
     );
     await userEvent.setup().click(screen.getByTestId("connection-row-c1"));
     expect(onSelect).toHaveBeenCalledWith("c1");
@@ -135,9 +123,7 @@ describe("ConnectionListRow", () => {
         onEdit={onEdit}
       />,
     );
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("connection-row-c1-more"));
+    await userEvent.setup().click(screen.getByTestId("connection-row-c1-more"));
     // Trigger click should not select the row.
     expect(onSelect).not.toHaveBeenCalled();
   });
@@ -151,11 +137,7 @@ describe("ConnectionListRow", () => {
 
   it("marks selected via data-selected", () => {
     renderWithProviders(
-      <ConnectionListRow
-        item={item()}
-        selected={true}
-        onSelect={() => {}}
-      />,
+      <ConnectionListRow item={item()} selected={true} onSelect={() => {}} />,
     );
     expect(
       screen.getByTestId("connection-row-c1").getAttribute("data-selected"),

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionQuickEdit.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionQuickEdit.test.tsx
@@ -119,9 +119,9 @@ describe("ConnectionQuickEdit", () => {
     );
     await user.type(screen.getByTestId("conn-quickedit-password"), "pw");
     await user.click(screen.getByTestId("conn-quickedit-rotate"));
-    expect(await screen.findByTestId("conn-quickedit-rotate-msg")).toHaveTextContent(
-      /updated/i,
-    );
+    expect(
+      await screen.findByTestId("conn-quickedit-rotate-msg"),
+    ).toHaveTextContent(/updated/i);
     expect(onChanged).toHaveBeenCalled();
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsDetailPanel.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsDetailPanel.test.tsx
@@ -32,9 +32,7 @@ describe("ConnectionsDetailPanel", () => {
     renderWithProviders(
       <ConnectionsDetailPanel selectedConnectionName={null} />,
     );
-    expect(
-      screen.getByTestId("connections-detail-empty"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("connections-detail-empty")).toBeInTheDocument();
     expect(screen.getByText(/Nothing selected/i)).toBeInTheDocument();
   });
 
@@ -42,9 +40,7 @@ describe("ConnectionsDetailPanel", () => {
     renderWithProviders(
       <ConnectionsDetailPanel selectedConnectionName="prod-db" />,
     );
-    const placeholder = screen.getByTestId(
-      "connections-detail-placeholder",
-    );
+    const placeholder = screen.getByTestId("connections-detail-placeholder");
     expect(placeholder).toBeInTheDocument();
     expect(placeholder.textContent).toContain("prod-db");
   });
@@ -56,16 +52,10 @@ describe("ConnectionsDetailPanel", () => {
         selectedConnection={conn()}
       />,
     );
-    expect(
-      screen.getByTestId("connections-detail-loaded"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("connection-credentials"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("connections-detail-loaded")).toBeInTheDocument();
+    expect(screen.getByTestId("connection-credentials")).toBeInTheDocument();
     // Placeholder must NOT render alongside the loaded panel.
-    expect(
-      screen.queryByTestId("connections-detail-placeholder"),
-    ).toBeNull();
+    expect(screen.queryByTestId("connections-detail-placeholder")).toBeNull();
   });
 
   it("forwards onSaveCredentials + onRotatePassword to the credentials section", () => {
@@ -81,11 +71,7 @@ describe("ConnectionsDetailPanel", () => {
     );
     // Smoke: the credentials section is mounted; deeper button
     // semantics are covered in ConnectionDetailCredentials.test.tsx.
-    expect(
-      screen.getByTestId("credentials-edit"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("credentials-rotate"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-edit")).toBeInTheDocument();
+    expect(screen.getByTestId("credentials-rotate")).toBeInTheDocument();
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsKindSidebar.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsKindSidebar.test.tsx
@@ -75,9 +75,7 @@ describe("ConnectionsKindSidebar", () => {
   });
 
   it("shows 'No environments' when envs is empty", () => {
-    renderWithProviders(
-      <ConnectionsKindSidebar {...defaults()} envs={[]} />,
-    );
+    renderWithProviders(<ConnectionsKindSidebar {...defaults()} envs={[]} />);
     expect(screen.getByText("No environments")).toBeInTheDocument();
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsList.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsList.test.tsx
@@ -58,7 +58,9 @@ describe("ConnectionsList", () => {
       mkConn("c2", "prod-mysql", "mysql"),
     ]);
     renderWithProviders(<ConnectionsList />);
-    await waitFor(() => expect(screen.getByText("local-pg")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("local-pg")).toBeInTheDocument(),
+    );
     expect(screen.getByText("prod-mysql")).toBeInTheDocument();
   });
 
@@ -69,14 +71,14 @@ describe("ConnectionsList", () => {
       mkConn("c3", "staging-rep", "postgres"),
     ]);
     renderWithProviders(<ConnectionsList />);
-    await waitFor(() => expect(screen.getByText("PROD-mysql")).toBeInTheDocument());
-    expect(screen.getByTestId("sidebar-connection-c2-prod")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("PROD-mysql")).toBeInTheDocument(),
+    );
     expect(
-      screen.queryByTestId("sidebar-connection-c1-prod"),
-    ).toBeNull();
-    expect(
-      screen.queryByTestId("sidebar-connection-c3-prod"),
-    ).toBeNull();
+      screen.getByTestId("sidebar-connection-c2-prod"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar-connection-c1-prod")).toBeNull();
+    expect(screen.queryByTestId("sidebar-connection-c3-prod")).toBeNull();
   });
 
   it("auto-pings each connection on mount and shows latency + ok dot", async () => {
@@ -115,9 +117,7 @@ describe("ConnectionsList", () => {
     const user = userEvent.setup();
     renderWithProviders(<ConnectionsList />);
     await user.click(screen.getByLabelText("New connection"));
-    expect(
-      screen.getByRole("button", { name: /Create/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create/i })).toBeInTheDocument();
   });
 
   it("clicking the chip opens the quick-edit popover", async () => {
@@ -128,15 +128,11 @@ describe("ConnectionsList", () => {
       expect(screen.getByText("local-pg")).toBeInTheDocument(),
     );
     await user.click(screen.getByTestId("sidebar-connection-c1"));
-    expect(
-      await screen.findByTestId("conn-quickedit-c1"),
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId("conn-quickedit-c1")).toBeInTheDocument();
     expect(screen.getByTestId("conn-quickedit-rotate")).toBeInTheDocument();
     expect(screen.getByTestId("conn-quickedit-apply")).toBeInTheDocument();
     expect(screen.getByTestId("conn-quickedit-test")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("conn-quickedit-duplicate"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("conn-quickedit-duplicate")).toBeInTheDocument();
   });
 
   it("Delete in the popover calls delete_connection then refresh", async () => {
@@ -232,9 +228,9 @@ describe("ConnectionsList", () => {
     ).toEqual({ host: "db.staging", port: 5599 });
     // Chip on the sidebar row reflects the TEMPORARY state.
     expect(
-      screen.getByTestId("sidebar-connection-c1").getAttribute(
-        "data-temporary",
-      ),
+      screen
+        .getByTestId("sidebar-connection-c1")
+        .getAttribute("data-temporary"),
     ).toBe("true");
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsListPanel.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsListPanel.test.tsx
@@ -16,7 +16,9 @@ function defaults() {
 describe("ConnectionsListPanel", () => {
   it("renders the heading and the canvas-spec status counts", () => {
     renderWithProviders(<ConnectionsListPanel {...defaults()} />);
-    expect(screen.getByRole("heading", { name: "Connections" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Connections" }),
+    ).toBeInTheDocument();
     const status = screen.getByTestId("connections-list-status");
     expect(status.textContent).toContain("16");
     expect(status.textContent).toContain("14 ok");
@@ -27,14 +29,9 @@ describe("ConnectionsListPanel", () => {
   it("New button dispatches its handler", async () => {
     const onCreateNew = vi.fn();
     renderWithProviders(
-      <ConnectionsListPanel
-        {...defaults()}
-        onCreateNew={onCreateNew}
-      />,
+      <ConnectionsListPanel {...defaults()} onCreateNew={onCreateNew} />,
     );
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("connections-create-new"));
+    await userEvent.setup().click(screen.getByTestId("connections-create-new"));
     expect(onCreateNew).toHaveBeenCalledTimes(1);
   });
 
@@ -46,14 +43,9 @@ describe("ConnectionsListPanel", () => {
   it("dispatches onSearchChange as the user types", async () => {
     const onSearchChange = vi.fn();
     renderWithProviders(
-      <ConnectionsListPanel
-        {...defaults()}
-        onSearchChange={onSearchChange}
-      />,
+      <ConnectionsListPanel {...defaults()} onSearchChange={onSearchChange} />,
     );
-    await userEvent
-      .setup()
-      .type(screen.getByTestId("connections-search"), "p");
+    await userEvent.setup().type(screen.getByTestId("connections-search"), "p");
     expect(onSearchChange).toHaveBeenCalled();
   });
 
@@ -67,9 +59,9 @@ describe("ConnectionsListPanel", () => {
     renderWithProviders(
       <ConnectionsListPanel {...defaults()} emptyHint="No matches" />,
     );
-    expect(
-      screen.getByTestId("connections-list-empty").textContent,
-    ).toContain("No matches");
+    expect(screen.getByTestId("connections-list-empty").textContent).toContain(
+      "No matches",
+    );
   });
 
   it("legacy footer hint is gone", () => {

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPage.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPage.test.tsx
@@ -35,15 +35,9 @@ describe("ConnectionsPage", () => {
   it("composes the kind sidebar, list panel, and detail panel", () => {
     renderWithProviders(<ConnectionsPage />);
     expect(screen.getByTestId("connections-page")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("connections-kind-sidebar"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("connections-list-panel"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("connections-detail-panel"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("connections-kind-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("connections-list-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("connections-detail-panel")).toBeInTheDocument();
   });
 
   it("renders zero status when no props are passed", () => {
@@ -55,9 +49,7 @@ describe("ConnectionsPage", () => {
 
   it("renders the keychain hint card", () => {
     renderWithProviders(<ConnectionsPage />);
-    expect(
-      screen.getByTestId("connections-keychain-hint"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("connections-keychain-hint")).toBeInTheDocument();
   });
 
   it("clicking a kind row toggles selection (no crash)", async () => {
@@ -71,26 +63,20 @@ describe("ConnectionsPage", () => {
   it("forwards onCreateNew when supplied", async () => {
     const onCreateNew = vi.fn();
     renderWithProviders(<ConnectionsPage onCreateNew={onCreateNew} />);
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("connections-create-new"));
+    await userEvent.setup().click(screen.getByTestId("connections-create-new"));
     expect(onCreateNew).toHaveBeenCalledTimes(1);
   });
 
   it("typing in the search box updates the input", async () => {
     renderWithProviders(<ConnectionsPage />);
-    const search = screen.getByTestId(
-      "connections-search",
-    ) as HTMLInputElement;
+    const search = screen.getByTestId("connections-search") as HTMLInputElement;
     await userEvent.setup().type(search, "prod");
     expect(search.value).toBe("prod");
   });
 
   it("renders the per-environment section when envs are supplied", () => {
     renderWithProviders(
-      <ConnectionsPage
-        envs={[{ name: "staging", status: "ok", count: 5 }]}
-      />,
+      <ConnectionsPage envs={[{ name: "staging", status: "ok", count: 5 }]} />,
     );
     expect(screen.getByTestId("env-row-staging")).toBeInTheDocument();
   });
@@ -105,9 +91,7 @@ describe("ConnectionsPage", () => {
         ]}
       />,
     );
-    expect(
-      screen.getByTestId("kind-row-postgres").textContent,
-    ).toContain("2");
+    expect(screen.getByTestId("kind-row-postgres").textContent).toContain("2");
     expect(screen.getByTestId("kind-row-mysql").textContent).toContain("1");
   });
 
@@ -163,14 +147,10 @@ describe("ConnectionsPage", () => {
 
   it("clicking a row updates the detail-panel placeholder name", async () => {
     renderWithProviders(
-      <ConnectionsPage
-        connections={[conn("a", "alpha-conn", "postgres")]}
-      />,
+      <ConnectionsPage connections={[conn("a", "alpha-conn", "postgres")]} />,
     );
     // Detail panel starts on empty state
-    expect(
-      screen.getByTestId("connections-detail-empty"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("connections-detail-empty")).toBeInTheDocument();
     await userEvent.setup().click(screen.getByTestId("connection-row-a"));
     // Slice 2 (Story 02): with a real Connection in the list,
     // selection routes into the loaded credentials panel.
@@ -201,10 +181,7 @@ describe("ConnectionsPage", () => {
     await user.click(screen.getByTestId("connection-row-c1"));
     await user.click(screen.getByTestId("credentials-edit"));
     await user.click(screen.getByTestId("credentials-save"));
-    expect(onSaveCredentials).toHaveBeenCalledWith(
-      "c1",
-      expect.any(Object),
-    );
+    expect(onSaveCredentials).toHaveBeenCalledWith("c1", expect.any(Object));
   });
 
   it("forwards onRotatePassword with the selected connection id", async () => {
@@ -218,10 +195,7 @@ describe("ConnectionsPage", () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId("connection-row-c1"));
     await user.click(screen.getByTestId("credentials-rotate"));
-    await user.type(
-      screen.getByTestId("credentials-rotate-input"),
-      "new-pw",
-    );
+    await user.type(screen.getByTestId("credentials-rotate-input"), "new-pw");
     await user.click(screen.getByTestId("credentials-rotate-save"));
     expect(onRotatePassword).toHaveBeenCalledWith("c1", "new-pw");
   });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
@@ -2,11 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test/render";
 import userEvent from "@testing-library/user-event";
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
+import {
+  emitTauriEvent,
+  clearTauriListeners,
+} from "@/test/mocks/tauri-event";
 
 vi.mock("@/lib/theme/apply", () => ({ applyTheme: vi.fn() }));
 
 import { ConnectionsPageContainer } from "@/components/layout/connections/ConnectionsPageContainer";
 import { useWorkspaceStore } from "@/stores/workspace";
+import { useSchemaCacheStore } from "@/stores/schemaCache";
 
 const sampleList = [
   {
@@ -32,7 +37,9 @@ const sampleList = [
 
 beforeEach(() => {
   useWorkspaceStore.setState({ vaultPath: "/tmp/vault" });
+  useSchemaCacheStore.setState({ byConnection: {} });
   clearTauriMocks();
+  clearTauriListeners();
   mockTauriCommand("list_connections", () => sampleList);
   mockTauriCommand("find_connection_uses_cmd", () => []);
   mockTauriCommand("test_connection", () => undefined);
@@ -45,6 +52,8 @@ beforeEach(() => {
 
 afterEach(() => {
   clearTauriMocks();
+  clearTauriListeners();
+  useSchemaCacheStore.setState({ byConnection: {} });
   useWorkspaceStore.setState({ vaultPath: null });
 });
 
@@ -103,30 +112,286 @@ describe("ConnectionsPageContainer", () => {
     await waitFor(() => {
       expect(calls).toBe(1);
     });
-    // Emit a Tauri event imitation via window — the listener wraps
-    // tauri's listen() which our mocks expose as the `tauri-bridge`
-    // events stream. Skip if the test harness doesn't support it.
-    const w = window as unknown as { __TAURI_EVENT__?: unknown };
-    if (!w.__TAURI_EVENT__) return;
+    emitTauriEvent("config-changed", { category: "connections" });
+    await waitFor(() => {
+      expect(calls).toBe(2);
+    });
   });
 
-  it("forwards onOpenUsage clicks to the parent navigation handler", async () => {
-    let opened: string | null = null;
+  it("ignores config-changed events for other categories", async () => {
+    let calls = 0;
+    mockTauriCommand("list_connections", () => {
+      calls += 1;
+      return sampleList;
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    await waitFor(() => {
+      expect(calls).toBe(1);
+    });
+    emitTauriEvent("config-changed", { category: "environments" });
+    // Give the (no-op) handler a tick; reload must NOT fire.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(calls).toBe(1);
+  });
+
+  it("selecting a row pre-fetches schema + runbook usages", async () => {
+    const introspect = vi.fn(() => [
+      {
+        schema_name: "public",
+        table_name: "orders",
+        column_name: "id",
+        data_type: "int",
+      },
+    ]);
+    mockTauriCommand("introspect_schema", introspect);
+    let usesArgs: unknown = null;
+    mockTauriCommand("find_connection_uses_cmd", (args) => {
+      usesArgs = args;
+      return [{ file: "notes/a.md", line: 12 }];
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    await waitFor(() => {
+      expect(introspect).toHaveBeenCalledWith({
+        connectionId: "payments-db",
+      });
+    });
+    expect(usesArgs).toEqual({
+      vaultPath: "/tmp/vault",
+      connectionName: "payments-db",
+    });
+    // The schema cache feeding the schemaProp memo is now populated.
+    await waitFor(() => {
+      expect(
+        useSchemaCacheStore.getState().byConnection["payments-db"]?.schema,
+      ).toBeTruthy();
+    });
+    // The mapped usage row renders in the detail panel.
+    expect(await screen.findByTestId("used-in-row-0")).toBeInTheDocument();
+  });
+
+  it("clicking a runbook-usage row forwards the file path to onNavigateFile", async () => {
+    mockTauriCommand("find_connection_uses_cmd", () => [
+      { file: "notes/use.md", line: 7 },
+    ]);
+    const onNavigateFile = vi.fn();
     renderWithProviders(
-      <ConnectionsPageContainer
-        onNavigateFile={(path) => {
-          opened = path;
-        }}
-      />,
+      <ConnectionsPageContainer onNavigateFile={onNavigateFile} />,
     );
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    const usageRow = await screen.findByTestId("used-in-row-0");
+    await user.click(usageRow);
+    expect(onNavigateFile).toHaveBeenCalledWith("notes/use.md");
+  });
+
+  it("detail-panel Edit delegates to the edit modal (onRequestEditCredentials)", async () => {
+    // The container always passes onRequestEditCredentials, so the
+    // credentials "Edit" button opens the modal in edit mode instead
+    // of inline editing — exercising the `editing` lookup + modalOpen.
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    await user.click(await screen.findByTestId("credentials-edit"));
+    const modal = await screen.findByTestId("new-connection-modal");
+    expect(modal).toBeTruthy();
+    // Edit mode reflects the selected connection's name.
+    expect(modal.textContent).toContain("payments-db");
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByTestId("new-connection-modal")).toBeNull();
+    });
+  });
+
+  it("rotating the password calls update_connection with the new password", async () => {
+    let updateArgs:
+      | { id?: string; input?: { password?: string } }
+      | undefined;
+    mockTauriCommand("update_connection", (args) => {
+      updateArgs = args as { id?: string; input?: { password?: string } };
+      return sampleList[0];
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    await user.click(await screen.findByTestId("credentials-rotate"));
+    await user.type(
+      await screen.findByTestId("credentials-rotate-input"),
+      "s3cret",
+    );
+    await user.click(await screen.findByTestId("credentials-rotate-save"));
+    await waitFor(() => {
+      expect(updateArgs).toMatchObject({
+        id: "payments-db",
+        input: { password: "s3cret" },
+      });
+    });
+  });
+
+  it("footer Test invokes test_connection for the selected connection", async () => {
+    let tested: unknown = null;
+    mockTauriCommand("test_connection", (args) => {
+      tested = args;
+      return undefined;
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    await user.click(await screen.findByTestId("footer-test"));
+    await waitFor(() => {
+      expect(tested).toEqual({ id: "payments-db" });
+    });
+  });
+
+  it("footer Duplicate creates a -copy connection then reloads", async () => {
+    let createArgs:
+      | { input?: { name?: string; driver?: string } }
+      | undefined;
+    let listCalls = 0;
+    mockTauriCommand("list_connections", () => {
+      listCalls += 1;
+      return sampleList;
+    });
+    mockTauriCommand("create_connection", (args) => {
+      createArgs = args as { input?: { name?: string; driver?: string } };
+      return sampleList[0];
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    await user.click(await screen.findByTestId("footer-duplicate"));
+    await waitFor(() => {
+      expect(createArgs).toMatchObject({
+        input: { name: "payments-db-copy", driver: "postgres" },
+      });
+    });
+    await waitFor(() => {
+      expect(listCalls).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("footer Delete (two-step) deletes the connection then reloads", async () => {
+    let deleted: unknown = null;
+    let listCalls = 0;
+    mockTauriCommand("list_connections", () => {
+      listCalls += 1;
+      return sampleList;
+    });
+    mockTauriCommand("delete_connection", (args) => {
+      deleted = args;
+      return undefined;
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    // First click arms confirm; second click commits.
+    await user.click(await screen.findByTestId("footer-delete"));
+    await user.click(await screen.findByTestId("footer-delete"));
+    await waitFor(() => {
+      expect(deleted).toEqual({ id: "payments-db" });
+    });
+    await waitFor(() => {
+      expect(listCalls).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("the ⋮ row Test action calls test_connection directly", async () => {
+    let tested: unknown = null;
+    mockTauriCommand("test_connection", (args) => {
+      tested = args;
+      return undefined;
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db-more"));
+    await user.click(await screen.findByText("Test"));
+    await waitFor(() => {
+      expect(tested).toEqual({ id: "payments-db" });
+    });
+  });
+
+  it("the ⋮ row Edit action opens the modal in edit mode and closes it", async () => {
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db-more"));
+    await user.click(await screen.findByText("Edit"));
+    expect(await screen.findByTestId("new-connection-modal")).toBeTruthy();
+    // Close it — exercises the onClose (setNewOpen(false)+setEditingId(null)).
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByTestId("new-connection-modal")).toBeNull();
+    });
+  });
+
+  it("creating a connection from the modal triggers a reload then closes", async () => {
+    let listCalls = 0;
+    let created: { input?: { name?: string } } | undefined;
+    mockTauriCommand("list_connections", () => {
+      listCalls += 1;
+      return sampleList;
+    });
+    mockTauriCommand("create_connection", (args) => {
+      created = args as { input?: { name?: string } };
+      return sampleList[0];
+    });
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
     await waitFor(() => {
       expect(screen.getByTestId("connections-page")).toBeTruthy();
     });
-    // Trigger via the callback path indirectly: nothing visible until
-    // a row is selected + usages render. Coverage gain comes from the
-    // handler being defined; selection-driven render is exercised in
-    // ConnectionsPage's own tests.
-    void opened;
-    expect(true).toBe(true);
+    await user.click(screen.getByTestId("connections-create-new"));
+    expect(await screen.findByTestId("new-connection-modal")).toBeTruthy();
+    // Save is gated on a non-empty name; fill it then submit.
+    await user.type(
+      await screen.findByTestId("new-connection-field-name"),
+      "fresh-db",
+    );
+    const before = listCalls;
+    await user.click(await screen.findByTestId("new-connection-save"));
+    await waitFor(() => {
+      expect(created).toMatchObject({ input: { name: "fresh-db" } });
+    });
+    // onCreated → reload (list_connections re-called).
+    await waitFor(() => {
+      expect(listCalls).toBeGreaterThan(before);
+    });
+    // onClose → modal unmounts.
+    await waitFor(() => {
+      expect(screen.queryByTestId("new-connection-modal")).toBeNull();
+    });
+  });
+
+  it("refreshing the schema preview delegates to the schema cache store", async () => {
+    const refreshSpy = vi.spyOn(
+      useSchemaCacheStore.getState(),
+      "refresh",
+    );
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    const refreshBtn = await screen.findByTestId("schema-refresh");
+    await user.click(refreshBtn);
+    await waitFor(() => {
+      expect(refreshSpy).toHaveBeenCalledWith("payments-db");
+    });
+    refreshSpy.mockRestore();
+  });
+
+  it("deleting the selected connection clears the selection", async () => {
+    renderWithProviders(<ConnectionsPageContainer />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("connection-row-payments-db"));
+    expect(
+      await screen.findByTestId("connections-detail-loaded"),
+    ).toBeInTheDocument();
+    await user.click(await screen.findByTestId("footer-delete"));
+    await user.click(await screen.findByTestId("footer-delete"));
+    // selectedId === id → setSelectedId(null) → detail panel empties.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("connections-detail-loaded"),
+      ).toBeNull();
+    });
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
@@ -81,9 +81,7 @@ describe("ConnectionsPageContainer", () => {
     await waitFor(() => {
       expect(screen.getByTestId("connections-page")).toBeTruthy();
     });
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("connections-create-new"));
+    await userEvent.setup().click(screen.getByTestId("connections-create-new"));
     expect(screen.getByTestId("new-connection-modal")).toBeTruthy();
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/ConnectionsPageContainer.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test/render";
 import userEvent from "@testing-library/user-event";
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
-import {
-  emitTauriEvent,
-  clearTauriListeners,
-} from "@/test/mocks/tauri-event";
+import { emitTauriEvent, clearTauriListeners } from "@/test/mocks/tauri-event";
 
 vi.mock("@/lib/theme/apply", () => ({ applyTheme: vi.fn() }));
 
@@ -205,9 +202,7 @@ describe("ConnectionsPageContainer", () => {
   });
 
   it("rotating the password calls update_connection with the new password", async () => {
-    let updateArgs:
-      | { id?: string; input?: { password?: string } }
-      | undefined;
+    let updateArgs: { id?: string; input?: { password?: string } } | undefined;
     mockTauriCommand("update_connection", (args) => {
       updateArgs = args as { id?: string; input?: { password?: string } };
       return sampleList[0];
@@ -245,9 +240,7 @@ describe("ConnectionsPageContainer", () => {
   });
 
   it("footer Duplicate creates a -copy connection then reloads", async () => {
-    let createArgs:
-      | { input?: { name?: string; driver?: string } }
-      | undefined;
+    let createArgs: { input?: { name?: string; driver?: string } } | undefined;
     let listCalls = 0;
     mockTauriCommand("list_connections", () => {
       listCalls += 1;
@@ -304,7 +297,9 @@ describe("ConnectionsPageContainer", () => {
     });
     renderWithProviders(<ConnectionsPageContainer />);
     const user = userEvent.setup();
-    await user.click(await screen.findByTestId("connection-row-payments-db-more"));
+    await user.click(
+      await screen.findByTestId("connection-row-payments-db-more"),
+    );
     await user.click(await screen.findByText("Test"));
     await waitFor(() => {
       expect(tested).toEqual({ id: "payments-db" });
@@ -314,7 +309,9 @@ describe("ConnectionsPageContainer", () => {
   it("the ⋮ row Edit action opens the modal in edit mode and closes it", async () => {
     renderWithProviders(<ConnectionsPageContainer />);
     const user = userEvent.setup();
-    await user.click(await screen.findByTestId("connection-row-payments-db-more"));
+    await user.click(
+      await screen.findByTestId("connection-row-payments-db-more"),
+    );
     await user.click(await screen.findByText("Edit"));
     expect(await screen.findByTestId("new-connection-modal")).toBeTruthy();
     // Close it — exercises the onClose (setNewOpen(false)+setEditingId(null)).
@@ -363,10 +360,7 @@ describe("ConnectionsPageContainer", () => {
   });
 
   it("refreshing the schema preview delegates to the schema cache store", async () => {
-    const refreshSpy = vi.spyOn(
-      useSchemaCacheStore.getState(),
-      "refresh",
-    );
+    const refreshSpy = vi.spyOn(useSchemaCacheStore.getState(), "refresh");
     renderWithProviders(<ConnectionsPageContainer />);
     const user = userEvent.setup();
     await user.click(await screen.findByTestId("connection-row-payments-db"));
@@ -389,9 +383,7 @@ describe("ConnectionsPageContainer", () => {
     await user.click(await screen.findByTestId("footer-delete"));
     // selectedId === id → setSelectedId(null) → detail panel empties.
     await waitFor(() => {
-      expect(
-        screen.queryByTestId("connections-detail-loaded"),
-      ).toBeNull();
+      expect(screen.queryByTestId("connections-detail-loaded")).toBeNull();
     });
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionEnvBinder.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionEnvBinder.test.tsx
@@ -64,9 +64,9 @@ describe("NewConnectionEnvBinder", () => {
         onToggle={onToggle}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-env-pill-local"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-env-pill-local"));
     expect(onToggle).toHaveBeenCalledWith("local");
   });
 
@@ -105,9 +105,9 @@ describe("NewConnectionEnvBinder", () => {
         onCreateNew={onCreateNew}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-env-pill-new"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-env-pill-new"));
     expect(onCreateNew).toHaveBeenCalledTimes(1);
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionFormTab.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionFormTab.test.tsx
@@ -16,9 +16,7 @@ describe("NewConnectionFormTab", () => {
         onChange={vi.fn()}
       />,
     );
-    expect(
-      screen.getByTestId("new-connection-form-tab"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-form-tab")).toBeInTheDocument();
     for (const field of [
       "name",
       "host",
@@ -47,12 +45,8 @@ describe("NewConnectionFormTab", () => {
         onChange={vi.fn()}
       />,
     );
-    expect(
-      screen.getByTestId("new-connection-form-tab"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("new-connection-field-host"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-form-tab")).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-field-host")).toBeInTheDocument();
   });
 
   it("renders the stub for non-postgres-shape kinds", () => {
@@ -175,8 +169,8 @@ describe("NewConnectionFormTab", () => {
             f.id === "host"
               ? "localhost" + f.typed
               : f.id === "port"
-              ? "5432" + f.typed
-              : f.typed,
+                ? "5432" + f.typed
+                : f.typed,
         }),
       );
     }

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionFormTab.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionFormTab.test.tsx
@@ -1,11 +1,20 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 
 import { renderWithProviders, screen } from "@/test/render";
 import {
   NewConnectionFormTab,
   EMPTY_POSTGRES_VALUE,
+  emptyFormValueForKind,
 } from "@/components/layout/connections/NewConnectionFormTab";
+
+const mockOpenFileDialog = vi.mocked(openFileDialog);
+
+beforeEach(() => {
+  mockOpenFileDialog.mockReset();
+  mockOpenFileDialog.mockResolvedValue(null);
+});
 
 describe("NewConnectionFormTab", () => {
   it("renders the postgres field grid + keychain hint + suffix", () => {
@@ -190,5 +199,172 @@ describe("NewConnectionFormTab", () => {
       ).toBeInTheDocument();
       unmount();
     }
+  });
+
+  describe("emptyFormValueForKind", () => {
+    it("uses port 3306 for mysql", () => {
+      expect(emptyFormValueForKind("mysql")).toEqual({
+        ...EMPTY_POSTGRES_VALUE,
+        port: "3306",
+      });
+    });
+
+    it("clears host + port for sqlite", () => {
+      expect(emptyFormValueForKind("sqlite")).toEqual({
+        ...EMPTY_POSTGRES_VALUE,
+        host: "",
+        port: "",
+      });
+    });
+
+    it("falls back to the postgres default for other kinds", () => {
+      expect(emptyFormValueForKind("postgres")).toBe(EMPTY_POSTGRES_VALUE);
+      expect(emptyFormValueForKind("grpc")).toBe(EMPTY_POSTGRES_VALUE);
+    });
+  });
+
+  describe("sqlite shape", () => {
+    const sqliteValue = { ...EMPTY_POSTGRES_VALUE, host: "", port: "" };
+
+    it("renders the sqlite-specific name + database file fields", () => {
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={vi.fn()}
+        />,
+      );
+      expect(
+        screen.getByTestId("new-connection-form-tab-sqlite"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("new-connection-field-name"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("new-connection-field-database"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("new-connection-field-database-browse"),
+      ).toBeInTheDocument();
+      // The postgres-shape grid must NOT render for sqlite.
+      expect(
+        screen.queryByTestId("new-connection-form-tab"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("typing into the sqlite name field patches onChange", async () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={onChange}
+        />,
+      );
+      await userEvent
+        .setup()
+        .type(screen.getByTestId("new-connection-field-name"), "c");
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...sqliteValue,
+        name: "c",
+      });
+    });
+
+    it("typing into the sqlite database path field patches onChange", async () => {
+      const onChange = vi.fn();
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={onChange}
+        />,
+      );
+      await userEvent
+        .setup()
+        .type(screen.getByTestId("new-connection-field-database"), "x");
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...sqliteValue,
+        database: "x",
+      });
+    });
+
+    it("browse button patches the database path with the picked file", async () => {
+      mockOpenFileDialog.mockResolvedValue("/abs/path/cache.sqlite");
+      const onChange = vi.fn();
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={onChange}
+        />,
+      );
+      await userEvent
+        .setup()
+        .click(screen.getByTestId("new-connection-field-database-browse"));
+      expect(mockOpenFileDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          multiple: false,
+          directory: false,
+        }),
+      );
+      expect(onChange).toHaveBeenCalledWith({
+        ...sqliteValue,
+        database: "/abs/path/cache.sqlite",
+      });
+    });
+
+    it("browse button is a no-op when the dialog is dismissed (null)", async () => {
+      mockOpenFileDialog.mockResolvedValue(null);
+      const onChange = vi.fn();
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={onChange}
+        />,
+      );
+      await userEvent
+        .setup()
+        .click(screen.getByTestId("new-connection-field-database-browse"));
+      expect(mockOpenFileDialog).toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("browse button swallows dialog plugin errors", async () => {
+      mockOpenFileDialog.mockRejectedValue(new Error("plugin unavailable"));
+      const onChange = vi.fn();
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={onChange}
+        />,
+      );
+      await userEvent
+        .setup()
+        .click(screen.getByTestId("new-connection-field-database-browse"));
+      expect(mockOpenFileDialog).toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("renders sqlite env + test slots when supplied", () => {
+      renderWithProviders(
+        <NewConnectionFormTab
+          kind="sqlite"
+          value={sqliteValue}
+          onChange={vi.fn()}
+          envBinder={<div data-testid="sqlite-env-stub" />}
+          testBanner={<div data-testid="sqlite-test-stub" />}
+        />,
+      );
+      expect(
+        screen.getByTestId("new-connection-form-env-slot"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("sqlite-env-stub")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("new-connection-form-test-slot"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("sqlite-test-stub")).toBeInTheDocument();
+    });
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionKindPicker.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionKindPicker.test.tsx
@@ -33,10 +33,7 @@ describe("NewConnectionKindPicker", () => {
 
   it("marks the selected row via data-selected and aria-pressed", () => {
     renderWithProviders(
-      <NewConnectionKindPicker
-        selectedKind="mysql"
-        onSelectKind={vi.fn()}
-      />,
+      <NewConnectionKindPicker selectedKind="mysql" onSelectKind={vi.fn()} />,
     );
     const mysql = screen.getByTestId("new-connection-kind-mysql");
     expect(mysql.getAttribute("data-selected")).toBe("true");
@@ -54,9 +51,9 @@ describe("NewConnectionKindPicker", () => {
         onSelectKind={onSelectKind}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-kind-mongo"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-kind-mongo"));
     expect(onSelectKind).toHaveBeenCalledWith("mongo");
   });
 
@@ -72,9 +69,9 @@ describe("NewConnectionKindPicker", () => {
         onSelectKind={onSelectKind}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-kind-postgres"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-kind-postgres"));
     expect(onSelectKind).toHaveBeenCalledWith("postgres");
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionModal.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionModal.test.tsx
@@ -15,18 +15,14 @@ function getHeader() {
 
 describe("NewConnectionModal", () => {
   it("renders nothing when closed", () => {
-    renderWithProviders(
-      <NewConnectionModal open={false} onCancel={vi.fn()} />,
-    );
+    renderWithProviders(<NewConnectionModal open={false} onCancel={vi.fn()} />);
     expect(
       screen.queryByTestId("new-connection-modal"),
     ).not.toBeInTheDocument();
   });
 
   it("renders the modal with header, sidebar, tabs, body, footer", () => {
-    renderWithProviders(
-      <NewConnectionModal open onCancel={vi.fn()} />,
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={vi.fn()} />);
     expect(screen.getByTestId("new-connection-modal")).toBeInTheDocument();
     expect(
       screen.getByTestId("new-connection-kind-picker"),
@@ -34,22 +30,14 @@ describe("NewConnectionModal", () => {
     expect(
       screen.getByTestId("new-connection-form-header"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("new-connection-paste-hint"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("new-connection-tabs"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("new-connection-tab-body"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-paste-hint")).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-tabs")).toBeInTheDocument();
+    expect(screen.getByTestId("new-connection-tab-body")).toBeInTheDocument();
     expect(screen.getByTestId("new-connection-footer")).toBeInTheDocument();
   });
 
   it("defaults to postgres header + Form tab", () => {
-    renderWithProviders(
-      <NewConnectionModal open onCancel={vi.fn()} />,
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={vi.fn()} />);
     expect(getHeader().getByText("PostgreSQL")).toBeInTheDocument();
     expect(
       screen.getByTestId("new-connection-placeholder-form"),
@@ -58,35 +46,29 @@ describe("NewConnectionModal", () => {
 
   it("respects initialKind", () => {
     renderWithProviders(
-      <NewConnectionModal
-        open
-        initialKind="mongo"
-        onCancel={vi.fn()}
-      />,
+      <NewConnectionModal open initialKind="mongo" onCancel={vi.fn()} />,
     );
     expect(getHeader().getByText("MongoDB")).toBeInTheDocument();
   });
 
   it("switching kind in the picker updates the header", async () => {
-    renderWithProviders(
-      <NewConnectionModal open onCancel={vi.fn()} />,
-    );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-kind-mysql"),
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={vi.fn()} />);
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-kind-mysql"));
     expect(getHeader().getByText("MySQL / MariaDB")).toBeInTheDocument();
   });
 
   it("switching tabs swaps the placeholder", async () => {
-    renderWithProviders(
-      <NewConnectionModal open onCancel={vi.fn()} />,
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={vi.fn()} />);
     const sslTabId = NEW_CONNECTION_TABS.find((t) => t.id === "ssl")!.id;
-    await userEvent.setup().click(
-      screen.getByText(
-        NEW_CONNECTION_TABS.find((t) => t.id === sslTabId)!.label,
-      ),
-    );
+    await userEvent
+      .setup()
+      .click(
+        screen.getByText(
+          NEW_CONNECTION_TABS.find((t) => t.id === sslTabId)!.label,
+        ),
+      );
     expect(
       screen.getByTestId("new-connection-placeholder-ssl"),
     ).toBeInTheDocument();
@@ -103,9 +85,7 @@ describe("NewConnectionModal", () => {
         renderTabBody={renderTabBody}
       />,
     );
-    expect(screen.getByTestId("custom-body").textContent).toBe(
-      "postgres/form",
-    );
+    expect(screen.getByTestId("custom-body").textContent).toBe("postgres/form");
     expect(renderTabBody).toHaveBeenCalledWith({
       kind: "postgres",
       tab: "form",
@@ -117,43 +97,31 @@ describe("NewConnectionModal", () => {
 
   it("Escape key dispatches onCancel", async () => {
     const onCancel = vi.fn();
-    renderWithProviders(
-      <NewConnectionModal open onCancel={onCancel} />,
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={onCancel} />);
     await userEvent.setup().keyboard("{Escape}");
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("clicking the overlay dispatches onCancel", async () => {
     const onCancel = vi.fn();
-    renderWithProviders(
-      <NewConnectionModal open onCancel={onCancel} />,
-    );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-modal-overlay"),
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={onCancel} />);
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-modal-overlay"));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("clicking inside the modal does NOT dispatch onCancel", async () => {
     const onCancel = vi.fn();
-    renderWithProviders(
-      <NewConnectionModal open onCancel={onCancel} />,
-    );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-modal"),
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={onCancel} />);
+    await userEvent.setup().click(screen.getByTestId("new-connection-modal"));
     expect(onCancel).not.toHaveBeenCalled();
   });
 
   it("Cancel button dispatches onCancel", async () => {
     const onCancel = vi.fn();
-    renderWithProviders(
-      <NewConnectionModal open onCancel={onCancel} />,
-    );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-cancel"),
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={onCancel} />);
+    await userEvent.setup().click(screen.getByTestId("new-connection-cancel"));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
@@ -162,9 +130,7 @@ describe("NewConnectionModal", () => {
     renderWithProviders(
       <NewConnectionModal open onCancel={vi.fn()} onSave={onSave} />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-save"),
-    );
+    await userEvent.setup().click(screen.getByTestId("new-connection-save"));
     expect(onSave).toHaveBeenCalledWith({ kind: "postgres", tab: "form" });
   });
 
@@ -176,9 +142,7 @@ describe("NewConnectionModal", () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId("new-connection-kind-mysql"));
     await user.click(
-      screen.getByText(
-        NEW_CONNECTION_TABS.find((t) => t.id === "ssl")!.label,
-      ),
+      screen.getByText(NEW_CONNECTION_TABS.find((t) => t.id === "ssl")!.label),
     );
     await user.click(screen.getByTestId("new-connection-save"));
     expect(onSave).toHaveBeenCalledWith({ kind: "mysql", tab: "ssl" });
@@ -189,9 +153,7 @@ describe("NewConnectionModal", () => {
     renderWithProviders(
       <NewConnectionModal open onCancel={vi.fn()} onTest={onTest} />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-test"),
-    );
+    await userEvent.setup().click(screen.getByTestId("new-connection-test"));
     expect(onTest).toHaveBeenCalledWith({ kind: "postgres", tab: "form" });
   });
 
@@ -200,8 +162,7 @@ describe("NewConnectionModal", () => {
       <NewConnectionModal open onCancel={vi.fn()} />,
     );
     expect(
-      (screen.getByTestId("new-connection-save") as HTMLButtonElement)
-        .disabled,
+      (screen.getByTestId("new-connection-save") as HTMLButtonElement).disabled,
     ).toBe(true);
 
     rerender(
@@ -213,18 +174,14 @@ describe("NewConnectionModal", () => {
       />,
     );
     expect(
-      (screen.getByTestId("new-connection-save") as HTMLButtonElement)
-        .disabled,
+      (screen.getByTestId("new-connection-save") as HTMLButtonElement).disabled,
     ).toBe(true);
   });
 
   it("disables Test when onTest is omitted", () => {
-    renderWithProviders(
-      <NewConnectionModal open onCancel={vi.fn()} />,
-    );
+    renderWithProviders(<NewConnectionModal open onCancel={vi.fn()} />);
     expect(
-      (screen.getByTestId("new-connection-test") as HTMLButtonElement)
-        .disabled,
+      (screen.getByTestId("new-connection-test") as HTMLButtonElement).disabled,
     ).toBe(true);
   });
 
@@ -239,9 +196,9 @@ describe("NewConnectionModal", () => {
       />,
     );
     expect(getHeader().getByText("PostgreSQL")).toBeInTheDocument();
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-kind-mysql"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-kind-mysql"));
     expect(onKindChange).toHaveBeenCalledWith("mysql");
     // Header still reflects controlled prop until parent re-renders.
     expect(getHeader().getByText("PostgreSQL")).toBeInTheDocument();
@@ -266,11 +223,13 @@ describe("NewConnectionModal", () => {
         onCancel={vi.fn()}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByText(
-        NEW_CONNECTION_TABS.find((t) => t.id === "ssl")!.label,
-      ),
-    );
+    await userEvent
+      .setup()
+      .click(
+        screen.getByText(
+          NEW_CONNECTION_TABS.find((t) => t.id === "ssl")!.label,
+        ),
+      );
     expect(onTabChange).toHaveBeenCalledWith("ssl");
     // The placeholder still reflects the controlled prop ("form")
     // until the parent re-renders with the new value.

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionModalContainer.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionModalContainer.test.tsx
@@ -83,9 +83,7 @@ describe("NewConnectionModalContainer", () => {
         onCreated={() => {}}
       />,
     );
-    const save = screen.getByTestId(
-      "new-connection-save",
-    ) as HTMLButtonElement;
+    const save = screen.getByTestId("new-connection-save") as HTMLButtonElement;
     expect(save.disabled).toBe(true);
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionSslTab.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionSslTab.test.tsx
@@ -64,14 +64,8 @@ describe("NewConnectionSslTab", () => {
       <NewConnectionSslTab value={EMPTY_SSL_VALUE} onChange={onChange} />,
     );
     const user = userEvent.setup();
-    await user.type(
-      screen.getByTestId("new-connection-ssl-client-cert"),
-      "c",
-    );
-    await user.type(
-      screen.getByTestId("new-connection-ssl-client-key"),
-      "k",
-    );
+    await user.type(screen.getByTestId("new-connection-ssl-client-cert"), "c");
+    await user.type(screen.getByTestId("new-connection-ssl-client-key"), "k");
     expect(onChange).toHaveBeenNthCalledWith(1, {
       ...EMPTY_SSL_VALUE,
       clientCertPath: "c",
@@ -100,25 +94,16 @@ describe("NewConnectionSslTab", () => {
       />,
     );
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-ssl-root-cert",
-        ) as HTMLInputElement
-      ).value,
+      (screen.getByTestId("new-connection-ssl-root-cert") as HTMLInputElement)
+        .value,
     ).toBe("/ca");
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-ssl-client-cert",
-        ) as HTMLInputElement
-      ).value,
+      (screen.getByTestId("new-connection-ssl-client-cert") as HTMLInputElement)
+        .value,
     ).toBe("/cert");
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-ssl-client-key",
-        ) as HTMLInputElement
-      ).value,
+      (screen.getByTestId("new-connection-ssl-client-key") as HTMLInputElement)
+        .value,
     ).toBe("/key");
     expect(
       (screen.getByTestId("new-connection-ssl-mode") as HTMLSelectElement)

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionStringTab.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionStringTab.test.tsx
@@ -8,11 +8,8 @@ describe("NewConnectionStringTab", () => {
   it("disables Apply when the textarea is empty", () => {
     renderWithProviders(<NewConnectionStringTab onApply={vi.fn()} />);
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-string-apply",
-        ) as HTMLButtonElement
-      ).disabled,
+      (screen.getByTestId("new-connection-string-apply") as HTMLButtonElement)
+        .disabled,
     ).toBe(true);
   });
 
@@ -24,11 +21,8 @@ describe("NewConnectionStringTab", () => {
       />,
     );
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-string-input",
-        ) as HTMLTextAreaElement
-      ).value,
+      (screen.getByTestId("new-connection-string-input") as HTMLTextAreaElement)
+        .value,
     ).toBe("postgres://localhost/x");
   });
 
@@ -70,16 +64,10 @@ describe("NewConnectionStringTab", () => {
   it("re-enables apply once user types non-empty content", async () => {
     renderWithProviders(<NewConnectionStringTab onApply={vi.fn()} />);
     const user = userEvent.setup();
-    await user.type(
-      screen.getByTestId("new-connection-string-input"),
-      "x",
-    );
+    await user.type(screen.getByTestId("new-connection-string-input"), "x");
     expect(
-      (
-        screen.getByTestId(
-          "new-connection-string-apply",
-        ) as HTMLButtonElement
-      ).disabled,
+      (screen.getByTestId("new-connection-string-apply") as HTMLButtonElement)
+        .disabled,
     ).toBe(false);
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/NewConnectionTestBanner.test.tsx
+++ b/httui-desktop/src/components/layout/connections/__tests__/NewConnectionTestBanner.test.tsx
@@ -19,16 +19,18 @@ describe("NewConnectionTestBanner", () => {
     expect(
       screen.getByTestId("new-connection-test-banner-running"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("dot-running"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("dot-running")).toBeInTheDocument();
     expect(screen.getByText("Testing…")).toBeInTheDocument();
   });
 
   it("renders the ok banner with detail line + latency", () => {
     renderWithProviders(
       <NewConnectionTestBanner
-        state={{ kind: "ok", detail: "postgres 15.4 · 47 tables", latencyMs: 18 }}
+        state={{
+          kind: "ok",
+          detail: "postgres 15.4 · 47 tables",
+          latencyMs: 18,
+        }}
       />,
     );
     const banner = screen.getByTestId("new-connection-test-banner-ok");
@@ -60,9 +62,9 @@ describe("NewConnectionTestBanner", () => {
         onRetry={onRetry}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-test-retry"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-test-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
@@ -74,9 +76,9 @@ describe("NewConnectionTestBanner", () => {
         onRetry={onRetry}
       />,
     );
-    await userEvent.setup().click(
-      screen.getByTestId("new-connection-test-retry"),
-    );
+    await userEvent
+      .setup()
+      .click(screen.getByTestId("new-connection-test-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/httui-desktop/src/components/layout/connections/__tests__/connection-string-parser.test.ts
+++ b/httui-desktop/src/components/layout/connections/__tests__/connection-string-parser.test.ts
@@ -49,9 +49,7 @@ describe("parseConnectionString", () => {
   });
 
   it("normalizes postgresql:// alias to kind postgres", () => {
-    const result = parseConnectionString(
-      "postgresql://localhost/orders",
-    );
+    const result = parseConnectionString("postgresql://localhost/orders");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.kind).toBe("postgres");
@@ -106,9 +104,7 @@ describe("parseConnectionString", () => {
   });
 
   it("decodes percent-encoded credentials", () => {
-    const result = parseConnectionString(
-      "postgres://us%40er:pa%2Fss@h/db",
-    );
+    const result = parseConnectionString("postgres://us%40er:pa%2Fss@h/db");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.username).toBe("us@er");

--- a/httui-desktop/src/components/layout/connections/__tests__/connection-usages.test.ts
+++ b/httui-desktop/src/components/layout/connections/__tests__/connection-usages.test.ts
@@ -109,9 +109,7 @@ describe("findUsagesAcrossVault", () => {
   });
 
   it("returns empty when no file matches", () => {
-    const files = [
-      { path: "a.md", content: "no fences here\n" },
-    ];
+    const files = [{ path: "a.md", content: "no fences here\n" }];
     expect(findUsagesAcrossVault(files, "c1")).toEqual([]);
   });
 });

--- a/httui-desktop/src/components/layout/connections/__tests__/connections-derive.test.ts
+++ b/httui-desktop/src/components/layout/connections/__tests__/connections-derive.test.ts
@@ -115,10 +115,7 @@ describe("buildListRows", () => {
 
   it("filters by kind when kindFilter is set", () => {
     const rows = buildListRows({
-      connections: [
-        conn("a", "x", "postgres"),
-        conn("b", "y", "mysql"),
-      ],
+      connections: [conn("a", "x", "postgres"), conn("b", "y", "mysql")],
       kindFilter: "postgres",
     });
     expect(rows).toHaveLength(1);
@@ -135,10 +132,7 @@ describe("buildListRows", () => {
 
   it("filters by name substring (case-insensitive)", () => {
     const rows = buildListRows({
-      connections: [
-        conn("a", "Alpha", "postgres"),
-        conn("b", "Beta", "mysql"),
-      ],
+      connections: [conn("a", "Alpha", "postgres"), conn("b", "Beta", "mysql")],
       search: "alp",
     });
     expect(rows).toHaveLength(1);
@@ -226,11 +220,7 @@ describe("envSummaries", () => {
       { id: "b", env: "alpha", latencyMs: 0, uses: 0 },
       { id: "c", env: "mango", latencyMs: 0, uses: 0 },
     ]);
-    expect(summaries.map((s) => s.name)).toEqual([
-      "alpha",
-      "mango",
-      "zebra",
-    ]);
+    expect(summaries.map((s) => s.name)).toEqual(["alpha", "mango", "zebra"]);
   });
 });
 

--- a/httui-desktop/src/components/layout/connections/connections-derive.ts
+++ b/httui-desktop/src/components/layout/connections/connections-derive.ts
@@ -114,9 +114,7 @@ export function countsByKind(
 /** Aggregate counts + status intent per environment for the
  * sidebar POR AMBIENTE section. Production envs (name matches
  * `isProductionName`) get the `warn` intent. */
-export function envSummaries(
-  enrichment: ConnectionEnrichment[],
-): EnvSummary[] {
+export function envSummaries(enrichment: ConnectionEnrichment[]): EnvSummary[] {
   const counts = new Map<string, number>();
   for (const e of enrichment) {
     if (e.env === null) continue;
@@ -134,9 +132,7 @@ export function envSummaries(
 /** Aggregate the list header status counts:
  *  total / ok / slow / down. Untested rows are counted toward total
  *  but not toward any of the three sub-buckets. */
-export function listStatusCounts(
-  rows: ListRowItem[],
-): ListStatusCounts {
+export function listStatusCounts(rows: ListRowItem[]): ListStatusCounts {
   let ok = 0;
   let slow = 0;
   let down = 0;

--- a/httui-desktop/src/components/layout/connections/form/__tests__/AdvancedFields.test.tsx
+++ b/httui-desktop/src/components/layout/connections/form/__tests__/AdvancedFields.test.tsx
@@ -28,9 +28,7 @@ describe("AdvancedFields", () => {
 
   it("dispatches onToggle when the chevron row is clicked", async () => {
     const onToggle = vi.fn();
-    renderWithProviders(
-      <AdvancedFields {...defaults()} onToggle={onToggle} />,
-    );
+    renderWithProviders(<AdvancedFields {...defaults()} onToggle={onToggle} />);
     await userEvent.setup().click(screen.getByTestId("advanced-toggle"));
     expect(onToggle).toHaveBeenCalledTimes(1);
   });

--- a/httui-desktop/src/components/layout/connections/form/__tests__/NetworkFields.test.tsx
+++ b/httui-desktop/src/components/layout/connections/form/__tests__/NetworkFields.test.tsx
@@ -34,9 +34,7 @@ describe("NetworkFields", () => {
   });
 
   it("uses MySQL placeholder when driver is mysql", () => {
-    renderWithProviders(
-      <NetworkFields {...defaults()} driver="mysql" />,
-    );
+    renderWithProviders(<NetworkFields {...defaults()} driver="mysql" />);
     expect(screen.getByPlaceholderText("root")).toBeInTheDocument();
   });
 
@@ -61,9 +59,12 @@ describe("NetworkFields", () => {
       <NetworkFields {...defaults()} onSslModeChange={onSslModeChange} />,
     );
     const select = screen.getByRole("combobox") as HTMLSelectElement;
-    expect(
-      Array.from(select.options).map((o) => o.value),
-    ).toEqual(["disable", "require", "verify-ca", "verify-full"]);
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      "disable",
+      "require",
+      "verify-ca",
+      "verify-full",
+    ]);
     await userEvent.setup().selectOptions(select, "require");
     expect(onSslModeChange).toHaveBeenCalled();
   });

--- a/httui-desktop/src/components/layout/connections/form/__tests__/SqliteFields.test.tsx
+++ b/httui-desktop/src/components/layout/connections/form/__tests__/SqliteFields.test.tsx
@@ -22,9 +22,7 @@ describe("SqliteFields", () => {
 
   it("dispatches onDbNameChange as the user types", async () => {
     const onChange = vi.fn();
-    renderWithProviders(
-      <SqliteFields dbName="" onDbNameChange={onChange} />,
-    );
+    renderWithProviders(<SqliteFields dbName="" onDbNameChange={onChange} />);
     const input = screen.getByPlaceholderText("/path/to/database.db");
     await userEvent.setup().type(input, "x");
     expect(onChange).toHaveBeenCalled();
@@ -33,9 +31,7 @@ describe("SqliteFields", () => {
   it("Browse button opens the OS dialog and writes the selected path through", async () => {
     vi.mocked(openDialog).mockResolvedValue("/picked/path.db");
     const onChange = vi.fn();
-    renderWithProviders(
-      <SqliteFields dbName="" onDbNameChange={onChange} />,
-    );
+    renderWithProviders(<SqliteFields dbName="" onDbNameChange={onChange} />);
     await userEvent.setup().click(screen.getByLabelText("Browse"));
     // Wait a microtask so the awaited dialog resolves.
     await new Promise((r) => setTimeout(r, 10));
@@ -45,9 +41,7 @@ describe("SqliteFields", () => {
   it("Browse cancellation is a no-op (no onChange call)", async () => {
     vi.mocked(openDialog).mockResolvedValue(null);
     const onChange = vi.fn();
-    renderWithProviders(
-      <SqliteFields dbName="" onDbNameChange={onChange} />,
-    );
+    renderWithProviders(<SqliteFields dbName="" onDbNameChange={onChange} />);
     await userEvent.setup().click(screen.getByLabelText("Browse"));
     await new Promise((r) => setTimeout(r, 10));
     expect(onChange).not.toHaveBeenCalled();

--- a/httui-desktop/src/components/layout/connections/form/__tests__/connection-string.test.ts
+++ b/httui-desktop/src/components/layout/connections/form/__tests__/connection-string.test.ts
@@ -4,9 +4,9 @@ import { buildConnectionPreview } from "@/components/layout/connections/form/con
 
 describe("buildConnectionPreview", () => {
   it("returns the file path verbatim for sqlite", () => {
-    expect(
-      buildConnectionPreview("sqlite", "", "", "/tmp/notes.db", ""),
-    ).toBe("/tmp/notes.db");
+    expect(buildConnectionPreview("sqlite", "", "", "/tmp/notes.db", "")).toBe(
+      "/tmp/notes.db",
+    );
   });
 
   it("returns a placeholder when sqlite path is empty", () => {
@@ -17,13 +17,7 @@ describe("buildConnectionPreview", () => {
 
   it("builds a postgres URI from fields", () => {
     expect(
-      buildConnectionPreview(
-        "postgres",
-        "db.local",
-        "5432",
-        "app",
-        "alice",
-      ),
+      buildConnectionPreview("postgres", "db.local", "5432", "app", "alice"),
     ).toBe("postgres://alice@db.local:5432/app");
   });
 

--- a/httui-desktop/src/components/layout/docheader/DocHeaderAbstract.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderAbstract.tsx
@@ -14,7 +14,7 @@
 // to a single space on commit (slice-1 schema is single-line scalar).
 
 import { useEffect, useRef, useState } from "react";
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, chakra } from "@chakra-ui/react";
 
 import {
   deriveAbstractDisplay,
@@ -169,8 +169,7 @@ function DocHeaderAbstractInput({
 
   return (
     <Box mt={3} position="relative">
-      <Box
-        as="textarea"
+      <chakra.textarea
         data-testid="docheader-abstract-input"
         rows={2}
         value={local}

--- a/httui-desktop/src/components/layout/docheader/DocHeaderCard.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderCard.tsx
@@ -12,7 +12,7 @@
 // don't pass `onTitleSave` (kept the diff viewer + tests working).
 
 import { useContext, useEffect, useRef, useState } from "react";
-import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, Text, chakra } from "@chakra-ui/react";
 
 import {
   registerDocHeaderTitleInput,
@@ -74,9 +74,7 @@ export function DocHeaderCard({
     firstHeading ?? null,
     filePath,
   );
-  const breadcrumb = relativeFilePath
-    ? deriveBreadcrumb(relativeFilePath)
-    : [];
+  const breadcrumb = relativeFilePath ? deriveBreadcrumb(relativeFilePath) : [];
 
   return (
     <Box
@@ -112,18 +110,14 @@ export function DocHeaderCard({
                   fontFamily="mono"
                   fontSize="11px"
                   color={isLeaf ? "fg.muted" : "fg.subtle"}
-                  cursor={
-                    onBreadcrumbSelect && !isLeaf ? "pointer" : undefined
-                  }
+                  cursor={onBreadcrumbSelect && !isLeaf ? "pointer" : undefined}
                   onClick={
                     onBreadcrumbSelect && !isLeaf
                       ? () => onBreadcrumbSelect(seg.path)
                       : undefined
                   }
                   _hover={
-                    onBreadcrumbSelect && !isLeaf
-                      ? { color: "fg" }
-                      : undefined
+                    onBreadcrumbSelect && !isLeaf ? { color: "fg" } : undefined
                   }
                 >
                   {seg.label}
@@ -139,10 +133,7 @@ export function DocHeaderCard({
       )}
 
       {editable ? (
-        <DocHeaderTitleInput
-          value={editableValue}
-          onSave={onTitleSave!}
-        />
+        <DocHeaderTitleInput value={editableValue} onSave={onTitleSave!} />
       ) : (
         <Heading
           as={onTitleClick ? "button" : "h1"}
@@ -226,8 +217,7 @@ function DocHeaderTitleInput({ value, onSave }: DocHeaderTitleInputProps) {
   };
 
   return (
-    <Box
-      as="input"
+    <chakra.input
       ref={inputRef}
       data-testid="docheader-title"
       type="text"

--- a/httui-desktop/src/components/layout/docheader/DocHeaderChecklist.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderChecklist.tsx
@@ -14,7 +14,7 @@
 // the checklist visually.
 
 import { useState } from "react";
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 
 import { Btn, Input } from "@/components/atoms";
 import type { TaskItem } from "@/lib/blocks/task-item";
@@ -172,8 +172,7 @@ function ChecklistRow({
       align="center"
       gap={2}
     >
-      <Flex
-        as="button"
+      <chakra.button
         type="button"
         data-testid="docheader-checklist-checkbox"
         data-checked={item.done ? "true" : undefined}
@@ -181,8 +180,9 @@ function ChecklistRow({
         disabled={!editable}
         w="16px"
         h="16px"
-        align="center"
-        justify="center"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
         borderWidth="1px"
         borderRadius="3px"
         cursor={editable ? "pointer" : "default"}
@@ -218,10 +218,9 @@ function ChecklistRow({
             ✓
           </Text>
         )}
-      </Flex>
+      </chakra.button>
       {editable && editingText ? (
-        <Box
-          as="input"
+        <chakra.input
           data-testid="docheader-checklist-text-input"
           type="text"
           value={draft}
@@ -277,8 +276,7 @@ function ChecklistRow({
         </Text>
       )}
       {editable && (
-        <Text
-          as="button"
+        <chakra.button
           type="button"
           data-testid="docheader-checklist-remove"
           fontFamily="mono"
@@ -289,7 +287,7 @@ function ChecklistRow({
           _hover={{ color: "error" }}
         >
           ×
-        </Text>
+        </chakra.button>
       )}
     </Flex>
   );

--- a/httui-desktop/src/components/layout/docheader/DocHeaderMetaStrip.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderMetaStrip.tsx
@@ -7,7 +7,7 @@
 // the relevant panel (Git / History / etc.).
 
 import { useState } from "react";
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Flex, Text, chakra } from "@chakra-ui/react";
 
 import { gravatarUrl } from "@/lib/avatars/gravatar";
 
@@ -66,17 +66,14 @@ export function DocHeaderMetaStrip({
       mt={2}
       flexWrap="wrap"
     >
-      {author && (
-        <AuthorChip
-          author={author}
-          onClick={onSelectAuthor}
-        />
-      )}
+      {author && <AuthorChip author={author} onClick={onSelectAuthor} />}
       {trimmedOwner && (
         <Chip
           testId="docheader-meta-owner"
           tone="muted"
-          onClick={onSelectOwner ? () => onSelectOwner(trimmedOwner) : undefined}
+          onClick={
+            onSelectOwner ? () => onSelectOwner(trimmedOwner) : undefined
+          }
           title={`owner: ${trimmedOwner}`}
         >
           @{trimmedOwner}
@@ -230,8 +227,7 @@ function AuthorChip({
       flexShrink={0}
     >
       {gravatar && gravatarOk ? (
-        <Box
-          as="img"
+        <chakra.img
           data-testid="docheader-meta-author-avatar"
           src={gravatar}
           alt=""

--- a/httui-desktop/src/components/layout/docheader/DocHeaderShell.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderShell.tsx
@@ -97,7 +97,9 @@ export interface DocHeaderShellProps {
    *  surfaces a `+ Add check` button and click-to-edit on existing
    *  pills. The consumer mutates the frontmatter via the
    *  `updateFrontmatterPreflightChecks` writer. */
-  onAddPreflightCheck?: (check: import("@/lib/blocks/preflight-checks").PreflightCheck) => void;
+  onAddPreflightCheck?: (
+    check: import("@/lib/blocks/preflight-checks").PreflightCheck,
+  ) => void;
   onEditPreflightCheck?: (
     idx: number,
     next: import("@/lib/blocks/preflight-checks").PreflightCheck,
@@ -165,8 +167,7 @@ export function DocHeaderShell(props: DocHeaderShellProps) {
   const showAbstract = !effectiveCompact;
   const showPreflight =
     !effectiveCompact &&
-    ((preflightItems?.length ?? 0) > 0 ||
-      onAddPreflightCheck !== undefined);
+    ((preflightItems?.length ?? 0) > 0 || onAddPreflightCheck !== undefined);
   const showTags =
     !effectiveCompact &&
     (onAddTag !== undefined ||
@@ -174,8 +175,7 @@ export function DocHeaderShell(props: DocHeaderShellProps) {
       (frontmatter?.tags?.length ?? 0) > 0);
   const showChecklist =
     !effectiveCompact &&
-    (onChecklistSave !== undefined ||
-      (frontmatter?.tasks?.length ?? 0) > 0);
+    (onChecklistSave !== undefined || (frontmatter?.tasks?.length ?? 0) > 0);
 
   return (
     <Box

--- a/httui-desktop/src/components/layout/docheader/DocHeaderStatusBadge.tsx
+++ b/httui-desktop/src/components/layout/docheader/DocHeaderStatusBadge.tsx
@@ -62,9 +62,7 @@ export function DocHeaderStatusBadge({
     : FALLBACK_PALETTE;
   const interactive = !!onSelect;
 
-  const handleClick = interactive
-    ? () => onSelect?.(normalized)
-    : undefined;
+  const handleClick = interactive ? () => onSelect?.(normalized) : undefined;
 
   return (
     <Box

--- a/httui-desktop/src/components/layout/docheader/TagColumn.tsx
+++ b/httui-desktop/src/components/layout/docheader/TagColumn.tsx
@@ -9,7 +9,7 @@
 // drawn from `availableTags` minus the currently-applied set.
 
 import { useMemo, useState } from "react";
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 
 import { Btn, Input } from "@/components/atoms";
 
@@ -123,9 +123,8 @@ export function TagColumn({
                 borderRadius="4px"
               >
                 {suggestions.map((s) => (
-                  <Text
+                  <chakra.button
                     key={s}
-                    as="button"
                     data-testid={`tag-column-suggestion-${s}`}
                     fontFamily="mono"
                     fontSize="11px"
@@ -139,7 +138,7 @@ export function TagColumn({
                     cursor="pointer"
                   >
                     {s}
-                  </Text>
+                  </chakra.button>
                 ))}
               </Flex>
             )}
@@ -192,8 +191,7 @@ function TagChip({
         #{tag}
       </Text>
       {onRemove && (
-        <Text
-          as="button"
+        <chakra.button
           data-testid={`tag-column-chip-${tag}-remove`}
           fontFamily="mono"
           fontSize="11px"
@@ -207,7 +205,7 @@ function TagChip({
           _hover={{ color: "error" }}
         >
           ×
-        </Text>
+        </chakra.button>
       )}
     </Flex>
   );

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderAbstract.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderAbstract.test.tsx
@@ -8,25 +8,19 @@ import { renderWithProviders, screen } from "@/test/render";
 describe("DocHeaderAbstract", () => {
   it("renders nothing when frontmatter is null", () => {
     renderWithProviders(<DocHeaderAbstract frontmatter={null} />);
-    expect(
-      screen.queryByTestId("docheader-abstract"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("docheader-abstract")).not.toBeInTheDocument();
   });
 
   it("renders nothing when frontmatter has no abstract", () => {
     renderWithProviders(<DocHeaderAbstract frontmatter={{}} />);
-    expect(
-      screen.queryByTestId("docheader-abstract"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("docheader-abstract")).not.toBeInTheDocument();
   });
 
   it("renders nothing when abstract is whitespace-only", () => {
     renderWithProviders(
       <DocHeaderAbstract frontmatter={{ abstract: "   " }} />,
     );
-    expect(
-      screen.queryByTestId("docheader-abstract"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("docheader-abstract")).not.toBeInTheDocument();
   });
 
   it("renders a short abstract without truncation hints", () => {
@@ -43,31 +37,23 @@ describe("DocHeaderAbstract", () => {
       screen.queryByTestId("docheader-abstract-fade"),
     ).not.toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("docheader-abstract")
-        .getAttribute("data-clamped"),
+      screen.getByTestId("docheader-abstract").getAttribute("data-clamped"),
     ).toBeNull();
   });
 
   it("renders the toggle + fade for long abstracts (>250 chars)", () => {
     const long = "x".repeat(ABSTRACT_FADE_THRESHOLD + 1);
-    renderWithProviders(
-      <DocHeaderAbstract frontmatter={{ abstract: long }} />,
-    );
+    renderWithProviders(<DocHeaderAbstract frontmatter={{ abstract: long }} />);
     expect(screen.getByTestId("docheader-abstract-toggle")).toBeInTheDocument();
     expect(screen.getByTestId("docheader-abstract-fade")).toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("docheader-abstract")
-        .getAttribute("data-clamped"),
+      screen.getByTestId("docheader-abstract").getAttribute("data-clamped"),
     ).toBe("true");
   });
 
   it("toggle reads 'more' when collapsed and 'less' when expanded", async () => {
     const long = "x".repeat(ABSTRACT_FADE_THRESHOLD + 1);
-    renderWithProviders(
-      <DocHeaderAbstract frontmatter={{ abstract: long }} />,
-    );
+    renderWithProviders(<DocHeaderAbstract frontmatter={{ abstract: long }} />);
     const toggle = screen.getByTestId("docheader-abstract-toggle");
     expect(toggle.textContent).toBe("more");
     await userEvent.setup().click(toggle);
@@ -76,9 +62,7 @@ describe("DocHeaderAbstract", () => {
 
   it("removes the fade and clamp flag when expanded", async () => {
     const long = "x".repeat(ABSTRACT_FADE_THRESHOLD + 1);
-    renderWithProviders(
-      <DocHeaderAbstract frontmatter={{ abstract: long }} />,
-    );
+    renderWithProviders(<DocHeaderAbstract frontmatter={{ abstract: long }} />);
     await userEvent
       .setup()
       .click(screen.getByTestId("docheader-abstract-toggle"));
@@ -86,9 +70,7 @@ describe("DocHeaderAbstract", () => {
       screen.queryByTestId("docheader-abstract-fade"),
     ).not.toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("docheader-abstract")
-        .getAttribute("data-clamped"),
+      screen.getByTestId("docheader-abstract").getAttribute("data-clamped"),
     ).toBeNull();
   });
 

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderActionRow.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderActionRow.test.tsx
@@ -30,9 +30,7 @@ describe("DocHeaderActionRow", () => {
   });
 
   it("disables the Run-all button when busy", () => {
-    renderWithProviders(
-      <DocHeaderActionRow onRunAll={() => {}} runAllBusy />,
-    );
+    renderWithProviders(<DocHeaderActionRow onRunAll={() => {}} runAllBusy />);
     const btn = screen.getByTestId(
       "docheader-action-run-all",
     ) as HTMLButtonElement;
@@ -43,14 +41,14 @@ describe("DocHeaderActionRow", () => {
   it("renders the Share button and fires onShare on click", async () => {
     const onShare = vi.fn();
     renderWithProviders(<DocHeaderActionRow onShare={onShare} />);
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("docheader-action-share"));
+    await userEvent.setup().click(screen.getByTestId("docheader-action-share"));
     expect(onShare).toHaveBeenCalledTimes(1);
   });
 
   it("hides the overflow trigger when no overflow handler is provided", () => {
-    renderWithProviders(<DocHeaderActionRow onRunAll={() => {}} onShare={() => {}} />);
+    renderWithProviders(
+      <DocHeaderActionRow onRunAll={() => {}} onShare={() => {}} />,
+    );
     expect(
       screen.queryByTestId("docheader-action-overflow"),
     ).not.toBeInTheDocument();
@@ -73,9 +71,7 @@ describe("DocHeaderActionRow", () => {
       screen.getByTestId("docheader-action-overflow-menu"),
     ).toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("docheader-action-overflow")
-        .getAttribute("data-open"),
+      screen.getByTestId("docheader-action-overflow").getAttribute("data-open"),
     ).toBe("true");
   });
 
@@ -111,9 +107,7 @@ describe("DocHeaderActionRow", () => {
       .setup()
       .click(screen.getByTestId("docheader-action-overflow"));
     expect(
-      screen
-        .getByTestId("docheader-action-delete")
-        .getAttribute("data-tone"),
+      screen.getByTestId("docheader-action-delete").getAttribute("data-tone"),
     ).toBe("error");
   });
 

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderCard.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderCard.test.tsx
@@ -19,10 +19,7 @@ describe("DocHeaderCard", () => {
 
   it("falls back to firstHeading when frontmatter has no title", () => {
     renderWithProviders(
-      <DocHeaderCard
-        filePath="notes/db.md"
-        firstHeading="Database Runbook"
-      />,
+      <DocHeaderCard filePath="notes/db.md" firstHeading="Database Runbook" />,
     );
     expect(screen.getByTestId("docheader-title").textContent).toBe(
       "Database Runbook",
@@ -95,9 +92,7 @@ describe("DocHeaderCard", () => {
     );
     const leaf = screen.getByTestId("docheader-breadcrumb-segment-1");
     expect(leaf.querySelector("button")).toBeNull();
-    expect(
-      leaf.querySelector("[data-leaf='true']"),
-    ).toBeInTheDocument();
+    expect(leaf.querySelector("[data-leaf='true']")).toBeInTheDocument();
   });
 
   it("flags compact mode via data-compact", () => {
@@ -227,10 +222,7 @@ describe("DocHeaderCard", () => {
 
     it("hides the badge when frontmatter has no error", () => {
       renderWithProviders(
-        <DocHeaderCard
-          filePath="notes/db.md"
-          frontmatter={{ title: "x" }}
-        />,
+        <DocHeaderCard filePath="notes/db.md" frontmatter={{ title: "x" }} />,
       );
       expect(
         screen.queryByTestId("docheader-frontmatter-error"),

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderChecklist.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderChecklist.test.tsx
@@ -7,9 +7,7 @@ import { renderWithProviders, screen } from "@/test/render";
 describe("DocHeaderChecklist", () => {
   it("renders nothing when there are no items and no save handler", () => {
     renderWithProviders(<DocHeaderChecklist items={[]} />);
-    expect(
-      screen.queryByTestId("docheader-checklist"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("docheader-checklist")).not.toBeInTheDocument();
   });
 
   it("renders read-only rows when no save handler is provided", () => {
@@ -79,7 +77,9 @@ describe("DocHeaderChecklist", () => {
     );
 
     await user.click(screen.getByTestId("docheader-checklist-add"));
-    const input = screen.getByTestId("docheader-checklist-add-input") as HTMLInputElement;
+    const input = screen.getByTestId(
+      "docheader-checklist-add-input",
+    ) as HTMLInputElement;
     await user.type(input, "Verify the thing");
     await user.keyboard("{Enter}");
     expect(onChecklistSave).toHaveBeenCalledWith([
@@ -95,7 +95,9 @@ describe("DocHeaderChecklist", () => {
     );
 
     await user.click(screen.getByTestId("docheader-checklist-add"));
-    const input = screen.getByTestId("docheader-checklist-add-input") as HTMLInputElement;
+    const input = screen.getByTestId(
+      "docheader-checklist-add-input",
+    ) as HTMLInputElement;
     await user.type(input, "Cancelled");
     await user.keyboard("{Escape}");
     expect(onChecklistSave).not.toHaveBeenCalled();

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderMetaStrip.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderMetaStrip.test.tsx
@@ -55,9 +55,7 @@ describe("DocHeaderMetaStrip", () => {
 
   it("renders the edited chip with mtime + dirty flag", () => {
     const tenMinAgo = Date.now() - 10 * 60_000;
-    renderWithProviders(
-      <DocHeaderMetaStrip mtimeMs={tenMinAgo} dirty />,
-    );
+    renderWithProviders(<DocHeaderMetaStrip mtimeMs={tenMinAgo} dirty />);
     const chip = screen.getByTestId("docheader-meta-edited");
     expect(chip.textContent).toMatch(/Edited 10m ago/);
     expect(chip.textContent).toMatch(/unsaved/);
@@ -101,9 +99,7 @@ describe("DocHeaderMetaStrip", () => {
       />,
     );
     expect(
-      screen
-        .getByTestId("docheader-meta-last-run")
-        .getAttribute("data-tone"),
+      screen.getByTestId("docheader-meta-last-run").getAttribute("data-tone"),
     ).toBe("fail");
   });
 
@@ -148,9 +144,9 @@ describe("DocHeaderMetaStrip", () => {
 
   it("renders the edited chip even when mtimeMs is null (loading state)", () => {
     renderWithProviders(<DocHeaderMetaStrip mtimeMs={null} />);
-    expect(
-      screen.getByTestId("docheader-meta-edited").textContent,
-    ).toMatch(/Not yet saved/);
+    expect(screen.getByTestId("docheader-meta-edited").textContent).toMatch(
+      /Not yet saved/,
+    );
   });
 
   it("renders the owner chip with @-prefix when owner is set", () => {
@@ -182,9 +178,7 @@ describe("DocHeaderMetaStrip", () => {
 
   it("trims owner whitespace before render", () => {
     renderWithProviders(<DocHeaderMetaStrip owner="  bob  " />);
-    expect(screen.getByTestId("docheader-meta-owner").textContent).toBe(
-      "@bob",
-    );
+    expect(screen.getByTestId("docheader-meta-owner").textContent).toBe("@bob");
   });
 
   it("owner chip becomes a button and fires onSelectOwner with trimmed value", async () => {

--- a/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderShell.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/DocHeaderShell.test.tsx
@@ -5,7 +5,9 @@ import { DocHeaderShell } from "@/components/layout/docheader/DocHeaderShell";
 import type { PreflightPillItem } from "@/components/blocks/preflight/PreflightPills";
 import { renderWithProviders, screen } from "@/test/render";
 
-function preflightItem(over: Partial<PreflightPillItem> = {}): PreflightPillItem {
+function preflightItem(
+  over: Partial<PreflightPillItem> = {},
+): PreflightPillItem {
   return {
     id: "i1",
     label: "i1",
@@ -66,9 +68,7 @@ describe("DocHeaderShell", () => {
   });
 
   it("hides the preflight slot when items array is empty even in non-compact mode", () => {
-    renderWithProviders(
-      <DocHeaderShell filePath="x.md" preflightItems={[]} />,
-    );
+    renderWithProviders(<DocHeaderShell filePath="x.md" preflightItems={[]} />);
     expect(
       screen.queryByTestId("docheader-shell-preflight-slot"),
     ).not.toBeInTheDocument();
@@ -128,9 +128,7 @@ describe("DocHeaderShell", () => {
 
   it("forwards Run-all through the action row", async () => {
     const onRunAll = vi.fn();
-    renderWithProviders(
-      <DocHeaderShell filePath="x.md" onRunAll={onRunAll} />,
-    );
+    renderWithProviders(<DocHeaderShell filePath="x.md" onRunAll={onRunAll} />);
     await userEvent
       .setup()
       .click(screen.getByTestId("docheader-action-run-all"));

--- a/httui-desktop/src/components/layout/docheader/__tests__/TagColumn.test.tsx
+++ b/httui-desktop/src/components/layout/docheader/__tests__/TagColumn.test.tsx
@@ -15,9 +15,9 @@ describe("TagColumn", () => {
     expect(
       screen.getByTestId("tag-column-chip-payments-label").textContent,
     ).toBe("#payments");
-    expect(
-      screen.getByTestId("tag-column-chip-debug-label").textContent,
-    ).toBe("#debug");
+    expect(screen.getByTestId("tag-column-chip-debug-label").textContent).toBe(
+      "#debug",
+    );
   });
 
   it("encodes tag count via data-tag-count", () => {
@@ -29,9 +29,7 @@ describe("TagColumn", () => {
 
   it("makes chips interactive only when onSelectTag is supplied", async () => {
     const onSelectTag = vi.fn();
-    renderWithProviders(
-      <TagColumn tags={["a"]} onSelectTag={onSelectTag} />,
-    );
+    renderWithProviders(<TagColumn tags={["a"]} onSelectTag={onSelectTag} />);
     const label = screen.getByTestId("tag-column-chip-a-label");
     expect(label.tagName).toBe("BUTTON");
     await userEvent.setup().click(label);
@@ -40,9 +38,7 @@ describe("TagColumn", () => {
 
   it("renders chip labels as inert spans without onSelectTag", () => {
     renderWithProviders(<TagColumn tags={["a"]} />);
-    expect(screen.getByTestId("tag-column-chip-a-label").tagName).toBe(
-      "SPAN",
-    );
+    expect(screen.getByTestId("tag-column-chip-a-label").tagName).toBe("SPAN");
   });
 
   it("hides + Add tag when no onAddTag is supplied", () => {
@@ -62,9 +58,7 @@ describe("TagColumn", () => {
     );
     expect(onAddTag).toHaveBeenCalledWith("new-tag");
     // Form closes after submit.
-    expect(
-      screen.queryByTestId("tag-column-add-form"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tag-column-add-form")).not.toBeInTheDocument();
   });
 
   it("does not fire onAddTag when the value is whitespace", async () => {
@@ -72,10 +66,7 @@ describe("TagColumn", () => {
     renderWithProviders(<TagColumn tags={[]} onAddTag={onAddTag} />);
     const user = userEvent.setup();
     await user.click(screen.getByTestId("tag-column-add"));
-    await user.type(
-      screen.getByTestId("tag-column-add-input"),
-      "   {Enter}",
-    );
+    await user.type(screen.getByTestId("tag-column-add-input"), "   {Enter}");
     expect(onAddTag).not.toHaveBeenCalled();
   });
 
@@ -84,10 +75,7 @@ describe("TagColumn", () => {
     renderWithProviders(<TagColumn tags={["dup"]} onAddTag={onAddTag} />);
     const user = userEvent.setup();
     await user.click(screen.getByTestId("tag-column-add"));
-    await user.type(
-      screen.getByTestId("tag-column-add-input"),
-      "dup{Enter}",
-    );
+    await user.type(screen.getByTestId("tag-column-add-input"), "dup{Enter}");
     expect(onAddTag).not.toHaveBeenCalled();
   });
 
@@ -96,21 +84,14 @@ describe("TagColumn", () => {
     renderWithProviders(<TagColumn tags={[]} onAddTag={onAddTag} />);
     const user = userEvent.setup();
     await user.click(screen.getByTestId("tag-column-add"));
-    await user.type(
-      screen.getByTestId("tag-column-add-input"),
-      "x{Escape}",
-    );
+    await user.type(screen.getByTestId("tag-column-add-input"), "x{Escape}");
     expect(onAddTag).not.toHaveBeenCalled();
-    expect(
-      screen.queryByTestId("tag-column-add-form"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tag-column-add-form")).not.toBeInTheDocument();
   });
 
   it("fires onRemoveTag on chip × click", async () => {
     const onRemoveTag = vi.fn();
-    renderWithProviders(
-      <TagColumn tags={["a"]} onRemoveTag={onRemoveTag} />,
-    );
+    renderWithProviders(<TagColumn tags={["a"]} onRemoveTag={onRemoveTag} />);
     await userEvent
       .setup()
       .click(screen.getByTestId("tag-column-chip-a-remove"));
@@ -135,8 +116,9 @@ describe("TagColumn", () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId("tag-column-add"));
     await user.type(screen.getByTestId("tag-column-add-input"), "de");
-    expect(screen.getByTestId("tag-column-suggestion-debug"))
-      .toBeInTheDocument();
+    expect(
+      screen.getByTestId("tag-column-suggestion-debug"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId("tag-column-suggestion-payments"),
     ).not.toBeInTheDocument();
@@ -156,9 +138,7 @@ describe("TagColumn", () => {
     await user.type(screen.getByTestId("tag-column-add-input"), "pay");
     await user.click(screen.getByTestId("tag-column-suggestion-payments"));
     expect(onAddTag).toHaveBeenCalledWith("payments");
-    expect(
-      screen.queryByTestId("tag-column-add-form"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tag-column-add-form")).not.toBeInTheDocument();
   });
 
   it("hides suggestions for already-applied tags", async () => {
@@ -188,8 +168,8 @@ describe("TagColumn", () => {
     );
     const add = screen.getByTestId("tag-column-add") as HTMLButtonElement;
     expect(add.disabled).toBe(true);
-    expect(
-      screen.getByTestId("tag-column").getAttribute("data-busy"),
-    ).toBe("true");
+    expect(screen.getByTestId("tag-column").getAttribute("data-busy")).toBe(
+      "true",
+    );
   });
 });

--- a/httui-desktop/src/components/layout/docheader/__tests__/docheader-derive.test.ts
+++ b/httui-desktop/src/components/layout/docheader/__tests__/docheader-derive.test.ts
@@ -11,15 +11,15 @@ import {
 
 describe("pickH1Title", () => {
   it("prefers frontmatter title when present", () => {
-    expect(
-      pickH1Title({ title: "Custom" }, "Heading", "notes/db.md"),
-    ).toBe("Custom");
+    expect(pickH1Title({ title: "Custom" }, "Heading", "notes/db.md")).toBe(
+      "Custom",
+    );
   });
 
   it("treats blank frontmatter title as absent", () => {
-    expect(
-      pickH1Title({ title: "   " }, "Heading", "notes/db.md"),
-    ).toBe("Heading");
+    expect(pickH1Title({ title: "   " }, "Heading", "notes/db.md")).toBe(
+      "Heading",
+    );
   });
 
   it("falls back to first heading when frontmatter title is missing", () => {
@@ -27,9 +27,7 @@ describe("pickH1Title", () => {
   });
 
   it("falls back to filename when no frontmatter and no heading", () => {
-    expect(pickH1Title(null, null, "notes/db-runbook.md")).toBe(
-      "db-runbook",
-    );
+    expect(pickH1Title(null, null, "notes/db-runbook.md")).toBe("db-runbook");
   });
 
   it("trims surrounding whitespace on the picked value", () => {
@@ -97,9 +95,7 @@ describe("deriveAbstractDisplay", () => {
   it("returns null when frontmatter has no abstract", () => {
     expect(deriveAbstractDisplay(null)).toBeNull();
     expect(deriveAbstractDisplay({})).toBeNull();
-    expect(
-      deriveAbstractDisplay({ abstract: "" }),
-    ).toBeNull();
+    expect(deriveAbstractDisplay({ abstract: "" })).toBeNull();
     expect(deriveAbstractDisplay({ abstract: "   " })).toBeNull();
   });
 

--- a/httui-desktop/src/components/layout/docheader/__tests__/docheader-meta.test.ts
+++ b/httui-desktop/src/components/layout/docheader/__tests__/docheader-meta.test.ts
@@ -20,9 +20,9 @@ describe("authorInitialsFromFirstCommit", () => {
   });
 
   it("returns first two letters for single-word names", () => {
-    expect(
-      authorInitialsFromFirstCommit({ name: "alice", email: null }),
-    ).toBe("AL");
+    expect(authorInitialsFromFirstCommit({ name: "alice", email: null })).toBe(
+      "AL",
+    );
   });
 
   it("falls back to email local-part when name is empty", () => {
@@ -33,9 +33,9 @@ describe("authorInitialsFromFirstCommit", () => {
 
   it("returns ? when name and email are both empty", () => {
     expect(authorInitialsFromFirstCommit({ name: "", email: "" })).toBe("?");
-    expect(
-      authorInitialsFromFirstCommit({ name: null, email: null }),
-    ).toBe("?");
+    expect(authorInitialsFromFirstCommit({ name: null, email: null })).toBe(
+      "?",
+    );
   });
 });
 
@@ -170,9 +170,9 @@ describe("formatLastRun", () => {
 
 describe("lastRunTone", () => {
   it("returns muted when no runs", () => {
-    expect(
-      lastRunTone({ ranAt: null, blockCount: 0, failedCount: 0 }),
-    ).toBe("muted");
+    expect(lastRunTone({ ranAt: null, blockCount: 0, failedCount: 0 })).toBe(
+      "muted",
+    );
   });
 
   it("returns ok when all blocks passed", () => {

--- a/httui-desktop/src/components/layout/docheader/docheader-derive.ts
+++ b/httui-desktop/src/components/layout/docheader/docheader-derive.ts
@@ -47,7 +47,10 @@ export function pickH1Title(
 export function filenameWithoutExtension(filePath: string): string {
   // Use the last `/` in either separator family — vaults are POSIX
   // by convention but Windows backslashes can leak in via paste.
-  const lastSlash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  const lastSlash = Math.max(
+    filePath.lastIndexOf("/"),
+    filePath.lastIndexOf("\\"),
+  );
   const base = lastSlash === -1 ? filePath : filePath.slice(lastSlash + 1);
   const dotIdx = base.lastIndexOf(".");
   return dotIdx <= 0 ? base : base.slice(0, dotIdx);

--- a/httui-desktop/src/components/layout/docheader/docheader-meta.ts
+++ b/httui-desktop/src/components/layout/docheader/docheader-meta.ts
@@ -39,7 +39,8 @@ export function formatEditedTime(
   const suffix = dirty ? " · unsaved" : "";
   if (diffSec < 60) return `Edited just now${suffix}`;
   if (diffSec < 3600) return `Edited ${Math.floor(diffSec / 60)}m ago${suffix}`;
-  if (diffSec < 86400) return `Edited ${Math.floor(diffSec / 3600)}h ago${suffix}`;
+  if (diffSec < 86400)
+    return `Edited ${Math.floor(diffSec / 3600)}h ago${suffix}`;
   return `Edited ${Math.floor(diffSec / 86400)}d ago${suffix}`;
 }
 
@@ -74,9 +75,7 @@ export function formatLastRun(summary: LastRunSummary): string {
   const time = formatHHMM(summary.ranAt);
   const blocks = `${summary.blockCount} block${summary.blockCount === 1 ? "" : "s"}`;
   const failed =
-    summary.failedCount > 0
-      ? ` · ${summary.failedCount} failed`
-      : "";
+    summary.failedCount > 0 ? ` · ${summary.failedCount} failed` : "";
   return `Last run ${time} · ${blocks}${failed}`;
 }
 

--- a/httui-desktop/src/components/layout/editor-toolbar/EditorToolbar.tsx
+++ b/httui-desktop/src/components/layout/editor-toolbar/EditorToolbar.tsx
@@ -54,7 +54,10 @@ export function shortenPath(filePath: string): string {
 
 /** Render a relative-time string like "2m ago" / "3h ago" /
  * "5d ago" / "just now". Resolution caps at days; older is "Apr 5". */
-export function formatRelativeTime(date: Date | null, now = new Date()): string {
+export function formatRelativeTime(
+  date: Date | null,
+  now = new Date(),
+): string {
   if (!date) return "—";
   const ms = now.getTime() - date.getTime();
   if (ms < 30_000) return "just now";
@@ -147,10 +150,7 @@ export function EditorToolbar({
       </ToggleButton>
 
       {onAddBlock && (
-        <AddBlockMenu
-          onInsert={onAddBlock}
-          ariaLabel="Add block to document"
-        />
+        <AddBlockMenu onInsert={onAddBlock} ariaLabel="Add block to document" />
       )}
     </HStack>
   );

--- a/httui-desktop/src/components/layout/editor-toolbar/__tests__/EditorToolbar.test.tsx
+++ b/httui-desktop/src/components/layout/editor-toolbar/__tests__/EditorToolbar.test.tsx
@@ -79,9 +79,9 @@ describe("EditorToolbar", () => {
 
   it("shows the full path on the title attribute (hover)", () => {
     renderWithProviders(<EditorToolbar {...baseProps} />);
-    expect(screen.getByTestId("editor-toolbar-path").getAttribute("title")).toBe(
-      "/v/runbooks/auth/login.md",
-    );
+    expect(
+      screen.getByTestId("editor-toolbar-path").getAttribute("title"),
+    ).toBe("/v/runbooks/auth/login.md");
   });
 
   it("renders 'edited Xm ago' for clean tab", () => {
@@ -136,6 +136,8 @@ describe("EditorToolbar", () => {
 
   it("toolbar exposes data-atom='editor-toolbar' for testing/styling hooks", () => {
     const { container } = renderWithProviders(<EditorToolbar {...baseProps} />);
-    expect(container.querySelector('[data-atom="editor-toolbar"]')).toBeTruthy();
+    expect(
+      container.querySelector('[data-atom="editor-toolbar"]'),
+    ).toBeTruthy();
   });
 });

--- a/httui-desktop/src/components/layout/editor-toolbar/blockCount.ts
+++ b/httui-desktop/src/components/layout/editor-toolbar/blockCount.ts
@@ -11,7 +11,11 @@ const EXECUTABLE_FENCES = ["http", "db", "db-"] as const;
 
 function isExecutableFence(token: string): boolean {
   for (const exe of EXECUTABLE_FENCES) {
-    if (token === exe || token.startsWith(`${exe}-`) || token === exe.replace("-", "")) {
+    if (
+      token === exe ||
+      token.startsWith(`${exe}-`) ||
+      token === exe.replace("-", "")
+    ) {
       return true;
     }
   }

--- a/httui-desktop/src/components/layout/empty-vault/MigrationBanner.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/MigrationBanner.tsx
@@ -43,8 +43,8 @@ export function MigrationBanner({
     >
       <Box flex={1} fontSize="13px" lineHeight={1.4}>
         <Text fontWeight={600}>
-          MVP vault detected — run the v1 migration to unlock the
-          new file layout.
+          MVP vault detected — run the v1 migration to unlock the new file
+          layout.
         </Text>
         <Text fontSize="12px" color="fg.muted" mt={0.5}>
           See{" "}
@@ -58,8 +58,8 @@ export function MigrationBanner({
           >
             docs/MIGRATION.md
           </DocsLink>{" "}
-          for what changes (vault data is backed up before any
-          destructive write).
+          for what changes (vault data is backed up before any destructive
+          write).
         </Text>
       </Box>
       <Btn

--- a/httui-desktop/src/components/layout/empty-vault/OpenVaultCard.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/OpenVaultCard.tsx
@@ -16,7 +16,10 @@ export interface OpenVaultCardProps {
   busy?: boolean;
 }
 
-export function OpenVaultCard({ onOpenClick, busy = false }: OpenVaultCardProps) {
+export function OpenVaultCard({
+  onOpenClick,
+  busy = false,
+}: OpenVaultCardProps) {
   return (
     <CardBox
       type="button"

--- a/httui-desktop/src/components/layout/empty-vault/__tests__/CloneVaultCard.test.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/__tests__/CloneVaultCard.test.tsx
@@ -8,11 +8,7 @@ function setup(over: Partial<Parameters<typeof CloneVaultCard>[0]> = {}) {
   const onClone = vi.fn(async () => {});
   const onPickParent = vi.fn(async () => null as string | null);
   const utils = renderWithProviders(
-    <CloneVaultCard
-      onClone={onClone}
-      onPickParent={onPickParent}
-      {...over}
-    />,
+    <CloneVaultCard onClone={onClone} onPickParent={onPickParent} {...over} />,
   );
   return { ...utils, onClone, onPickParent };
 }
@@ -119,11 +115,7 @@ describe("CloneVaultCard — expanded state", () => {
     const onClone = vi.fn(async () => {});
     const onPickParent = vi.fn(async () => null as string | null);
     renderWithProviders(
-      <CloneVaultCard
-        onClone={onClone}
-        onPickParent={onPickParent}
-        busy
-      />,
+      <CloneVaultCard onClone={onClone} onPickParent={onPickParent} busy />,
     );
     const cta = screen.getByTestId("clone-vault-expand") as HTMLButtonElement;
     expect(cta.disabled).toBe(true);

--- a/httui-desktop/src/components/layout/empty-vault/__tests__/CreateVaultCard.test.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/__tests__/CreateVaultCard.test.tsx
@@ -119,11 +119,7 @@ describe("CreateVaultCard — expanded state", () => {
     const onCreate = vi.fn(async () => {});
     const onPickParent = vi.fn(async () => null as string | null);
     renderWithProviders(
-      <CreateVaultCard
-        onCreate={onCreate}
-        onPickParent={onPickParent}
-        busy
-      />,
+      <CreateVaultCard onCreate={onCreate} onPickParent={onPickParent} busy />,
     );
     const cta = screen.getByTestId("create-vault-expand") as HTMLButtonElement;
     expect(cta.disabled).toBe(true);

--- a/httui-desktop/src/components/layout/empty-vault/__tests__/EmptyVaultSidebar.test.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/__tests__/EmptyVaultSidebar.test.tsx
@@ -77,9 +77,7 @@ describe("EmptyVaultSidebar", () => {
     expect(screen.getByTestId("explore-variables").textContent).toContain(
       "(0)",
     );
-    expect(screen.getByTestId("explore-members").textContent).toContain(
-      "(1)",
-    );
+    expect(screen.getByTestId("explore-members").textContent).toContain("(1)");
   });
 
   it("tags the wrapper with data-atom='empty-vault-sidebar'", () => {

--- a/httui-desktop/src/components/layout/empty-vault/__tests__/OpenVaultCard.test.tsx
+++ b/httui-desktop/src/components/layout/empty-vault/__tests__/OpenVaultCard.test.tsx
@@ -30,9 +30,7 @@ describe("OpenVaultCard", () => {
   it("respects busy: disables click and dims", async () => {
     const user = userEvent.setup();
     const onOpenClick = vi.fn();
-    renderWithProviders(
-      <OpenVaultCard onOpenClick={onOpenClick} busy />,
-    );
+    renderWithProviders(<OpenVaultCard onOpenClick={onOpenClick} busy />);
     const card = screen.getByTestId("open-vault-card") as HTMLButtonElement;
     expect(card.disabled).toBe(true);
     await user.click(card);

--- a/httui-desktop/src/components/layout/environments/CloneEnvironmentForm.tsx
+++ b/httui-desktop/src/components/layout/environments/CloneEnvironmentForm.tsx
@@ -153,7 +153,11 @@ export function CloneEnvironmentForm({
         </Flex>
 
         <Flex justify="space-between" align="center">
-          <Text fontSize="11px" color="fg.subtle" data-testid="clone-target-hint">
+          <Text
+            fontSize="11px"
+            color="fg.subtle"
+            data-testid="clone-target-hint"
+          >
             creates{" "}
             <Text as="span" fontFamily="mono">
               envs/{targetFilename}

--- a/httui-desktop/src/components/layout/environments/EnvironmentCard.tsx
+++ b/httui-desktop/src/components/layout/environments/EnvironmentCard.tsx
@@ -16,14 +16,10 @@ import {
   Menu,
   Portal,
   Text,
+  chakra,
 } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
-import {
-  LuCopy,
-  LuEllipsisVertical,
-  LuPencil,
-  LuTrash2,
-} from "react-icons/lu";
+import { LuCopy, LuEllipsisVertical, LuPencil, LuTrash2 } from "react-icons/lu";
 
 import type { EnvironmentSummary } from "./envs-meta";
 
@@ -45,6 +41,7 @@ export function EnvironmentCard({
   onDelete,
 }: EnvironmentCardProps) {
   const interactive = !!onActivate;
+  const BodyComp = interactive ? chakra.button : chakra.div;
   const hasActions = !!(onClone || onRename || onDelete);
 
   // Detect false → true transition on isActive to fire a one-shot
@@ -107,8 +104,7 @@ export function EnvironmentCard({
           : undefined
       }
     >
-      <Box
-        as={interactive ? "button" : "div"}
+      <BodyComp
         type={interactive ? "button" : undefined}
         onClick={interactive ? () => onActivate?.(env.filename) : undefined}
         textAlign="left"
@@ -151,7 +147,13 @@ export function EnvironmentCard({
           )}
         </Flex>
 
-        <Flex gap={3} fontFamily="mono" fontSize="11px" color="fg.muted" mb={1.5}>
+        <Flex
+          gap={3}
+          fontFamily="mono"
+          fontSize="11px"
+          color="fg.muted"
+          mb={1.5}
+        >
           <Text data-testid={`environment-card-${env.filename}-vars`}>
             {env.varCount} {env.varCount === 1 ? "var" : "vars"}
           </Text>
@@ -189,7 +191,7 @@ export function EnvironmentCard({
             {env.description}
           </Text>
         )}
-      </Box>
+      </BodyComp>
 
       {hasActions && (
         <Box position="absolute" top={1.5} right={1.5}>
@@ -209,7 +211,10 @@ export function EnvironmentCard({
               <Menu.Positioner>
                 <Menu.Content>
                   {onClone && (
-                    <Menu.Item value="clone" onSelect={() => onClone(env.filename)}>
+                    <Menu.Item
+                      value="clone"
+                      onSelect={() => onClone(env.filename)}
+                    >
                       <LuCopy />
                       Clone
                     </Menu.Item>

--- a/httui-desktop/src/components/layout/environments/EnvironmentManager.tsx
+++ b/httui-desktop/src/components/layout/environments/EnvironmentManager.tsx
@@ -22,10 +22,7 @@ import { LuCopy, LuTrash2, LuX } from "react-icons/lu";
 
 import { Btn, Input } from "@/components/atoms";
 import { useEnvironmentStore } from "@/stores/environment";
-import {
-  resolveEnvVariables,
-  type EnvVariable,
-} from "@/lib/tauri/commands";
+import { resolveEnvVariables, type EnvVariable } from "@/lib/tauri/commands";
 
 import { NewVariableForm } from "../variables/NewVariableForm";
 import { VariableValueRow } from "../variables/VariableValueRow";
@@ -116,7 +113,12 @@ export function EnvironmentManager() {
     }) => {
       const target = environments.find((e) => e.name === payload.env);
       if (!target) return;
-      await setVariable(target.id, payload.name, payload.value, payload.isSecret);
+      await setVariable(
+        target.id,
+        payload.name,
+        payload.value,
+        payload.isSecret,
+      );
       setCreating(false);
       await refreshVars();
     },
@@ -219,11 +221,7 @@ export function EnvironmentManager() {
                 />
               </Flex>
             ) : (
-              <Btn
-                variant="ghost"
-                size="xs"
-                onClick={() => setNewEnvCreating(true)}
-              >
+              <Btn variant="ghost" onClick={() => setNewEnvCreating(true)}>
                 + New env
               </Btn>
             )}
@@ -250,7 +248,6 @@ export function EnvironmentManager() {
                   ) : (
                     <Btn
                       variant="ghost"
-                      size="xs"
                       onClick={() => switchEnvironment(selectedEnv.id)}
                     >
                       Set active
@@ -310,11 +307,7 @@ export function EnvironmentManager() {
                     />
                   ) : (
                     <Box px={4} py={2}>
-                      <Btn
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => setCreating(true)}
-                      >
+                      <Btn variant="ghost" onClick={() => setCreating(true)}>
                         + New variable
                       </Btn>
                     </Box>

--- a/httui-desktop/src/components/layout/environments/EnvironmentsPageContainer.tsx
+++ b/httui-desktop/src/components/layout/environments/EnvironmentsPageContainer.tsx
@@ -44,7 +44,10 @@ import {
  * lands when the backend exposes it). `isPersonal` therefore stays
  * false for now — the personal/committed split is display-only and
  * can be enriched without breaking page consumers. */
-export function envToSummary(env: Environment, varCount: number): EnvironmentSummary {
+export function envToSummary(
+  env: Environment,
+  varCount: number,
+): EnvironmentSummary {
   return {
     name: env.name,
     filename: `${env.name}.toml`,

--- a/httui-desktop/src/components/layout/environments/__tests__/EnvironmentCard.test.tsx
+++ b/httui-desktop/src/components/layout/environments/__tests__/EnvironmentCard.test.tsx
@@ -164,11 +164,7 @@ describe("EnvironmentCard", () => {
     const onActivate = vi.fn();
     const onClone = vi.fn();
     renderWithProviders(
-      <EnvironmentCard
-        env={env()}
-        onActivate={onActivate}
-        onClone={onClone}
-      />,
+      <EnvironmentCard env={env()} onActivate={onActivate} onClone={onClone} />,
     );
     await userEvent
       .setup()

--- a/httui-desktop/src/components/layout/environments/__tests__/EnvironmentManager.test.tsx
+++ b/httui-desktop/src/components/layout/environments/__tests__/EnvironmentManager.test.tsx
@@ -183,16 +183,13 @@ describe("EnvironmentManager", () => {
     const user = userEvent.setup();
     renderWithProviders(<EnvironmentManager />);
     await user.click(await screen.findByText("+ New variable"));
-    await user.type(
-      await screen.findByTestId("new-variable-name"),
-      "FRESH",
-    );
+    await user.type(await screen.findByTestId("new-variable-name"), "FRESH");
     await user.type(screen.getByTestId("new-variable-value"), "value");
     await user.click(screen.getByTestId("new-variable-save"));
     await waitFor(() => {
       expect(setCalled).not.toBeNull();
     });
-    expect((setCalled as { key: string }).key).toBe("FRESH");
+    expect(setCalled).toMatchObject({ key: "FRESH" });
   });
 
   it("'Set active' on the selected env dispatches set_active_environment", async () => {
@@ -254,7 +251,7 @@ describe("EnvironmentManager", () => {
     await waitFor(() => {
       expect(deletedId).not.toBeNull();
     });
-    expect((deletedId as { id: string }).id).toBe("v1");
+    expect(deletedId).toMatchObject({ id: "v1" });
   });
 
   it("Escape key cancels the inline creator", async () => {
@@ -266,6 +263,8 @@ describe("EnvironmentManager", () => {
     expect(screen.getByTestId("env-mgr-new-env-name")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    expect(screen.queryByTestId("env-mgr-new-env-name")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("env-mgr-new-env-name"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/httui-desktop/src/components/layout/environments/__tests__/EnvironmentsPageContainer.test.tsx
+++ b/httui-desktop/src/components/layout/environments/__tests__/EnvironmentsPageContainer.test.tsx
@@ -71,7 +71,8 @@ beforeEach(() => {
   mockTauriCommand("list_env_variables", (args) => {
     const a = args as { environmentId?: string };
     if (a.environmentId === "env-local") return [v({ id: "v1" })];
-    if (a.environmentId === "env-prod") return [v({ id: "v2" }), v({ id: "v3" })];
+    if (a.environmentId === "env-prod")
+      return [v({ id: "v2" }), v({ id: "v3" })];
     return [];
   });
 });
@@ -154,9 +155,7 @@ describe("EnvironmentsPageContainer", () => {
       setActiveCalled = args as { id: string };
       return undefined;
     });
-    const { default: userEvent } = await import(
-      "@testing-library/user-event"
-    );
+    const { default: userEvent } = await import("@testing-library/user-event");
     renderWithProviders(<EnvironmentsPageContainer />);
     const card = await screen.findByTestId("environment-card-prod.toml");
     const activateBtn = card.querySelector("button");
@@ -215,9 +214,7 @@ describe("EnvironmentsPageContainer", () => {
       await screen.findByTestId("delete-environment-confirm-input"),
       "prod",
     );
-    await user.click(
-      screen.getByTestId("delete-environment-confirm-submit"),
-    );
+    await user.click(screen.getByTestId("delete-environment-confirm-submit"));
 
     await waitFor(() => {
       expect(deleteCalled).not.toBeNull();

--- a/httui-desktop/src/components/layout/file-tree/FileTree.tsx
+++ b/httui-desktop/src/components/layout/file-tree/FileTree.tsx
@@ -82,9 +82,7 @@ function ArchiveFilterToggle() {
     (s) => Object.keys(s.archivedFiles).length,
   );
   const showArchived = useArchiveFilterStore((s) => s.showArchived);
-  const toggleShowArchived = useArchiveFilterStore(
-    (s) => s.toggleShowArchived,
-  );
+  const toggleShowArchived = useArchiveFilterStore((s) => s.toggleShowArchived);
   if (archivedCount === 0) return null;
   return (
     <Flex

--- a/httui-desktop/src/components/layout/file-tree/__tests__/FileTreeTagDots.test.tsx
+++ b/httui-desktop/src/components/layout/file-tree/__tests__/FileTreeTagDots.test.tsx
@@ -26,7 +26,9 @@ describe("FileTreeTagDots", () => {
     renderWithProviders(<FileTreeTagDots filePath="/v/x.md" />);
     expect(screen.getByTestId("file-tree-tag-dots")).toBeInTheDocument();
     expect(screen.getByTestId("file-tree-tag-dot-api")).toBeInTheDocument();
-    expect(screen.getByTestId("file-tree-tag-dot-payments")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("file-tree-tag-dot-payments"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId("file-tree-tag-dots-overflow"),
     ).not.toBeInTheDocument();
@@ -40,18 +42,14 @@ describe("FileTreeTagDots", () => {
     expect(screen.getByTestId("file-tree-tag-dot-a")).toBeInTheDocument();
     expect(screen.getByTestId("file-tree-tag-dot-b")).toBeInTheDocument();
     expect(screen.getByTestId("file-tree-tag-dot-c")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("file-tree-tag-dot-d"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("file-tree-tag-dot-d")).not.toBeInTheDocument();
     expect(screen.getByTestId("file-tree-tag-dots-overflow").textContent).toBe(
       "+2",
     );
   });
 
   it("the wrapper title attribute lists every tag (incl. overflow)", () => {
-    useTagIndexStore
-      .getState()
-      .setTagsForFile("/v/z.md", ["a", "b", "c", "d"]);
+    useTagIndexStore.getState().setTagsForFile("/v/z.md", ["a", "b", "c", "d"]);
     renderWithProviders(<FileTreeTagDots filePath="/v/z.md" />);
     expect(screen.getByTestId("file-tree-tag-dots").title).toBe("a, b, c, d");
   });

--- a/httui-desktop/src/components/layout/file-tree/__tests__/file-tree-drag.test.ts
+++ b/httui-desktop/src/components/layout/file-tree/__tests__/file-tree-drag.test.ts
@@ -25,10 +25,7 @@ describe("resolveFileTreeDrop", () => {
   it("returns null when the drop target is the source itself", () => {
     expect(
       resolveFileTreeDrop(
-        event(
-          overWith("a", "a.md"),
-          activeWith("a", "a.md"),
-        ),
+        event(overWith("a", "a.md"), activeWith("a", "a.md")),
       ),
     ).toBeNull();
   });
@@ -43,19 +40,14 @@ describe("resolveFileTreeDrop", () => {
 
   it("returns null when over has no dirPath data", () => {
     expect(
-      resolveFileTreeDrop(
-        event(overWith("dir"), activeWith("a", "a.md")),
-      ),
+      resolveFileTreeDrop(event(overWith("dir"), activeWith("a", "a.md"))),
     ).toBeNull();
   });
 
   it("returns null when source equals target dir (drop on own dir)", () => {
     expect(
       resolveFileTreeDrop(
-        event(
-          overWith("dir", "notes"),
-          activeWith("notes", "notes"),
-        ),
+        event(overWith("dir", "notes"), activeWith("notes", "notes")),
       ),
     ).toBeNull();
   });
@@ -63,10 +55,7 @@ describe("resolveFileTreeDrop", () => {
   it("returns null when target dir is a descendant of the source", () => {
     expect(
       resolveFileTreeDrop(
-        event(
-          overWith("subdir", "notes/subdir"),
-          activeWith("notes", "notes"),
-        ),
+        event(overWith("subdir", "notes/subdir"), activeWith("notes", "notes")),
       ),
     ).toBeNull();
   });
@@ -85,10 +74,7 @@ describe("resolveFileTreeDrop", () => {
   it("accepts an empty-string targetDir (root drop)", () => {
     expect(
       resolveFileTreeDrop(
-        event(
-          overWith("root", ""),
-          activeWith("note", "drafts/note.md"),
-        ),
+        event(overWith("root", ""), activeWith("note", "drafts/note.md")),
       ),
     ).toEqual({ sourcePath: "drafts/note.md", targetDir: "" });
   });

--- a/httui-desktop/src/components/layout/git/CommitChangelog.tsx
+++ b/httui-desktop/src/components/layout/git/CommitChangelog.tsx
@@ -14,7 +14,7 @@
 // - Body: bulleted list, 12px, fg.1, line-height 1.5
 // - Each item: `• <blockId mono>: <text>`
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 import { Kbd } from "@/components/atoms";
 
 export interface CommitChangelogEntry {
@@ -54,7 +54,13 @@ export function CommitChangelog({
     <Box
       data-testid="commit-changelog"
       data-state={
-        error ? "error" : loading ? "loading" : entries.length ? "ready" : "empty"
+        error
+          ? "error"
+          : loading
+            ? "loading"
+            : entries.length
+              ? "ready"
+              : "empty"
       }
       bg="bg.muted"
       borderRadius="6px"
@@ -83,8 +89,7 @@ export function CommitChangelog({
         <Box flex={1} />
         <Kbd data-testid="commit-changelog-tab-hint">tab</Kbd>
         {onDismiss && (
-          <Box
-            as="button"
+          <chakra.button
             type="button"
             data-testid="commit-changelog-dismiss"
             aria-label="Dismiss AI changelog"
@@ -101,7 +106,7 @@ export function CommitChangelog({
             _hover={{ color: "fg" }}
           >
             ×
-          </Box>
+          </chakra.button>
         )}
       </Flex>
       {error ? (
@@ -153,9 +158,9 @@ interface ChangelogRowProps {
 
 function ChangelogRow({ entry, onAccept }: ChangelogRowProps) {
   const interactive = typeof onAccept === "function";
+  const RowComp = interactive ? chakra.button : chakra.li;
   return (
-    <Box
-      as={interactive ? "button" : "li"}
+    <RowComp
       type={interactive ? "button" : undefined}
       role={interactive ? undefined : "listitem"}
       onClick={interactive ? () => onAccept!(entry) : undefined}
@@ -190,6 +195,6 @@ function ChangelogRow({ entry, onAccept }: ChangelogRowProps) {
       <Text as="span" data-testid="commit-changelog-row-text">
         {entry.text}
       </Text>
-    </Box>
+    </RowComp>
   );
 }

--- a/httui-desktop/src/components/layout/git/GitCommitDiffViewer.tsx
+++ b/httui-desktop/src/components/layout/git/GitCommitDiffViewer.tsx
@@ -33,7 +33,12 @@ export function GitCommitDiffViewer({
 }: GitCommitDiffViewerProps) {
   if (diff === null) {
     return (
-      <Box data-testid="git-commit-diff-viewer" data-loading="true" px={3} py={4}>
+      <Box
+        data-testid="git-commit-diff-viewer"
+        data-loading="true"
+        px={3}
+        py={4}
+      >
         <Text fontSize="11px" color="fg.subtle">
           Loading diff…
         </Text>
@@ -87,8 +92,8 @@ export function GitCommitDiffViewer({
               color="warn"
               mt={2}
             >
-              … truncated at {maxLines} lines (full size{" "}
-              {allLines.length} lines).
+              … truncated at {maxLines} lines (full size {allLines.length}{" "}
+              lines).
             </Text>
           )}
         </Box>

--- a/httui-desktop/src/components/layout/git/GitCommitForm.tsx
+++ b/httui-desktop/src/components/layout/git/GitCommitForm.tsx
@@ -100,9 +100,7 @@ export function GitCommitForm({
           variant={disabled ? "ghost" : "primary"}
           data-testid="git-commit-form-submit"
           disabled={disabled}
-          onClick={() =>
-            onCommit({ message: message.trim(), amend })
-          }
+          onClick={() => onCommit({ message: message.trim(), amend })}
         >
           {amend ? "Amend" : "Commit"}
         </Btn>

--- a/httui-desktop/src/components/layout/git/GitConflictResolver.tsx
+++ b/httui-desktop/src/components/layout/git/GitConflictResolver.tsx
@@ -129,7 +129,13 @@ export function GitConflictResolver({
           >
             Merge base
           </Text>
-          <Box as="pre" m={0} fontFamily="mono" fontSize="11px" color="fg.muted">
+          <Box
+            as="pre"
+            m={0}
+            fontFamily="mono"
+            fontSize="11px"
+            color="fg.muted"
+          >
             {versions.base.length > 0
               ? versions.base
               : "(no common ancestor — add/add conflict)"}

--- a/httui-desktop/src/components/layout/git/GitFileList.tsx
+++ b/httui-desktop/src/components/layout/git/GitFileList.tsx
@@ -49,7 +49,11 @@ export function GitFileList({
   return (
     <Box data-testid="git-file-list" data-count={changed.length}>
       {staged.length > 0 && (
-        <Group testId="git-file-list-staged" label="Staged" count={staged.length}>
+        <Group
+          testId="git-file-list-staged"
+          label="Staged"
+          count={staged.length}
+        >
           {staged.map((f) => (
             <Row
               key={f.path}

--- a/httui-desktop/src/components/layout/git/GitLogFilter.tsx
+++ b/httui-desktop/src/components/layout/git/GitLogFilter.tsx
@@ -35,9 +35,7 @@ export function GitLogFilter({ state, onChange }: GitLogFilterProps) {
         <Input
           data-testid="git-log-filter-input"
           placeholder={
-            state.mode === "author"
-              ? "Filter by author…"
-              : "Filter by path…"
+            state.mode === "author" ? "Filter by author…" : "Filter by path…"
           }
           value={state.query}
           onChange={(e) => onChange({ ...state, query: e.target.value })}

--- a/httui-desktop/src/components/layout/git/__tests__/CommitChangelog.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/CommitChangelog.test.tsx
@@ -7,32 +7,32 @@ import { renderWithProviders, screen } from "@/test/render";
 describe("CommitChangelog", () => {
   it("renders header with title + tab kbd hint", () => {
     renderWithProviders(<CommitChangelog entries={[]} />);
-    expect(
-      screen.getByTestId("commit-changelog-title").textContent,
-    ).toBe("Auto-generated changelog");
-    expect(
-      screen.getByTestId("commit-changelog-tab-hint").textContent,
-    ).toBe("tab");
+    expect(screen.getByTestId("commit-changelog-title").textContent).toBe(
+      "Auto-generated changelog",
+    );
+    expect(screen.getByTestId("commit-changelog-tab-hint").textContent).toBe(
+      "tab",
+    );
   });
 
   it("shows empty hint when entries is [] and not loading or errored", () => {
     renderWithProviders(<CommitChangelog entries={[]} />);
-    expect(
-      screen.getByTestId("commit-changelog-empty").textContent,
-    ).toMatch(/no block-level changes/i);
-    expect(screen.getByTestId("commit-changelog").getAttribute("data-state")).toBe(
-      "empty",
+    expect(screen.getByTestId("commit-changelog-empty").textContent).toMatch(
+      /no block-level changes/i,
     );
+    expect(
+      screen.getByTestId("commit-changelog").getAttribute("data-state"),
+    ).toBe("empty");
   });
 
   it("shows loading hint when loading is true (preempts empty)", () => {
     renderWithProviders(<CommitChangelog entries={[]} loading />);
-    expect(
-      screen.getByTestId("commit-changelog-loading").textContent,
-    ).toMatch(/generating changelog/i);
-    expect(screen.getByTestId("commit-changelog").getAttribute("data-state")).toBe(
-      "loading",
+    expect(screen.getByTestId("commit-changelog-loading").textContent).toMatch(
+      /generating changelog/i,
     );
+    expect(
+      screen.getByTestId("commit-changelog").getAttribute("data-state"),
+    ).toBe("loading");
   });
 
   it("shows error message and replaces body when error is set (preempts loading)", () => {
@@ -43,15 +43,15 @@ describe("CommitChangelog", () => {
         error="Sidecar offline — try again"
       />,
     );
-    expect(
-      screen.getByTestId("commit-changelog-error").textContent,
-    ).toBe("Sidecar offline — try again");
+    expect(screen.getByTestId("commit-changelog-error").textContent).toBe(
+      "Sidecar offline — try again",
+    );
     expect(
       screen.queryByTestId("commit-changelog-loading"),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("commit-changelog").getAttribute("data-state")).toBe(
-      "error",
-    );
+    expect(
+      screen.getByTestId("commit-changelog").getAttribute("data-state"),
+    ).toBe("error");
   });
 
   it("renders entries with monospaced block id and description", () => {
@@ -70,9 +70,9 @@ describe("CommitChangelog", () => {
     expect(ids[1]!.textContent).toBe("b08:");
     expect(rows[0]!.getAttribute("data-block-id")).toBe("b06");
     expect(rows[0]!.tagName).toBe("LI"); // non-interactive when onAccept absent
-    expect(screen.getByTestId("commit-changelog").getAttribute("data-state")).toBe(
-      "ready",
-    );
+    expect(
+      screen.getByTestId("commit-changelog").getAttribute("data-state"),
+    ).toBe("ready");
   });
 
   it("rows become buttons when onAccept is supplied and fire with the entry", async () => {
@@ -89,9 +89,7 @@ describe("CommitChangelog", () => {
   });
 
   it("dismiss button only renders when onDismiss is set, and fires onDismiss", async () => {
-    const { rerender } = renderWithProviders(
-      <CommitChangelog entries={[]} />,
-    );
+    const { rerender } = renderWithProviders(<CommitChangelog entries={[]} />);
     expect(
       screen.queryByTestId("commit-changelog-dismiss"),
     ).not.toBeInTheDocument();

--- a/httui-desktop/src/components/layout/git/__tests__/GitBranchPicker.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitBranchPicker.test.tsx
@@ -82,10 +82,7 @@ describe("GitBranchPicker", () => {
   it("filters branches case-insensitively as the user types", async () => {
     renderWithProviders(
       <GitBranchPicker
-        branches={[
-          branch({ name: "main" }),
-          branch({ name: "feat/payments" }),
-        ]}
+        branches={[branch({ name: "main" }), branch({ name: "feat/payments" })]}
       />,
     );
     await userEvent

--- a/httui-desktop/src/components/layout/git/__tests__/GitCommitDiffViewer.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitCommitDiffViewer.test.tsx
@@ -72,16 +72,10 @@ describe("GitCommitDiffViewer", () => {
 
   it("renders the header with shortSha + subject when provided", () => {
     renderWithProviders(
-      <GitCommitDiffViewer
-        shortSha="abc1234"
-        subject="fix bug"
-        diff="+a"
-      />,
+      <GitCommitDiffViewer shortSha="abc1234" subject="fix bug" diff="+a" />,
     );
     expect(
-      screen
-        .getByTestId("git-commit-diff-viewer-header")
-        .textContent,
+      screen.getByTestId("git-commit-diff-viewer-header").textContent,
     ).toMatch(/abc1234.*fix bug/);
   });
 

--- a/httui-desktop/src/components/layout/git/__tests__/GitCommitForm.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitCommitForm.test.tsx
@@ -78,9 +78,9 @@ describe("GitCommitForm", () => {
 
   it("agrees sing/plural in the staged-files summary", () => {
     render({ stagedCount: 1 });
-    expect(
-      screen.getByTestId("git-commit-form-summary").textContent,
-    ).toMatch(/1 file staged/);
+    expect(screen.getByTestId("git-commit-form-summary").textContent).toMatch(
+      /1 file staged/,
+    );
 
     render({ stagedCount: 3 });
     const sums = screen.getAllByTestId("git-commit-form-summary");

--- a/httui-desktop/src/components/layout/git/__tests__/GitConflictBanner.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitConflictBanner.test.tsx
@@ -22,9 +22,7 @@ describe("GitConflictBanner", () => {
   });
 
   it("agrees plural for >1 conflicts", () => {
-    renderWithProviders(
-      <GitConflictBanner conflicts={["a.md", "b.md"]} />,
-    );
+    renderWithProviders(<GitConflictBanner conflicts={["a.md", "b.md"]} />);
     expect(screen.getByTestId("git-conflict-banner").textContent).toMatch(
       /2 conflicts to resolve/,
     );
@@ -41,9 +39,7 @@ describe("GitConflictBanner", () => {
   });
 
   it("encodes count via data-count", () => {
-    renderWithProviders(
-      <GitConflictBanner conflicts={["a", "b", "c"]} />,
-    );
+    renderWithProviders(<GitConflictBanner conflicts={["a", "b", "c"]} />);
     expect(
       screen.getByTestId("git-conflict-banner").getAttribute("data-count"),
     ).toBe("3");
@@ -51,10 +47,7 @@ describe("GitConflictBanner", () => {
 
   it("only renders the action buttons whose handlers are provided", () => {
     renderWithProviders(
-      <GitConflictBanner
-        conflicts={["a.md"]}
-        onOpenDiff={() => {}}
-      />,
+      <GitConflictBanner conflicts={["a.md"]} onOpenDiff={() => {}} />,
     );
     expect(
       screen.getByTestId("git-conflict-row-a.md-resolve"),
@@ -81,10 +74,7 @@ describe("GitConflictBanner", () => {
   it("fires onAcceptYours on Accept-yours click", async () => {
     const onAcceptYours = vi.fn();
     renderWithProviders(
-      <GitConflictBanner
-        conflicts={["a.md"]}
-        onAcceptYours={onAcceptYours}
-      />,
+      <GitConflictBanner conflicts={["a.md"]} onAcceptYours={onAcceptYours} />,
     );
     await userEvent
       .setup()
@@ -117,19 +107,22 @@ describe("GitConflictBanner", () => {
       />,
     );
     expect(
-      (screen.getByTestId(
-        "git-conflict-row-a.md-resolve",
-      ) as HTMLButtonElement).disabled,
+      (screen.getByTestId("git-conflict-row-a.md-resolve") as HTMLButtonElement)
+        .disabled,
     ).toBe(true);
     expect(
-      (screen.getByTestId(
-        "git-conflict-row-a.md-accept-yours",
-      ) as HTMLButtonElement).disabled,
+      (
+        screen.getByTestId(
+          "git-conflict-row-a.md-accept-yours",
+        ) as HTMLButtonElement
+      ).disabled,
     ).toBe(true);
     expect(
-      (screen.getByTestId(
-        "git-conflict-row-a.md-accept-theirs",
-      ) as HTMLButtonElement).disabled,
+      (
+        screen.getByTestId(
+          "git-conflict-row-a.md-accept-theirs",
+        ) as HTMLButtonElement
+      ).disabled,
     ).toBe(true);
     expect(
       screen.getByTestId("git-conflict-banner").getAttribute("data-busy"),

--- a/httui-desktop/src/components/layout/git/__tests__/GitConflictResolver.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitConflictResolver.test.tsx
@@ -39,9 +39,7 @@ describe("GitConflictResolver", () => {
     expect(
       screen.queryByTestId("git-conflict-resolver-base"),
     ).not.toBeInTheDocument();
-    await user.click(
-      screen.getByTestId("git-conflict-resolver-base-toggle"),
-    );
+    await user.click(screen.getByTestId("git-conflict-resolver-base-toggle"));
     const base = screen.getByTestId("git-conflict-resolver-base");
     expect(base.textContent).toContain("base line");
   });
@@ -56,9 +54,7 @@ describe("GitConflictResolver", () => {
         onCancel={vi.fn()}
       />,
     );
-    await user.click(
-      screen.getByTestId("git-conflict-resolver-base-toggle"),
-    );
+    await user.click(screen.getByTestId("git-conflict-resolver-base-toggle"));
     expect(
       screen.getByTestId("git-conflict-resolver-base").textContent,
     ).toContain("no common ancestor");

--- a/httui-desktop/src/components/layout/git/__tests__/GitFileList.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitFileList.test.tsx
@@ -32,19 +32,13 @@ describe("GitFileList", () => {
       />,
     );
     expect(
-      screen
-        .getByTestId("git-file-list-staged")
-        .getAttribute("data-count"),
+      screen.getByTestId("git-file-list-staged").getAttribute("data-count"),
     ).toBe("1");
     expect(
-      screen
-        .getByTestId("git-file-list-unstaged")
-        .getAttribute("data-count"),
+      screen.getByTestId("git-file-list-unstaged").getAttribute("data-count"),
     ).toBe("1");
     expect(
-      screen
-        .getByTestId("git-file-list-untracked")
-        .getAttribute("data-count"),
+      screen.getByTestId("git-file-list-untracked").getAttribute("data-count"),
     ).toBe("1");
   });
 

--- a/httui-desktop/src/components/layout/git/__tests__/GitLogFilter.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitLogFilter.test.tsx
@@ -19,7 +19,9 @@ describe("GitLogFilter", () => {
     ) as HTMLInputElement;
     expect(input.placeholder).toBe("Filter by author…");
 
-    rerender(<GitLogFilter state={state({ mode: "path" })} onChange={() => {}} />);
+    rerender(
+      <GitLogFilter state={state({ mode: "path" })} onChange={() => {}} />,
+    );
     expect(
       (screen.getByTestId("git-log-filter-input") as HTMLInputElement)
         .placeholder,
@@ -30,9 +32,9 @@ describe("GitLogFilter", () => {
     renderWithProviders(
       <GitLogFilter state={state({ mode: "author" })} onChange={() => {}} />,
     );
-    expect(
-      screen.getByTestId("git-log-filter").getAttribute("data-mode"),
-    ).toBe("author");
+    expect(screen.getByTestId("git-log-filter").getAttribute("data-mode")).toBe(
+      "author",
+    );
     expect(
       screen
         .getByTestId("git-log-filter-mode-author")
@@ -47,9 +49,7 @@ describe("GitLogFilter", () => {
 
   it("fires onChange with the next state on input change", async () => {
     const onChange = vi.fn();
-    renderWithProviders(
-      <GitLogFilter state={state()} onChange={onChange} />,
-    );
+    renderWithProviders(<GitLogFilter state={state()} onChange={onChange} />);
     await userEvent
       .setup()
       .type(screen.getByTestId("git-log-filter-input"), "j");
@@ -59,9 +59,7 @@ describe("GitLogFilter", () => {
 
   it("fires onChange when toggling mode buttons", async () => {
     const onChange = vi.fn();
-    renderWithProviders(
-      <GitLogFilter state={state()} onChange={onChange} />,
-    );
+    renderWithProviders(<GitLogFilter state={state()} onChange={onChange} />);
     await userEvent
       .setup()
       .click(screen.getByTestId("git-log-filter-mode-path"));
@@ -99,9 +97,7 @@ describe("GitLogFilter", () => {
     renderWithProviders(
       <GitLogFilter state={state({ query: "alice" })} onChange={onChange} />,
     );
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("git-log-filter-clear"));
+    await userEvent.setup().click(screen.getByTestId("git-log-filter-clear"));
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0]![0].query).toBe("");
   });

--- a/httui-desktop/src/components/layout/git/__tests__/GitLogList.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitLogList.test.tsx
@@ -29,12 +29,12 @@ describe("GitLogList", () => {
         commits={[commit(), commit({ short_sha: "f00ba12", subject: "next" })]}
       />,
     );
-    expect(
-      screen.getByTestId("git-log-list").getAttribute("data-count"),
-    ).toBe("2");
-    expect(
-      screen.getByTestId("git-log-row-deadbee-initials").textContent,
-    ).toBe("JD");
+    expect(screen.getByTestId("git-log-list").getAttribute("data-count")).toBe(
+      "2",
+    );
+    expect(screen.getByTestId("git-log-row-deadbee-initials").textContent).toBe(
+      "JD",
+    );
     expect(screen.getByTestId("git-log-row-f00ba12")).toBeInTheDocument();
   });
 
@@ -63,9 +63,7 @@ describe("GitLogList", () => {
   it("renders relative time as '<N>s ago' for recent commits", () => {
     renderWithProviders(
       <GitLogList
-        commits={[
-          commit({ timestamp: Math.floor(Date.now() / 1000) - 10 }),
-        ]}
+        commits={[commit({ timestamp: Math.floor(Date.now() / 1000) - 10 })]}
       />,
     );
     expect(screen.getByTestId("git-log-row-deadbee").textContent).toMatch(

--- a/httui-desktop/src/components/layout/git/__tests__/GitPanel.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitPanel.test.tsx
@@ -151,9 +151,7 @@ describe("GitPanel", () => {
 
     it("omits the commit form when handlers are absent", () => {
       renderWithProviders(<GitPanel status={status()} commits={[]} />);
-      expect(
-        screen.queryByTestId("git-commit-form"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("git-commit-form")).not.toBeInTheDocument();
     });
 
     it("hides the diff inspector when diff is undefined", () => {
@@ -174,13 +172,11 @@ describe("GitPanel", () => {
           diff={null}
         />,
       );
+      expect(screen.getByTestId("git-panel-section-diff")).toBeInTheDocument();
       expect(
-        screen.getByTestId("git-panel-section-diff"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("git-commit-diff-viewer").getAttribute(
-          "data-loading",
-        ),
+        screen
+          .getByTestId("git-commit-diff-viewer")
+          .getAttribute("data-loading"),
       ).toBe("true");
     });
 
@@ -194,9 +190,7 @@ describe("GitPanel", () => {
           diffSubject="Working tree changes"
         />,
       );
-      expect(
-        screen.getByTestId("git-commit-diff-viewer"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-commit-diff-viewer")).toBeInTheDocument();
       expect(screen.getByText("+added")).toBeInTheDocument();
     });
   });
@@ -217,15 +211,9 @@ describe("GitPanel", () => {
 
     it("omits the log filter when not wired", () => {
       renderWithProviders(
-        <GitPanel
-          status={status()}
-          commits={[commit()]}
-          activeTab="log"
-        />,
+        <GitPanel status={status()} commits={[commit()]} activeTab="log" />,
       );
-      expect(
-        screen.queryByTestId("git-log-filter"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("git-log-filter")).not.toBeInTheDocument();
     });
 
     it("shows the commit diff inspector on the Log tab", () => {
@@ -240,9 +228,7 @@ describe("GitPanel", () => {
           diffSubject="first commit"
         />,
       );
-      expect(
-        screen.getByTestId("git-panel-section-diff"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-panel-section-diff")).toBeInTheDocument();
       expect(screen.getByText("+log line")).toBeInTheDocument();
     });
   });
@@ -263,9 +249,7 @@ describe("GitPanel", () => {
 
     it("omits the sync toolbar when no sync handlers", () => {
       renderWithProviders(<GitPanel status={status()} commits={[]} />);
-      expect(
-        screen.queryByTestId("git-sync-buttons"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("git-sync-buttons")).not.toBeInTheDocument();
     });
 
     it("shows the upstream prompt and fires confirm/cancel", async () => {
@@ -285,9 +269,7 @@ describe("GitPanel", () => {
       const prompt = screen.getByTestId("git-upstream-prompt");
       expect(prompt.textContent).toContain("feat/x");
       expect(prompt.textContent).toContain("origin/feat/x");
-      await user.click(
-        screen.getByTestId("git-upstream-prompt-confirm"),
-      );
+      await user.click(screen.getByTestId("git-upstream-prompt-confirm"));
       expect(onConfirm).toHaveBeenCalledTimes(1);
       await user.click(screen.getByTestId("git-upstream-prompt-cancel"));
       expect(onCancel).toHaveBeenCalledTimes(1);
@@ -302,13 +284,9 @@ describe("GitPanel", () => {
           hasRemote={false}
         />,
       );
-      const pushBtn = screen.getByTestId(
-        "git-sync-push",
-      ) as HTMLButtonElement;
+      const pushBtn = screen.getByTestId("git-sync-push") as HTMLButtonElement;
       expect(pushBtn.disabled).toBe(true);
-      expect(
-        screen.getByTestId("git-sync-no-remote-hint"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-sync-no-remote-hint")).toBeInTheDocument();
     });
   });
 
@@ -324,12 +302,8 @@ describe("GitPanel", () => {
           onAcceptTheirs={vi.fn()}
         />,
       );
-      expect(
-        screen.getByTestId("git-conflict-banner"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("git-conflict-row-a.md"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-conflict-banner")).toBeInTheDocument();
+      expect(screen.getByTestId("git-conflict-row-a.md")).toBeInTheDocument();
     });
 
     it("omits the banner when there are no conflicts", () => {
@@ -355,9 +329,7 @@ describe("GitPanel", () => {
         />,
       );
       expect(screen.getByTestId("git-panel-resolver")).toBeInTheDocument();
-      expect(
-        screen.getByTestId("git-conflict-resolver"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-conflict-resolver")).toBeInTheDocument();
       // Tab bodies are suppressed while resolving.
       expect(
         screen.queryByTestId("git-panel-section-working-tree"),
@@ -375,9 +347,7 @@ describe("GitPanel", () => {
           toolbarExtra={<div data-testid="share-slot-probe" />}
         />,
       );
-      expect(
-        screen.getByTestId("share-slot-probe"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("share-slot-probe")).toBeInTheDocument();
     });
 
     it("shows the toolbar for the slot even without sync handlers", () => {
@@ -388,12 +358,8 @@ describe("GitPanel", () => {
           toolbarExtra={<div data-testid="share-slot-probe" />}
         />,
       );
-      expect(
-        screen.getByTestId("share-slot-probe"),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByTestId("git-sync-buttons"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("share-slot-probe")).toBeInTheDocument();
+      expect(screen.queryByTestId("git-sync-buttons")).not.toBeInTheDocument();
     });
   });
 });

--- a/httui-desktop/src/components/layout/git/__tests__/GitPanelContainer.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitPanelContainer.test.tsx
@@ -118,9 +118,9 @@ describe("GitPanelContainer", () => {
   it("shows the loading state when no vault is open", () => {
     useWorkspaceStore.setState({ vaultPath: null });
     renderWithProviders(<GitPanelContainer />);
-    expect(
-      screen.getByTestId("git-panel").getAttribute("data-loading"),
-    ).toBe("true");
+    expect(screen.getByTestId("git-panel").getAttribute("data-loading")).toBe(
+      "true",
+    );
   });
 
   describe("stage + commit (cenário 2)", () => {
@@ -178,11 +178,8 @@ describe("GitPanelContainer", () => {
       await waitFor(() => expect(committed).toBe("fix: typo"));
       await waitFor(() =>
         expect(
-          (
-            screen.getByTestId(
-              "git-commit-form-message",
-            ) as HTMLTextAreaElement
-          ).value,
+          (screen.getByTestId("git-commit-form-message") as HTMLTextAreaElement)
+            .value,
         ).toBe(""),
       );
     });
@@ -319,10 +316,7 @@ describe("GitPanelContainer", () => {
       await user.click(screen.getByTestId("git-tab-log"));
       expect(await screen.findByTestId("git-log-row-deadbee")).toBeVisible();
       expect(screen.getByTestId("git-log-row-f00")).toBeVisible();
-      await user.type(
-        screen.getByTestId("git-log-filter-input"),
-        "Other",
-      );
+      await user.type(screen.getByTestId("git-log-filter-input"), "Other");
       await waitFor(() => {
         expect(
           screen.queryByTestId("git-log-row-deadbee"),
@@ -345,14 +339,9 @@ describe("GitPanelContainer", () => {
       });
       await user.click(screen.getByTestId("git-tab-log"));
       await user.click(screen.getByTestId("git-log-filter-mode-path"));
-      await user.type(
-        screen.getByTestId("git-log-filter-input"),
-        "src/app",
-      );
+      await user.type(screen.getByTestId("git-log-filter-input"), "src/app");
       await waitFor(() => {
-        expect((lastArgs as { pathFilter: string }).pathFilter).toBe(
-          "src/app",
-        );
+        expect((lastArgs as { pathFilter: string }).pathFilter).toBe("src/app");
       });
     });
 
@@ -426,9 +415,7 @@ describe("GitPanelContainer", () => {
       renderWithProviders(<GitPanelContainer />);
       await user.click(await screen.findByTestId("git-sync-push"));
       await waitFor(() =>
-        expect((pushArgs as { setUpstream: boolean }).setUpstream).toBe(
-          false,
-        ),
+        expect((pushArgs as { setUpstream: boolean }).setUpstream).toBe(false),
       );
       expect(
         screen.queryByTestId("git-upstream-prompt"),
@@ -448,9 +435,7 @@ describe("GitPanelContainer", () => {
       await user.click(await screen.findByTestId("git-sync-push"));
       const prompt = await screen.findByTestId("git-upstream-prompt");
       expect(prompt.textContent).toContain("feat/new");
-      await user.click(
-        screen.getByTestId("git-upstream-prompt-confirm"),
-      );
+      await user.click(screen.getByTestId("git-upstream-prompt-confirm"));
       await waitFor(() => expect(pushArgs).not.toBeNull());
       expect(pushArgs!.setUpstream).toBe(true);
       expect(pushArgs!.branch).toBe("feat/new");
@@ -471,9 +456,7 @@ describe("GitPanelContainer", () => {
       const user = userEvent.setup();
       renderWithProviders(<GitPanelContainer />);
       await user.click(await screen.findByTestId("git-sync-push"));
-      await user.click(
-        await screen.findByTestId("git-upstream-prompt-cancel"),
-      );
+      await user.click(await screen.findByTestId("git-upstream-prompt-cancel"));
       await waitFor(() =>
         expect(
           screen.queryByTestId("git-upstream-prompt"),
@@ -499,13 +482,9 @@ describe("GitPanelContainer", () => {
       mockTauriCommand("git_status_cmd", () => conflicted);
       renderWithProviders(<GitPanelContainer />);
       await waitFor(() => {
-        expect(
-          screen.getByTestId("git-conflict-banner"),
-        ).toBeInTheDocument();
+        expect(screen.getByTestId("git-conflict-banner")).toBeInTheDocument();
       });
-      expect(
-        screen.getByTestId("git-conflict-row-c.md"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-conflict-row-c.md")).toBeInTheDocument();
     });
 
     it("accepts ours via git_checkout_conflict_path_cmd", async () => {
@@ -541,9 +520,7 @@ describe("GitPanelContainer", () => {
         await screen.findByTestId("git-conflict-row-c.md-resolve"),
       );
       await waitFor(() => {
-        expect(
-          screen.getByTestId("git-conflict-resolver"),
-        ).toBeInTheDocument();
+        expect(screen.getByTestId("git-conflict-resolver")).toBeInTheDocument();
       });
       await user.click(screen.getByTestId("git-conflict-resolver-mark"));
       await waitFor(() => expect(wrote).toBe("ours\n"));
@@ -585,32 +562,23 @@ describe("GitPanelContainer", () => {
       const user = userEvent.setup();
       renderWithProviders(<GitPanelContainer />);
       await waitFor(() => {
-        expect(
-          screen.getByTestId("git-sync-buttons"),
-        ).toBeInTheDocument();
+        expect(screen.getByTestId("git-sync-buttons")).toBeInTheDocument();
       });
       expect(
-        (screen.getByTestId("git-sync-fetch") as HTMLButtonElement)
-          .disabled,
+        (screen.getByTestId("git-sync-fetch") as HTMLButtonElement).disabled,
       ).toBe(true);
       expect(
-        (screen.getByTestId("git-sync-pull") as HTMLButtonElement)
-          .disabled,
+        (screen.getByTestId("git-sync-pull") as HTMLButtonElement).disabled,
       ).toBe(true);
       expect(
-        (screen.getByTestId("git-sync-push") as HTMLButtonElement)
-          .disabled,
+        (screen.getByTestId("git-sync-push") as HTMLButtonElement).disabled,
       ).toBe(true);
-      expect(
-        screen.getByTestId("git-sync-no-remote-hint"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("git-sync-no-remote-hint")).toBeInTheDocument();
       // Toolbar Share popover surfaces the empty state.
       await user.click(screen.getByTestId("share-menu-trigger"));
       await waitFor(() => {
         expect(
-          screen
-            .getByTestId("share-popover")
-            .getAttribute("data-state"),
+          screen.getByTestId("share-popover").getAttribute("data-state"),
         ).toBe("empty");
       });
     });
@@ -630,8 +598,7 @@ describe("GitPanelContainer", () => {
           await vi.advanceTimersByTimeAsync(50);
         });
         expect(
-          (screen.getByTestId("git-sync-push") as HTMLButtonElement)
-            .disabled,
+          (screen.getByTestId("git-sync-push") as HTMLButtonElement).disabled,
         ).toBe(true);
         // `git remote add` happens outside the app.
         remotes = [{ name: "origin", url: "git@github.com:a/b.git" }];
@@ -640,8 +607,7 @@ describe("GitPanelContainer", () => {
           await vi.advanceTimersByTimeAsync(2100);
         });
         expect(
-          (screen.getByTestId("git-sync-push") as HTMLButtonElement)
-            .disabled,
+          (screen.getByTestId("git-sync-push") as HTMLButtonElement).disabled,
         ).toBe(false);
       } finally {
         vi.useRealTimers();
@@ -659,9 +625,7 @@ describe("GitPanelContainer", () => {
       expect(screen.getByTestId("git-tab-log")).toBeInTheDocument();
       // Audit dropped — was identical to Log without the v1.x
       // action-type filters.
-      expect(
-        screen.queryByTestId("git-tab-audit"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("git-tab-audit")).not.toBeInTheDocument();
     });
   });
 });

--- a/httui-desktop/src/components/layout/git/__tests__/GitStatusHeader.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitStatusHeader.test.tsx
@@ -36,9 +36,7 @@ describe("GitStatusHeader", () => {
       screen.queryByTestId("git-status-header-upstream"),
     ).not.toBeInTheDocument();
     expect(
-      screen
-        .getByTestId("git-status-header")
-        .getAttribute("data-no-upstream"),
+      screen.getByTestId("git-status-header").getAttribute("data-no-upstream"),
     ).toBe("true");
   });
 

--- a/httui-desktop/src/components/layout/git/__tests__/GitSyncButtons.test.tsx
+++ b/httui-desktop/src/components/layout/git/__tests__/GitSyncButtons.test.tsx
@@ -15,11 +15,7 @@ describe("GitSyncButtons", () => {
 
   it("renders each button when its handler is supplied", () => {
     renderWithProviders(
-      <GitSyncButtons
-        onFetch={() => {}}
-        onPull={() => {}}
-        onPush={() => {}}
-      />,
+      <GitSyncButtons onFetch={() => {}} onPull={() => {}} onPush={() => {}} />,
     );
     expect(screen.getByTestId("git-sync-fetch")).toBeInTheDocument();
     expect(screen.getByTestId("git-sync-pull")).toBeInTheDocument();
@@ -80,14 +76,10 @@ describe("GitSyncButtons", () => {
   });
 
   it("disables Push and shows the no-remote hint when hasRemote is false", () => {
-    renderWithProviders(
-      <GitSyncButtons hasRemote={false} onPush={() => {}} />,
-    );
+    renderWithProviders(<GitSyncButtons hasRemote={false} onPush={() => {}} />);
     const pushBtn = screen.getByTestId("git-sync-push") as HTMLButtonElement;
     expect(pushBtn.disabled).toBe(true);
-    expect(
-      screen.getByTestId("git-sync-no-remote-hint"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("git-sync-no-remote-hint")).toBeInTheDocument();
     expect(
       screen.getByTestId("git-sync-buttons").getAttribute("data-no-remote"),
     ).toBe("true");
@@ -143,9 +135,7 @@ describe("GitSyncButtons", () => {
   });
 
   it("encodes the in-flight op via root data-in-flight attribute", () => {
-    renderWithProviders(
-      <GitSyncButtons inFlight="push" onPush={() => {}} />,
-    );
+    renderWithProviders(<GitSyncButtons inFlight="push" onPush={() => {}} />);
     expect(
       screen.getByTestId("git-sync-buttons").getAttribute("data-in-flight"),
     ).toBe("push");

--- a/httui-desktop/src/components/layout/git/__tests__/git-commit-validate.test.ts
+++ b/httui-desktop/src/components/layout/git/__tests__/git-commit-validate.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  pluralizeFiles,
-  validateCommitMessage,
-} from "../git-commit-validate";
+import { pluralizeFiles, validateCommitMessage } from "../git-commit-validate";
 
 describe("validateCommitMessage", () => {
   it("rejects an empty message", () => {

--- a/httui-desktop/src/components/layout/git/git-commit-validate.ts
+++ b/httui-desktop/src/components/layout/git/git-commit-validate.ts
@@ -33,11 +33,14 @@ export function validateCommitMessage(message: string): CommitValidation {
   // empty and subject is the entire single-line message.
   const lines = trimmed.split("\n");
   const subject = lines[0]!.replace(/^\s+/u, "");
-  const blankIdx = lines.findIndex(
-    (l, i) => i > 0 && l.trim().length === 0,
-  );
+  const blankIdx = lines.findIndex((l, i) => i > 0 && l.trim().length === 0);
   const body =
-    blankIdx === -1 ? "" : lines.slice(blankIdx + 1).join("\n").trim();
+    blankIdx === -1
+      ? ""
+      : lines
+          .slice(blankIdx + 1)
+          .join("\n")
+          .trim();
 
   if (subject.length === 0) {
     errors.push("Commit subject (first line) cannot be empty.");

--- a/httui-desktop/src/components/layout/history/HistoryList.tsx
+++ b/httui-desktop/src/components/layout/history/HistoryList.tsx
@@ -161,8 +161,7 @@ export function label(entry: HistoryEntry): string {
  *  can reuse it in tooltips / detail panels without re-implementing
  *  the rounding rules. */
 export function formatRelative(isoOrMs: string | number): string {
-  const t =
-    typeof isoOrMs === "number" ? isoOrMs : Date.parse(isoOrMs);
+  const t = typeof isoOrMs === "number" ? isoOrMs : Date.parse(isoOrMs);
   if (!Number.isFinite(t)) return "—";
   const diff = Date.now() - t;
   if (diff < 0) return "now";

--- a/httui-desktop/src/components/layout/history/__tests__/HistoryList.test.tsx
+++ b/httui-desktop/src/components/layout/history/__tests__/HistoryList.test.tsx
@@ -43,9 +43,7 @@ describe("HistoryList", () => {
   it("renders the empty state when entries is empty", () => {
     renderWithProviders(<HistoryList entries={[]} />);
     expect(screen.getByTestId("history-empty")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("history-list"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("history-list")).not.toBeInTheDocument();
   });
 
   it("renders one row per entry with id + tone attrs", () => {
@@ -73,9 +71,7 @@ describe("HistoryList", () => {
   it("renders rows as buttons + fires onSelect with the entry", async () => {
     const onSelect = vi.fn();
     const e = entry({ id: 42 });
-    renderWithProviders(
-      <HistoryList entries={[e]} onSelect={onSelect} />,
-    );
+    renderWithProviders(<HistoryList entries={[e]} onSelect={onSelect} />);
     const row = screen.getByTestId("history-row");
     expect(row.tagName).toBe("BUTTON");
     vi.useRealTimers();
@@ -86,9 +82,7 @@ describe("HistoryList", () => {
   it("uses alias when present, else METHOD + URL", () => {
     expect(label(entry({ block_alias: "fetchUser" }))).toBe("fetchUser");
     expect(
-      label(
-        entry({ block_alias: "", method: "POST", url_canonical: "/x" }),
-      ),
+      label(entry({ block_alias: "", method: "POST", url_canonical: "/x" })),
     ).toBe("POST /x");
     expect(
       label(entry({ block_alias: "  ", method: "PUT", url_canonical: "/y" })),
@@ -96,9 +90,7 @@ describe("HistoryList", () => {
   });
 
   it("hides status text when entry.status is null", () => {
-    renderWithProviders(
-      <HistoryList entries={[entry({ status: null })]} />,
-    );
+    renderWithProviders(<HistoryList entries={[entry({ status: null })]} />);
     const row = screen.getByTestId("history-row");
     expect(row.textContent).not.toMatch(/^200/);
   });
@@ -131,9 +123,7 @@ describe("HistoryList", () => {
   });
 
   it("hides the plan chip when entry.plan is empty / whitespace", () => {
-    renderWithProviders(
-      <HistoryList entries={[entry({ plan: "   " })]} />,
-    );
+    renderWithProviders(<HistoryList entries={[entry({ plan: "   " })]} />);
     expect(screen.queryByTestId("history-row-plan")).not.toBeInTheDocument();
   });
 });

--- a/httui-desktop/src/components/layout/outline/__tests__/OutlineList.test.tsx
+++ b/httui-desktop/src/components/layout/outline/__tests__/OutlineList.test.tsx
@@ -17,9 +17,7 @@ describe("OutlineList", () => {
   it("renders the empty state when entries is empty", () => {
     renderWithProviders(<OutlineList entries={[]} />);
     expect(screen.getByTestId("outline-empty")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("outline-list"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("outline-list")).not.toBeInTheDocument();
   });
 
   it("renders one row per entry with level + line attrs", () => {
@@ -53,9 +51,7 @@ describe("OutlineList", () => {
 
   it("renders rows as buttons + fires onSelect with the entry", async () => {
     const onSelect = vi.fn();
-    renderWithProviders(
-      <OutlineList entries={SAMPLE} onSelect={onSelect} />,
-    );
+    renderWithProviders(<OutlineList entries={SAMPLE} onSelect={onSelect} />);
     const rows = screen.getAllByTestId("outline-row");
     expect(rows[0].tagName).toBe("BUTTON");
     await userEvent.click(rows[2]);
@@ -63,9 +59,7 @@ describe("OutlineList", () => {
   });
 
   it("highlights the entry whose line is largest <= activeLine", () => {
-    renderWithProviders(
-      <OutlineList entries={SAMPLE} activeLine={22} />,
-    );
+    renderWithProviders(<OutlineList entries={SAMPLE} activeLine={22} />);
     const rows = screen.getAllByTestId("outline-row");
     // activeLine=22 sits between Rollout (line 20) and PATCH (line 25)
     // → Rollout (idx 2) highlights.
@@ -77,19 +71,13 @@ describe("OutlineList", () => {
   });
 
   it("highlights nothing when activeLine is before every heading", () => {
-    renderWithProviders(
-      <OutlineList entries={SAMPLE} activeLine={1} />,
-    );
+    renderWithProviders(<OutlineList entries={SAMPLE} activeLine={1} />);
     const rows = screen.getAllByTestId("outline-row");
-    rows.forEach((r) =>
-      expect(r).toHaveAttribute("data-active", "false"),
-    );
+    rows.forEach((r) => expect(r).toHaveAttribute("data-active", "false"));
   });
 
   it("highlights the last entry when activeLine is far past the end", () => {
-    renderWithProviders(
-      <OutlineList entries={SAMPLE} activeLine={9999} />,
-    );
+    renderWithProviders(<OutlineList entries={SAMPLE} activeLine={9999} />);
     const rows = screen.getAllByTestId("outline-row");
     expect(rows[rows.length - 1]).toHaveAttribute("data-active", "true");
   });
@@ -97,9 +85,7 @@ describe("OutlineList", () => {
   it("highlights nothing when activeLine is omitted", () => {
     renderWithProviders(<OutlineList entries={SAMPLE} />);
     const rows = screen.getAllByTestId("outline-row");
-    rows.forEach((r) =>
-      expect(r).toHaveAttribute("data-active", "false"),
-    );
+    rows.forEach((r) => expect(r).toHaveAttribute("data-active", "false"));
   });
 
   it("indent class scales with level via inline padding", () => {

--- a/httui-desktop/src/components/layout/outline/__tests__/OutlinePanel.test.tsx
+++ b/httui-desktop/src/components/layout/outline/__tests__/OutlinePanel.test.tsx
@@ -65,10 +65,7 @@ describe("OutlinePanel", () => {
   });
 
   it("renders rows for the active file's headings", () => {
-    setActiveFile(
-      "a.md",
-      "# Top\n\nbody\n\n## Section\n\nmore\n\n### Sub\n",
-    );
+    setActiveFile("a.md", "# Top\n\nbody\n\n## Section\n\nmore\n\n### Sub\n");
     renderWithProviders(<OutlinePanel width={300} onClose={() => {}} />);
     // 3 headings → 3 rows.
     const rows = screen.getAllByTestId("outline-row");

--- a/httui-desktop/src/components/layout/pane/__tests__/DocHeaderedEditor.test.tsx
+++ b/httui-desktop/src/components/layout/pane/__tests__/DocHeaderedEditor.test.tsx
@@ -102,7 +102,6 @@ describe("DocHeaderedEditor", () => {
     onNavigateFile: undefined,
   };
 
-
   it("mounts the DocHeader card above the editor with filePath threaded", () => {
     mockTauriCommand("get_file_settings", () => ({ auto_capture: false }));
     renderWithProviders(<DocHeaderedEditor {...baseProps} />);
@@ -182,9 +181,7 @@ describe("DocHeaderedEditor", () => {
 
   it("renders the editor with the same filePath + content length", () => {
     mockTauriCommand("get_file_settings", () => ({ auto_capture: false }));
-    renderWithProviders(
-      <DocHeaderedEditor {...baseProps} content={"abcd"} />,
-    );
+    renderWithProviders(<DocHeaderedEditor {...baseProps} content={"abcd"} />);
     const editor = screen.getByTestId("markdown-editor");
     expect(editor.dataset.file).toBe("notes/foo.md");
     expect(editor.dataset.len).toBe("4");

--- a/httui-desktop/src/components/layout/pane/__tests__/PaneNode.test.tsx
+++ b/httui-desktop/src/components/layout/pane/__tests__/PaneNode.test.tsx
@@ -5,7 +5,7 @@ import { usePaneStore } from "@/stores/pane";
 import { useSettingsStore } from "@/stores/settings";
 import { clearTauriMocks, mockTauriCommand } from "@/test/mocks/tauri";
 import { renderWithProviders, screen } from "@/test/render";
-import type { PaneLayout } from "@/types/pane";
+import type { LeafPane, PaneLayout, SplitPane, TabState } from "@/types/pane";
 
 vi.mock("@/components/layout/pane/DocHeaderedEditor", () => ({
   DocHeaderedEditor: ({
@@ -66,8 +66,8 @@ vi.mock("../../TabBar", () => ({
 }));
 
 vi.mock("../SplitView", () => ({
-  SplitView: ({ layout }: { layout: PaneLayout }) => (
-    <div data-testid="split-view" data-id={layout.id} />
+  SplitView: ({ layout }: { layout: SplitPane }) => (
+    <div data-testid="split-view" data-direction={layout.direction} />
   ),
 }));
 
@@ -86,7 +86,7 @@ afterEach(() => {
   clearTauriMocks();
 });
 
-const leafLayout = (override?: Partial<PaneLayout>): PaneLayout => ({
+const leafLayout = (override?: Partial<LeafPane>): LeafPane => ({
   type: "leaf",
   id: "p1",
   tabs: [
@@ -94,9 +94,8 @@ const leafLayout = (override?: Partial<PaneLayout>): PaneLayout => ({
       kind: "file",
       filePath: "a.md",
       vaultPath: "/v",
-    } as PaneLayout extends { tabs: infer T } ? T : never extends Array<infer Tab>
-      ? Tab
-      : never,
+      unsaved: false,
+    } satisfies TabState,
   ],
   activeTab: 0,
   ...(override ?? {}),
@@ -111,22 +110,16 @@ describe("PaneNode", () => {
       activeTab: 0,
     };
     renderWithProviders(
-      <PaneNode
-        layout={layout}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={layout} path={[]} handleEditorChange={vi.fn()} />,
     );
-    expect(screen.getByText(/Open a file to start editing/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Open a file to start editing/),
+    ).toBeInTheDocument();
   });
 
   it("renders the DocHeaderedEditor for a file tab", () => {
     renderWithProviders(
-      <PaneNode
-        layout={leafLayout()}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={leafLayout()} path={[]} handleEditorChange={vi.fn()} />,
     );
     const editor = screen.getByTestId("docheadered-editor");
     expect(editor.dataset.file).toBe("a.md");
@@ -147,11 +140,7 @@ describe("PaneNode", () => {
       activeTab: 0,
     };
     renderWithProviders(
-      <PaneNode
-        layout={layout}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={layout} path={[]} handleEditorChange={vi.fn()} />,
     );
     expect(screen.getByTestId("diff-viewer")).toBeInTheDocument();
     expect(screen.queryByTestId("docheadered-editor")).not.toBeInTheDocument();
@@ -160,30 +149,25 @@ describe("PaneNode", () => {
   it("delegates non-leaf layouts to SplitView", () => {
     const layout: PaneLayout = {
       type: "split",
-      id: "root",
       direction: "horizontal",
       ratio: 0.5,
-      first: { type: "leaf", id: "p1", tabs: [], activeTab: 0 },
-      second: { type: "leaf", id: "p2", tabs: [], activeTab: 0 },
+      children: [
+        { type: "leaf", id: "p1", tabs: [], activeTab: 0 },
+        { type: "leaf", id: "p2", tabs: [], activeTab: 0 },
+      ],
     };
     renderWithProviders(
-      <PaneNode
-        layout={layout}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={layout} path={[]} handleEditorChange={vi.fn()} />,
     );
     expect(screen.getByTestId("split-view")).toBeInTheDocument();
-    expect(screen.getByTestId("split-view").dataset.id).toBe("root");
+    expect(screen.getByTestId("split-view").dataset.direction).toBe(
+      "horizontal",
+    );
   });
 
   it("renders the TabBar with the leaf's tab count", () => {
     renderWithProviders(
-      <PaneNode
-        layout={leafLayout()}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={leafLayout()} path={[]} handleEditorChange={vi.fn()} />,
     );
     expect(screen.getByTestId("tab-bar").dataset.count).toBe("1");
   });
@@ -193,11 +177,7 @@ describe("PaneNode", () => {
     // assert the mount path opens the editor at all (the file content
     // is in the editorContents Map keyed by filePath).
     renderWithProviders(
-      <PaneNode
-        layout={leafLayout()}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={leafLayout()} path={[]} handleEditorChange={vi.fn()} />,
     );
     expect(screen.getByTestId("docheadered-editor")).toBeInTheDocument();
   });
@@ -217,11 +197,7 @@ describe("PaneNode", () => {
       closeAll,
     } as never);
     renderWithProviders(
-      <PaneNode
-        layout={leafLayout()}
-        path={[]}
-        handleEditorChange={vi.fn()}
-      />,
+      <PaneNode layout={leafLayout()} path={[]} handleEditorChange={vi.fn()} />,
     );
     screen.getByTestId("select-tab").click();
     screen.getByTestId("close-tab").click();

--- a/httui-desktop/src/components/layout/schema/__tests__/SchemaPanel.test.tsx
+++ b/httui-desktop/src/components/layout/schema/__tests__/SchemaPanel.test.tsx
@@ -100,9 +100,7 @@ describe("SchemaPanel — connection auto-pick", () => {
     renderWithProviders(<SchemaPanel width={300} onClose={() => {}} />);
     // Wait for the effect to land. The native select shows one
     // <option> per connection; the picked one becomes the value.
-    const select = (await screen.findByRole(
-      "combobox",
-    )) as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
     await vi.waitFor(() => {
       expect(select.value).toBe("id-alpha");
     });
@@ -126,9 +124,7 @@ describe("SchemaPanel — connection auto-pick", () => {
       ].join("\n"),
     );
     renderWithProviders(<SchemaPanel width={300} onClose={() => {}} />);
-    const select = (await screen.findByRole(
-      "combobox",
-    )) as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
     await vi.waitFor(() => {
       // The most-recent block specifies `payments-db`; expect that
       // connection's id to be selected, not the first list entry.
@@ -143,9 +139,7 @@ describe("SchemaPanel — connection auto-pick", () => {
       "```db-postgres connection=ghost-db\nselect 1\n```\n",
     );
     renderWithProviders(<SchemaPanel width={300} onClose={() => {}} />);
-    const select = (await screen.findByRole(
-      "combobox",
-    )) as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
     await vi.waitFor(() => {
       // ghost-db isn't in the connections list → fallback is the
       // first one, alpha-db.
@@ -158,7 +152,9 @@ describe("SchemaPanel — connection auto-pick", () => {
     setActiveFile("file.md", "body\n");
     renderWithProviders(<SchemaPanel width={300} onClose={() => {}} />);
     // No throw, the panel chrome still renders.
-    expect(await screen.findByLabelText("Close schema panel")).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText("Close schema panel"),
+    ).toBeInTheDocument();
   });
 
   it("close button fires onClose", async () => {
@@ -175,9 +171,7 @@ describe("SchemaPanel — connection auto-pick", () => {
     mockTauriCommand("list_connections", () => fakeConnections);
     setActiveFile("file.md", "body\n");
     renderWithProviders(<SchemaPanel width={300} onClose={() => {}} />);
-    const select = (await screen.findByRole(
-      "combobox",
-    )) as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
     await vi.waitFor(() => {
       expect(select.value).toBe("id-alpha");
     });
@@ -199,9 +193,7 @@ describe("SchemaPanel — connection auto-pick", () => {
       expect(invokeCount).toBeGreaterThanOrEqual(1);
     });
     // Hint matches a connection in the list → that's the active value.
-    const select = (await screen.findByRole(
-      "combobox",
-    )) as HTMLSelectElement;
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
     await vi.waitFor(() => {
       expect(select.value).toBe("id-payments");
     });

--- a/httui-desktop/src/components/layout/settings/ColorModePicker.tsx
+++ b/httui-desktop/src/components/layout/settings/ColorModePicker.tsx
@@ -30,8 +30,8 @@ export function ColorModePicker() {
         Color mode
       </Text>
       <Text fontSize="xs" color="fg.muted">
-        Switch between Fuji at dusk (dark) and Fuji photo (light), or
-        follow the OS preference.
+        Switch between Fuji at dusk (dark) and Fuji photo (light), or follow the
+        OS preference.
       </Text>
       <HStack
         role="radiogroup"

--- a/httui-desktop/src/components/layout/settings/GeneralSection.tsx
+++ b/httui-desktop/src/components/layout/settings/GeneralSection.tsx
@@ -106,9 +106,7 @@ export function GeneralSection() {
           <Switch
             aria-label="Include pre-releases"
             checked={autoUpdateIncludePrereleases}
-            onCheckedChange={(d) =>
-              setAutoUpdateIncludePrereleases(d.checked)
-            }
+            onCheckedChange={(d) => setAutoUpdateIncludePrereleases(d.checked)}
             size="sm"
           />
         </Flex>

--- a/httui-desktop/src/components/layout/settings/__tests__/GeneralSection.test.tsx
+++ b/httui-desktop/src/components/layout/settings/__tests__/GeneralSection.test.tsx
@@ -82,9 +82,7 @@ describe("GeneralSection", () => {
       loaded: true,
     });
     renderWithWorkspace(<GeneralSection />);
-    expect(
-      screen.getByText(/Auto-save is disabled\./i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Auto-save is disabled\./i)).toBeInTheDocument();
   });
 
   it("does not show the autosave-disabled banner when interval is positive", () => {
@@ -139,9 +137,7 @@ describe("GeneralSection", () => {
     renderWithWorkspace(<GeneralSection />);
     const sw = screen.getByRole("checkbox", { name: "Include pre-releases" });
     await userEvent.setup().click(sw);
-    expect(
-      useSettingsStore.getState().autoUpdateIncludePrereleases,
-    ).toBe(true);
+    expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(true);
   });
 
   it("renders 'None' when no vault is active", () => {

--- a/httui-desktop/src/components/layout/share/__tests__/SharePopover.test.tsx
+++ b/httui-desktop/src/components/layout/share/__tests__/SharePopover.test.tsx
@@ -43,9 +43,7 @@ describe("SharePopover", () => {
   });
 
   it("renders the URL of the only remote when there's exactly one", () => {
-    renderWithProviders(
-      <SharePopover remotes={[ORIGIN]} onCopy={() => {}} />,
-    );
+    renderWithProviders(<SharePopover remotes={[ORIGIN]} onCopy={() => {}} />);
     const url = screen.getByTestId("share-popover-url");
     expect(url.textContent).toBe(ORIGIN.url);
     // No remote picker shown for a single remote.
@@ -56,12 +54,8 @@ describe("SharePopover", () => {
 
   it("fires onCopy with the active URL on Copy click", async () => {
     const onCopy = vi.fn();
-    renderWithProviders(
-      <SharePopover remotes={[ORIGIN]} onCopy={onCopy} />,
-    );
-    await userEvent
-      .setup()
-      .click(screen.getByTestId("share-popover-copy"));
+    renderWithProviders(<SharePopover remotes={[ORIGIN]} onCopy={onCopy} />);
+    await userEvent.setup().click(screen.getByTestId("share-popover-copy"));
     expect(onCopy).toHaveBeenCalledWith(ORIGIN.url);
   });
 
@@ -107,7 +101,9 @@ describe("SharePopover", () => {
       <SharePopover remotes={[ORIGIN, UPSTREAM]} onCopy={onCopy} />,
     );
     const user = userEvent.setup();
-    await user.click(screen.getByTestId(`share-popover-remote-${UPSTREAM.name}`));
+    await user.click(
+      screen.getByTestId(`share-popover-remote-${UPSTREAM.name}`),
+    );
     expect(screen.getByTestId("share-popover-url").textContent).toBe(
       UPSTREAM.url,
     );
@@ -120,9 +116,7 @@ describe("SharePopover", () => {
       <SharePopover remotes={[ORIGIN, UPSTREAM]} onCopy={() => {}} />,
     );
     expect(
-      screen
-        .getByTestId("share-popover")
-        .getAttribute("data-remote-count"),
+      screen.getByTestId("share-popover").getAttribute("data-remote-count"),
     ).toBe("2");
   });
 
@@ -158,9 +152,7 @@ describe("SharePopover", () => {
     });
 
     it("never shows Open when onOpen is absent", () => {
-      renderWithProviders(
-        <SharePopover remotes={[WEB]} onCopy={() => {}} />,
-      );
+      renderWithProviders(<SharePopover remotes={[WEB]} onCopy={() => {}} />);
       expect(
         screen.queryByTestId("share-popover-open"),
       ).not.toBeInTheDocument();

--- a/httui-desktop/src/components/layout/topbar/Brand.tsx
+++ b/httui-desktop/src/components/layout/topbar/Brand.tsx
@@ -29,14 +29,7 @@ export function Brand() {
           flexShrink: 0,
         }}
       />
-      <Box
-        aria-hidden
-        h="18px"
-        w="1px"
-        bg="border"
-        ml={2}
-        flexShrink={0}
-      />
+      <Box aria-hidden h="18px" w="1px" bg="border" ml={2} flexShrink={0} />
     </HStack>
   );
 }

--- a/httui-desktop/src/components/layout/topbar/__tests__/SegmentedEnvSwitcher.test.tsx
+++ b/httui-desktop/src/components/layout/topbar/__tests__/SegmentedEnvSwitcher.test.tsx
@@ -97,14 +97,20 @@ describe("SegmentedEnvSwitcher", () => {
 
   it("renders a Dot variant=err on environments whose name starts with 'prod'", () => {
     useEnvironmentStore.setState({
-      environments: [mkEnv("a", "local"), mkEnv("b", "prod"), mkEnv("c", "prod-canary")],
+      environments: [
+        mkEnv("a", "local"),
+        mkEnv("b", "prod"),
+        mkEnv("c", "prod-canary"),
+      ],
       activeEnvironment: mkEnv("a", "local"),
       switchEnvironment: switchSpy,
     } as never);
 
     const { container } = renderWithProviders(<SegmentedEnvSwitcher />);
     // 2 prod-prefixed envs → 2 err dots inside the prod cells
-    const errDots = container.querySelectorAll('[data-atom="dot"][data-variant="err"]');
+    const errDots = container.querySelectorAll(
+      '[data-atom="dot"][data-variant="err"]',
+    );
     expect(errDots.length).toBe(2);
   });
 });

--- a/httui-desktop/src/components/layout/topbar/__tests__/WorkspaceMenu.test.tsx
+++ b/httui-desktop/src/components/layout/topbar/__tests__/WorkspaceMenu.test.tsx
@@ -56,9 +56,7 @@ describe("WorkspaceMenu", () => {
     );
 
     const items = screen.getAllByRole("menuitem");
-    const active = items.find(
-      (i) => i.getAttribute("data-active") === "true",
-    );
+    const active = items.find((i) => i.getAttribute("data-active") === "true");
     expect(active?.getAttribute("data-vault-path")).toBe(
       "/Users/me/secret-test",
     );
@@ -67,9 +65,7 @@ describe("WorkspaceMenu", () => {
   it("clicking another vault calls onSwitch with its path", async () => {
     const user = userEvent.setup();
     const onSwitch = vi.fn();
-    renderWithProviders(
-      <WorkspaceMenu {...baseProps} onSwitch={onSwitch} />,
-    );
+    renderWithProviders(<WorkspaceMenu {...baseProps} onSwitch={onSwitch} />);
 
     await user.click(
       screen.getByRole("button", { name: /Workspace secret-test/ }),
@@ -121,9 +117,9 @@ describe("WorkspaceMenu", () => {
     expect(screen.getByText("Abrir outro vault…")).toBeInTheDocument();
     // No data-vault-path items
     expect(
-      screen.queryAllByRole("menuitem").filter(
-        (i) => !!i.getAttribute("data-vault-path"),
-      ),
+      screen
+        .queryAllByRole("menuitem")
+        .filter((i) => !!i.getAttribute("data-vault-path")),
     ).toHaveLength(0);
   });
 });

--- a/httui-desktop/src/components/layout/variables/NewVariableForm.tsx
+++ b/httui-desktop/src/components/layout/variables/NewVariableForm.tsx
@@ -57,11 +57,7 @@ export function NewVariableForm({
   }
 
   return (
-    <Box
-      data-testid="new-variable-form"
-      mx={5}
-      my={2}
-    >
+    <Box data-testid="new-variable-form" mx={5} my={2}>
       <Flex
         align="stretch"
         borderWidth="1px"
@@ -92,11 +88,7 @@ export function NewVariableForm({
             }}
           />
         </Box>
-        <Box
-          w="1px"
-          bg="border"
-          flexShrink={0}
-        />
+        <Box w="1px" bg="border" flexShrink={0} />
         <Box flex={1} minW={0}>
           <Input
             data-testid="new-variable-value"
@@ -183,7 +175,11 @@ export function NewVariableForm({
               {validation.reason}
             </Text>
           ) : (
-            <Text fontSize="11px" color="fg.subtle" data-testid="new-variable-hint">
+            <Text
+              fontSize="11px"
+              color="fg.subtle"
+              data-testid="new-variable-hint"
+            >
               landing in env{" "}
               <Text as="span" fontFamily="mono" color="fg.muted">
                 {activeEnv}

--- a/httui-desktop/src/components/layout/variables/TemporaryChip.tsx
+++ b/httui-desktop/src/components/layout/variables/TemporaryChip.tsx
@@ -5,7 +5,7 @@
 // `onClear` is supplied the chip becomes a button that drops the
 // override on click.
 
-import { Box } from "@chakra-ui/react";
+import { chakra } from "@chakra-ui/react";
 
 export interface TemporaryChipProps {
   /** Click handler to clear the override. When omitted the chip is purely informational. */
@@ -19,9 +19,9 @@ export function TemporaryChip({
   label = "TEMPORARY",
 }: TemporaryChipProps) {
   const interactive = !!onClear;
+  const Comp = interactive ? chakra.button : chakra.span;
   return (
-    <Box
-      as={interactive ? "button" : "span"}
+    <Comp
       type={interactive ? "button" : undefined}
       data-testid="temporary-chip"
       data-interactive={interactive || undefined}
@@ -41,6 +41,6 @@ export function TemporaryChip({
       _hover={interactive ? { opacity: 0.85 } : undefined}
     >
       {label}
-    </Box>
+    </Comp>
   );
 }

--- a/httui-desktop/src/components/layout/variables/UsedInBlocksList.tsx
+++ b/httui-desktop/src/components/layout/variables/UsedInBlocksList.tsx
@@ -4,7 +4,7 @@
 // `error`) and groups by file. Click a hit fires `onJump(filePath,
 // line)` so the consumer can open the file at the right line.
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, chakra } from "@chakra-ui/react";
 
 import type { VarUseEntry } from "@/lib/tauri/var-uses";
 
@@ -118,13 +118,14 @@ function Hit({
   onJump?: (filePath: string, line: number) => void;
 }) {
   const interactive = !!onJump;
+  const Comp = interactive ? chakra.button : chakra.div;
   return (
-    <Flex
-      as={interactive ? "button" : "div"}
+    <Comp
       type={interactive ? "button" : undefined}
       data-testid={`used-in-blocks-hit-${filePath}:${line}`}
       onClick={interactive ? () => onJump?.(filePath, line) : undefined}
-      align="baseline"
+      display="flex"
+      alignItems="baseline"
       gap={2}
       px={4}
       py={1}
@@ -156,6 +157,6 @@ function Hit({
       >
         {snippet}
       </Text>
-    </Flex>
+    </Comp>
   );
 }

--- a/httui-desktop/src/components/layout/variables/VariableValueRow.tsx
+++ b/httui-desktop/src/components/layout/variables/VariableValueRow.tsx
@@ -272,7 +272,12 @@ function ValueDisplay({
 
   if (reveal.kind === "loading") {
     return (
-      <Text fontFamily="mono" fontSize="11px" color="fg.subtle" data-testid={testId}>
+      <Text
+        fontFamily="mono"
+        fontSize="11px"
+        color="fg.subtle"
+        data-testid={testId}
+      >
         loading…
       </Text>
     );
@@ -292,7 +297,12 @@ function ValueDisplay({
   }
   if (isSecret && reveal.kind !== "revealed") {
     return (
-      <Text fontFamily="mono" fontSize="11px" color="fg.muted" data-testid={testId}>
+      <Text
+        fontFamily="mono"
+        fontSize="11px"
+        color="fg.muted"
+        data-testid={testId}
+      >
         {SECRET_MASK}
       </Text>
     );
@@ -317,7 +327,12 @@ function ValueDisplay({
   }
   if (value === undefined) {
     return (
-      <Text fontFamily="mono" fontSize="11px" color="fg.subtle" data-testid={testId}>
+      <Text
+        fontFamily="mono"
+        fontSize="11px"
+        color="fg.subtle"
+        data-testid={testId}
+      >
         —
       </Text>
     );

--- a/httui-desktop/src/components/layout/variables/VariablesDetailPanel.tsx
+++ b/httui-desktop/src/components/layout/variables/VariablesDetailPanel.tsx
@@ -59,9 +59,14 @@ function EmptyState() {
       <Text fontFamily="serif" fontSize="16px" color="fg.muted">
         Select a variable
       </Text>
-      <Text fontSize="11px" color="fg.subtle" textAlign="center" lineHeight={1.5}>
-        Click a row on the left to view and edit the value per env,
-        configure a session override, and list the blocks that use it.
+      <Text
+        fontSize="11px"
+        color="fg.subtle"
+        textAlign="center"
+        lineHeight={1.5}
+      >
+        Click a row on the left to view and edit the value per env, configure a
+        session override, and list the blocks that use it.
       </Text>
     </Flex>
   );

--- a/httui-desktop/src/components/layout/variables/VariablesPageContainer.tsx
+++ b/httui-desktop/src/components/layout/variables/VariablesPageContainer.tsx
@@ -191,7 +191,7 @@ export function VariablesPageContainer({
 
   const selectedRow = useMemo(
     () =>
-      selectedKey ? rows.find((r) => r.key === selectedKey) ?? null : null,
+      selectedKey ? (rows.find((r) => r.key === selectedKey) ?? null) : null,
     [selectedKey, rows],
   );
 
@@ -226,13 +226,17 @@ export function VariablesPageContainer({
         ? `Move "${selectedRow.key}" to the keychain? Value(s) will be removed from envs/*.toml.`
         : `Remove "${selectedRow.key}" from the keychain? Value(s) will be written as plaintext to envs/*.toml.`;
       if (!window.confirm(message)) return;
-      for (const [envName, currentValue] of Object.entries(selectedRow.values)) {
+      for (const [envName, currentValue] of Object.entries(
+        selectedRow.values,
+      )) {
         if (currentValue === undefined) continue;
         const e = envByName.get(envName);
         if (!e) continue;
         let valueToWrite = currentValue;
         if (selectedRow.isSecret && !next) {
-          const resolved = await resolveEnvVariables(e.id).catch(() => ({}));
+          const resolved = await resolveEnvVariables(e.id).catch(
+            (): Record<string, string> => ({}),
+          );
           valueToWrite = resolved[selectedRow.key] ?? "";
         }
         await setVariable(e.id, selectedRow.key, valueToWrite, next);
@@ -305,9 +309,7 @@ export function VariablesPageContainer({
       rows={rows}
       selectedKey={selectedKey}
       onSelectKey={handleSelectKey}
-      onCreateNew={
-        activeEnvironment ? () => setCreating(true) : undefined
-      }
+      onCreateNew={activeEnvironment ? () => setCreating(true) : undefined}
       detailSlot={detailSlot}
       inlineFormSlot={inlineFormSlot}
     />

--- a/httui-desktop/src/components/layout/variables/__tests__/NewVariablePopover.test.tsx
+++ b/httui-desktop/src/components/layout/variables/__tests__/NewVariablePopover.test.tsx
@@ -135,9 +135,7 @@ describe("NewVariablePopover", () => {
     openPopover();
     expect(screen.getByTestId("new-variable-popover")).toBeInTheDocument();
     await new Promise((r) => setTimeout(r, 5));
-    document.body.dispatchEvent(
-      new MouseEvent("mousedown", { bubbles: true }),
-    );
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     await vi.waitFor(() =>
       expect(useNewVariablePopoverStore.getState().open).toBe(false),
     );

--- a/httui-desktop/src/components/layout/variables/__tests__/VariableDetailHeader.test.tsx
+++ b/httui-desktop/src/components/layout/variables/__tests__/VariableDetailHeader.test.tsx
@@ -23,9 +23,7 @@ describe("VariableDetailHeader", () => {
     );
     // Lucide renders the icon as an inline SVG inside the slot.
     expect(
-      screen
-        .getByTestId("variable-detail-header-glyph")
-        .querySelector("svg"),
+      screen.getByTestId("variable-detail-header-glyph").querySelector("svg"),
     ).not.toBeNull();
   });
 

--- a/httui-desktop/src/components/layout/variables/__tests__/VariablesPageContainer.test.tsx
+++ b/httui-desktop/src/components/layout/variables/__tests__/VariablesPageContainer.test.tsx
@@ -16,7 +16,6 @@ const env = (over: Partial<Environment> = {}): Environment => ({
   description: null,
   is_active: false,
   created_at: "",
-  updated_at: "",
   ...over,
 });
 
@@ -38,7 +37,12 @@ describe("mergeCrossEnvVariables", () => {
       {
         env: local,
         vars: [
-          v({ id: "v1", environment_id: local.id, key: "API_BASE", value: "x" }),
+          v({
+            id: "v1",
+            environment_id: local.id,
+            key: "API_BASE",
+            value: "x",
+          }),
           v({ id: "v2", environment_id: local.id, key: "DB_URL", value: "y" }),
         ],
       },
@@ -69,7 +73,12 @@ describe("mergeCrossEnvVariables", () => {
       {
         env: prod,
         vars: [
-          v({ key: "TOKEN", environment_id: prod.id, value: "", is_secret: true }),
+          v({
+            key: "TOKEN",
+            environment_id: prod.id,
+            value: "",
+            is_secret: true,
+          }),
         ],
       },
     ]);
@@ -243,9 +252,7 @@ describe("VariablesPageContainer", () => {
       );
       return v({ id: "v-new" });
     });
-    const confirmSpy = vi
-      .spyOn(window, "confirm")
-      .mockReturnValue(true);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     renderWithProviders(<VariablesPageContainer />);
     const user = userEvent.setup();
@@ -272,9 +279,7 @@ describe("VariablesPageContainer", () => {
       setVarCalls += 1;
       return v({ id: "v-new" });
     });
-    const confirmSpy = vi
-      .spyOn(window, "confirm")
-      .mockReturnValue(false);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
 
     renderWithProviders(<VariablesPageContainer />);
     const user = userEvent.setup();

--- a/httui-desktop/src/components/layout/variables/__tests__/VariablesScopesSidebar.test.tsx
+++ b/httui-desktop/src/components/layout/variables/__tests__/VariablesScopesSidebar.test.tsx
@@ -37,9 +37,7 @@ describe("VariablesScopesSidebar", () => {
         .getAttribute("data-selected"),
     ).toBe("true");
     expect(
-      screen
-        .getByTestId("variables-scope-all")
-        .getAttribute("data-selected"),
+      screen.getByTestId("variables-scope-all").getAttribute("data-selected"),
     ).toBe("false");
     expect(screen.getByTestId("variables-scope-all-count").textContent).toBe(
       "8",

--- a/httui-desktop/src/components/search/__tests__/QuickOpen.test.tsx
+++ b/httui-desktop/src/components/search/__tests__/QuickOpen.test.tsx
@@ -56,7 +56,9 @@ describe("QuickOpen", () => {
 
   it("renders the search input when open", () => {
     renderWithWorkspace(<QuickOpen open onClose={vi.fn()} />);
-    expect(screen.getByPlaceholderText("Buscar arquivo… ou #tag")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Buscar arquivo… ou #tag"),
+    ).toBeInTheDocument();
   });
 
   it('shows "Nenhum resultado" when query has no matches', () => {
@@ -107,7 +109,10 @@ describe("QuickOpen", () => {
   it("typing in the input dispatches handleSearch", async () => {
     const user = userEvent.setup();
     renderWithWorkspace(<QuickOpen open onClose={vi.fn()} />);
-    await user.type(screen.getByPlaceholderText("Buscar arquivo… ou #tag"), "lo");
+    await user.type(
+      screen.getByPlaceholderText("Buscar arquivo… ou #tag"),
+      "lo",
+    );
     expect(mockState.handleSearch).toHaveBeenCalled();
   });
 });

--- a/httui-desktop/src/hooks/__tests__/useEditorSession.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useEditorSession.test.ts
@@ -370,13 +370,13 @@ describe("useEditorSession", () => {
         layout: {
           type: "leaf",
           id: "p1",
-          tabs: [{ filePath: "rb.md", vaultPath: VAULT, kind: "file" } as never],
+          tabs: [
+            { filePath: "rb.md", vaultPath: VAULT, kind: "file" } as never,
+          ],
           activeTab: 0,
         } as never,
         activePaneId: "p1",
-        editorContents: new Map([
-          ["rb.md", "---\ntags: [solo]\n---\nbody\n"],
-        ]),
+        editorContents: new Map([["rb.md", "---\ntags: [solo]\n---\nbody\n"]]),
         unsavedFiles: new Set(["rb.md"]),
       } as never);
       useTagIndexStore.getState().clearAll();

--- a/httui-desktop/src/hooks/__tests__/useFileAutoCapture.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFileAutoCapture.test.ts
@@ -14,9 +14,7 @@ afterEach(() => {
 
 describe("useFileAutoCapture", () => {
   it("idles when vaultPath is null", async () => {
-    const { result } = renderHook(() =>
-      useFileAutoCapture(null, "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture(null, "rollout.md"));
     await act(async () => {
       await Promise.resolve();
     });
@@ -36,9 +34,7 @@ describe("useFileAutoCapture", () => {
   it("populates auto_capture after the initial poll", async () => {
     mockTauriCommand("get_file_settings", () => ({ auto_capture: true }));
 
-    const { result } = renderHook(() =>
-      useFileAutoCapture("/v", "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture("/v", "rollout.md"));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -53,9 +49,7 @@ describe("useFileAutoCapture", () => {
       throw new Error("io error");
     });
 
-    const { result } = renderHook(() =>
-      useFileAutoCapture("/v", "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture("/v", "rollout.md"));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -71,13 +65,13 @@ describe("useFileAutoCapture", () => {
     const setCalls: { autoCapture: boolean }[] = [];
     mockTauriCommand("set_file_auto_capture", (args) => {
       setCalls.push(args as { autoCapture: boolean });
-      nextSettings = { auto_capture: Boolean((args as { autoCapture: boolean }).autoCapture) };
+      nextSettings = {
+        auto_capture: Boolean((args as { autoCapture: boolean }).autoCapture),
+      };
       return null;
     });
 
-    const { result } = renderHook(() =>
-      useFileAutoCapture("/v", "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture("/v", "rollout.md"));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -99,9 +93,7 @@ describe("useFileAutoCapture", () => {
       throw new Error("disk full");
     });
 
-    const { result } = renderHook(() =>
-      useFileAutoCapture("/v", "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture("/v", "rollout.md"));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -127,9 +119,7 @@ describe("useFileAutoCapture", () => {
       return null;
     });
 
-    const { result } = renderHook(() =>
-      useFileAutoCapture(null, "rollout.md"),
-    );
+    const { result } = renderHook(() => useFileAutoCapture(null, "rollout.md"));
     await act(async () => {
       await Promise.resolve();
     });

--- a/httui-desktop/src/hooks/__tests__/useFileCapturesHydrate.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFileCapturesHydrate.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";

--- a/httui-desktop/src/hooks/__tests__/useFileCapturesPersistence.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFileCapturesPersistence.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
@@ -182,9 +175,7 @@ describe("useFileCapturesPersistence", () => {
       return true;
     });
 
-    const { result } = renderHook(() =>
-      useFileCapturesPersistence(null, FILE),
-    );
+    const { result } = renderHook(() => useFileCapturesPersistence(null, FILE));
     // Inner is idle when vault is null — no Tauri calls fired.
     await act(async () => {
       await result.current.setAutoCapture(true);

--- a/httui-desktop/src/hooks/__tests__/useFileFirstAuthor.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFileFirstAuthor.test.ts
@@ -1,10 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
@@ -25,9 +19,7 @@ afterEach(() => clearTauriMocks());
 
 describe("useFileFirstAuthor", () => {
   it("idles when vaultPath is null", async () => {
-    const { result } = renderHook(() =>
-      useFileFirstAuthor(null, "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor(null, "runbook.md"));
     await act(async () => {
       await Promise.resolve();
     });
@@ -48,9 +40,7 @@ describe("useFileFirstAuthor", () => {
 
   it("populates the author after the initial fetch", async () => {
     mockTauriCommand("git_first_commit_author_cmd", () => ALICE);
-    const { result } = renderHook(() =>
-      useFileFirstAuthor("/v", "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor("/v", "runbook.md"));
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(result.current.author).toEqual(ALICE);
     expect(result.current.error).toBeNull();
@@ -70,9 +60,7 @@ describe("useFileFirstAuthor", () => {
     mockTauriCommand("git_first_commit_author_cmd", () => {
       throw new Error("not a git repo");
     });
-    const { result } = renderHook(() =>
-      useFileFirstAuthor("/v", "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor("/v", "runbook.md"));
     await waitFor(() => expect(result.current.error).toBe("not a git repo"));
     expect(result.current.author).toBeNull();
     expect(result.current.loaded).toBe(false);
@@ -82,18 +70,14 @@ describe("useFileFirstAuthor", () => {
     mockTauriCommand("git_first_commit_author_cmd", () => {
       throw "boom";
     });
-    const { result } = renderHook(() =>
-      useFileFirstAuthor("/v", "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor("/v", "runbook.md"));
     await waitFor(() => expect(result.current.error).toBe("boom"));
   });
 
   it("refresh re-fetches and replaces stale data", async () => {
     let next: CommitInfo | null = ALICE;
     mockTauriCommand("git_first_commit_author_cmd", () => next);
-    const { result } = renderHook(() =>
-      useFileFirstAuthor("/v", "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor("/v", "runbook.md"));
     await waitFor(() => expect(result.current.author).toEqual(ALICE));
 
     next = null;
@@ -125,9 +109,7 @@ describe("useFileFirstAuthor", () => {
       if (mode === "throw") throw new Error("transient");
       return ALICE;
     });
-    const { result } = renderHook(() =>
-      useFileFirstAuthor("/v", "runbook.md"),
-    );
+    const { result } = renderHook(() => useFileFirstAuthor("/v", "runbook.md"));
     await waitFor(() => expect(result.current.error).toBe("transient"));
 
     mode = "ok";

--- a/httui-desktop/src/hooks/__tests__/useFilePreflight.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFilePreflight.test.ts
@@ -171,7 +171,11 @@ describe("useFilePreflight", () => {
       { kind: "connection", label: "payments-db", result: { outcome: "pass" } },
       { kind: "env_var", label: "API_TOKEN", result: { outcome: "pass" } },
       { kind: "branch", label: "main", result: { outcome: "pass" } },
-      { kind: "unknown", label: "future", result: { outcome: "skip", reason: "x" } },
+      {
+        kind: "unknown",
+        label: "future",
+        result: { outcome: "skip", reason: "x" },
+      },
     ];
     mockTauriCommand("evaluate_preflight_cmd", () => raw);
 

--- a/httui-desktop/src/hooks/__tests__/useFileSearch.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useFileSearch.test.ts
@@ -338,8 +338,9 @@ describe("useFileSearch", () => {
         `${VAULT}/runbooks/refund.md`,
       ]);
       // `name` is the leaf without `.md` for cleaner display.
-      expect(result.current.results.find((r) => r.path.endsWith("billing.md"))?.name)
-        .toBe("billing");
+      expect(
+        result.current.results.find((r) => r.path.endsWith("billing.md"))?.name,
+      ).toBe("billing");
     });
 
     it("`#missing` returns empty without hitting search_files", async () => {
@@ -370,9 +371,7 @@ describe("useFileSearch", () => {
     });
 
     it("`#a AND #b` intersects the two tag sets", async () => {
-      useTagIndexStore
-        .getState()
-        .setTagsForFile(`${VAULT}/x.md`, ["a", "b"]);
+      useTagIndexStore.getState().setTagsForFile(`${VAULT}/x.md`, ["a", "b"]);
       useTagIndexStore.getState().setTagsForFile(`${VAULT}/y.md`, ["a"]);
       useTagIndexStore.getState().setTagsForFile(`${VAULT}/z.md`, ["b"]);
       mockTauriCommand("search_files", () => []);
@@ -425,9 +424,7 @@ describe("useFileSearch", () => {
     });
 
     it("tag mode works without a vaultPath (store is vault-agnostic)", async () => {
-      useTagIndexStore
-        .getState()
-        .setTagsForFile("/elsewhere/note.md", ["api"]);
+      useTagIndexStore.getState().setTagsForFile("/elsewhere/note.md", ["api"]);
       mockTauriCommand("search_files", () => []);
 
       const { result } = renderHook(() =>

--- a/httui-desktop/src/hooks/__tests__/useGitBranchActions.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useGitBranchActions.test.ts
@@ -42,9 +42,7 @@ describe("useGitBranchActions", () => {
   it("loads branches on demand", async () => {
     const { result } = renderHook(() => useGitBranchActions("/v"));
     act(() => result.current.loadBranches());
-    await waitFor(() =>
-      expect(result.current.branches).toHaveLength(3),
-    );
+    await waitFor(() => expect(result.current.branches).toHaveLength(3));
     expect(result.current.error).toBeNull();
   });
 
@@ -54,9 +52,7 @@ describe("useGitBranchActions", () => {
     });
     const { result } = renderHook(() => useGitBranchActions("/v"));
     act(() => result.current.loadBranches());
-    await waitFor(() =>
-      expect(result.current.error).toBe("not a git repo"),
-    );
+    await waitFor(() => expect(result.current.error).toBe("not a git repo"));
     expect(result.current.branches).toEqual([]);
   });
 

--- a/httui-desktop/src/hooks/__tests__/useGitConflictResolve.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useGitConflictResolve.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";

--- a/httui-desktop/src/hooks/__tests__/useGitSync.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useGitSync.test.ts
@@ -4,8 +4,9 @@ import { renderHook, act } from "@testing-library/react";
 import { clearTauriMocks, mockTauriCommand } from "@/test/mocks/tauri";
 import { resetGitStore, useGitStore } from "@/stores/git";
 import { useGitSync } from "@/hooks/useGitSync";
+import type { GitStatus } from "@/lib/tauri/git";
 
-const CLEAN = {
+const CLEAN: GitStatus = {
   branch: "main",
   upstream: "origin/main",
   ahead: 0,

--- a/httui-desktop/src/hooks/__tests__/useRunAllPreflightGate.test.tsx
+++ b/httui-desktop/src/hooks/__tests__/useRunAllPreflightGate.test.tsx
@@ -31,7 +31,11 @@ function skip(idx = 0): PreflightPillItem {
 
 interface HostProps {
   items: PreflightPillItem[];
-  onRunAll: (...args: Parameters<Parameters<typeof useRunAllPreflightGate>[0]["onRunAll"]>) => void;
+  onRunAll: (
+    ...args: Parameters<
+      Parameters<typeof useRunAllPreflightGate>[0]["onRunAll"]
+    >
+  ) => void;
   initialOverride?: boolean;
 }
 
@@ -129,11 +133,7 @@ describe("useRunAllPreflightGate", () => {
     const user = userEvent.setup();
     const onRunAll = vi.fn();
     renderWithProviders(
-      <HostWithButton
-        items={[fail(0)]}
-        onRunAll={onRunAll}
-        initialOverride
-      />,
+      <HostWithButton items={[fail(0)]} onRunAll={onRunAll} initialOverride />,
     );
     await user.click(screen.getByTestId("host-trigger"));
     expect(
@@ -153,9 +153,7 @@ describe("useRunAllPreflightGate", () => {
       />,
     );
     await user.click(screen.getByTestId("host-trigger"));
-    const note = screen.getByTestId(
-      "preflight-run-all-confirm-skipped",
-    );
+    const note = screen.getByTestId("preflight-run-all-confirm-skipped");
     expect(note.textContent).toMatch(/2 pre-flight checks skipped/);
   });
 
@@ -166,9 +164,7 @@ describe("useRunAllPreflightGate", () => {
       <HostWithButton items={[fail(0)]} onRunAll={onRunAll} />,
     );
     await user.click(screen.getByTestId("host-trigger"));
-    await user.click(
-      screen.getByTestId("preflight-run-all-confirm-overlay"),
-    );
+    await user.click(screen.getByTestId("preflight-run-all-confirm-overlay"));
     expect(
       screen.queryByTestId("preflight-run-all-confirm"),
     ).not.toBeInTheDocument();

--- a/httui-desktop/src/hooks/__tests__/useShareRepoUrl.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useShareRepoUrl.test.ts
@@ -33,9 +33,7 @@ describe("useShareRepoUrl", () => {
       { name: "origin", url: "git@github.com:acme/widgets.git" },
     ]);
     const { result } = renderHook(() => useShareRepoUrl("/v"));
-    await waitFor(() =>
-      expect(result.current.options).toHaveLength(3),
-    );
+    await waitFor(() => expect(result.current.options).toHaveLength(3));
     const byName = Object.fromEntries(
       result.current.options.map((o) => [o.name, o]),
     );
@@ -67,9 +65,7 @@ describe("useShareRepoUrl", () => {
     // The hook lazy-imports the shell plugin, so the call lands on
     // a microtask — wait for it.
     await waitFor(() =>
-      expect(shellOpen).toHaveBeenCalledWith(
-        "https://github.com/acme/widgets",
-      ),
+      expect(shellOpen).toHaveBeenCalledWith("https://github.com/acme/widgets"),
     );
   });
 });

--- a/httui-desktop/src/hooks/__tests__/useTemplates.test.ts
+++ b/httui-desktop/src/hooks/__tests__/useTemplates.test.ts
@@ -1,10 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";

--- a/httui-desktop/src/hooks/useFileAutoCapture.ts
+++ b/httui-desktop/src/hooks/useFileAutoCapture.ts
@@ -11,10 +11,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import {
-  getFileSettings,
-  setFileAutoCapture,
-} from "@/lib/tauri/files";
+import { getFileSettings, setFileAutoCapture } from "@/lib/tauri/files";
 
 export interface UseFileAutoCaptureResult {
   autoCapture: boolean;

--- a/httui-desktop/src/hooks/useFileCapturesPersistence.ts
+++ b/httui-desktop/src/hooks/useFileCapturesPersistence.ts
@@ -43,9 +43,7 @@ export function useFileCapturesPersistence(
       if (!vaultPath || !filePath) return;
       try {
         if (next) {
-          const json = useCaptureStore
-            .getState()
-            .dumpForCacheJson(filePath);
+          const json = useCaptureStore.getState().dumpForCacheJson(filePath);
           if (json !== null) {
             await writeCapturesCache(vaultPath, filePath, json);
           }

--- a/httui-desktop/src/hooks/useFileDocHeaderCompact.ts
+++ b/httui-desktop/src/hooks/useFileDocHeaderCompact.ts
@@ -11,10 +11,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import {
-  getFileSettings,
-  setFileDocheaderCompact,
-} from "@/lib/tauri/files";
+import { getFileSettings, setFileDocheaderCompact } from "@/lib/tauri/files";
 
 export interface UseFileDocHeaderCompactResult {
   compact: boolean;

--- a/httui-desktop/src/hooks/useFilePreflight.ts
+++ b/httui-desktop/src/hooks/useFilePreflight.ts
@@ -89,7 +89,10 @@ export function useFilePreflight({
   return { items, rechecking, recheck: run };
 }
 
-function toPillItem(raw: EvaluatedPreflightItem, idx: number): PreflightPillItem {
+function toPillItem(
+  raw: EvaluatedPreflightItem,
+  idx: number,
+): PreflightPillItem {
   // `unknown` items came from YAML the parser couldn't recognize — they
   // can't round-trip back to a valid `PreflightCheck` so the pill stays
   // read-only (kind/value undefined keeps `canEdit` false in
@@ -100,7 +103,9 @@ function toPillItem(raw: EvaluatedPreflightItem, idx: number): PreflightPillItem
     label: raw.label,
     result: raw.result,
     suggestion: suggestionFor(raw.kind, raw.label),
-    kind: editable ? (raw.kind as Exclude<PreflightItemKind, "unknown">) : undefined,
+    kind: editable
+      ? (raw.kind as Exclude<PreflightItemKind, "unknown">)
+      : undefined,
     value: editable ? raw.label : undefined,
   };
 }

--- a/httui-desktop/src/hooks/useRunAllPreflightGate.tsx
+++ b/httui-desktop/src/hooks/useRunAllPreflightGate.tsx
@@ -91,7 +91,11 @@ interface RunAllConfirmProps {
   onRunAnyway: () => void;
 }
 
-function RunAllConfirm({ decision, onCancel, onRunAnyway }: RunAllConfirmProps) {
+function RunAllConfirm({
+  decision,
+  onCancel,
+  onRunAnyway,
+}: RunAllConfirmProps) {
   return (
     <Portal>
       <Box

--- a/httui-desktop/src/lib/__tests__/active-file-save.test.ts
+++ b/httui-desktop/src/lib/__tests__/active-file-save.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import {
-  setActiveFileSaver,
-  saveActiveFileNow,
-} from "@/lib/active-file-save";
+import { setActiveFileSaver, saveActiveFileNow } from "@/lib/active-file-save";
 
 describe("active-file-save", () => {
   beforeEach(() => {

--- a/httui-desktop/src/lib/avatars/__tests__/md5.test.ts
+++ b/httui-desktop/src/lib/avatars/__tests__/md5.test.ts
@@ -17,9 +17,7 @@ describe("md5", () => {
   });
 
   it("hashes the message-digest ASCII vector", () => {
-    expect(md5("message digest")).toBe(
-      "f96b697d7cb7938d525a2f31aaf161d0",
-    );
+    expect(md5("message digest")).toBe("f96b697d7cb7938d525a2f31aaf161d0");
   });
 
   it("hashes the lowercase alphabet", () => {

--- a/httui-desktop/src/lib/avatars/md5.ts
+++ b/httui-desktop/src/lib/avatars/md5.ts
@@ -193,8 +193,7 @@ function rhex(n: number): string {
   const hex = "0123456789abcdef";
   let s = "";
   for (let i = 0; i < 4; i += 1) {
-    s +=
-      hex[(n >> (i * 8 + 4)) & 0x0f]! + hex[(n >> (i * 8)) & 0x0f]!;
+    s += hex[(n >> (i * 8 + 4)) & 0x0f]! + hex[(n >> (i * 8)) & 0x0f]!;
   }
   return s;
 }

--- a/httui-desktop/src/lib/blocks/__tests__/cm-ref-popover.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/cm-ref-popover.test.ts
@@ -106,7 +106,10 @@ describe("handleRefMousedown", () => {
   it("opens the popover for a valid chip and preventDefaults", () => {
     const span = chip("{{ api_base }}");
     const prevent = vi.fn();
-    const e = { target: span, preventDefault: prevent } as unknown as MouseEvent;
+    const e = {
+      target: span,
+      preventDefault: prevent,
+    } as unknown as MouseEvent;
     const view = fakeView();
     expect(handleRefMousedown(e, view as never)).toBe(true);
     expect(prevent).toHaveBeenCalled();

--- a/httui-desktop/src/lib/blocks/__tests__/doc-db-blocks.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/doc-db-blocks.test.ts
@@ -65,8 +65,7 @@ describe("findDocDbBlocks", () => {
   it("does not match a db fence inside another open fence", () => {
     // ```http opens a fence that "swallows" the inner ```db
     // line. The implementation just waits for the next ``` close.
-    const content =
-      "```http\n```db-postgres connection=swallowed\nq\n```\n";
+    const content = "```http\n```db-postgres connection=swallowed\nq\n```\n";
     const r = findDocDbBlocks(content);
     // The outer http fence closes at the inner ```; nothing emitted.
     expect(r).toHaveLength(0);

--- a/httui-desktop/src/lib/blocks/__tests__/extract-frontmatter-tags.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/extract-frontmatter-tags.test.ts
@@ -39,9 +39,9 @@ describe("extractFrontmatterTags", () => {
   });
 
   it("dedups same-tag-twice within the file", () => {
-    expect(
-      extractFrontmatterTags("---\ntags: [foo, foo, bar]\n---\n"),
-    ).toEqual(["foo", "bar"]);
+    expect(extractFrontmatterTags("---\ntags: [foo, foo, bar]\n---\n")).toEqual(
+      ["foo", "bar"],
+    );
   });
 
   it("returns [] on block-list shape (out of slice-1 schema)", () => {
@@ -82,7 +82,7 @@ describe("extractFrontmatterTags", () => {
 
   it("returns [] when the value isn't a flow array", () => {
     expect(extractFrontmatterTags("---\ntags: notabracket\n---\n")).toEqual([]);
-    expect(extractFrontmatterTags("---\ntags: \"hello\"\n---\n")).toEqual([]);
+    expect(extractFrontmatterTags('---\ntags: "hello"\n---\n')).toEqual([]);
     expect(extractFrontmatterTags("---\ntags: 42\n---\n")).toEqual([]);
   });
 
@@ -159,8 +159,7 @@ describe("extractFrontmatter", () => {
   });
 
   it("extracts a tasks checklist", () => {
-    const doc =
-      '---\ntitle: x\ntasks: ["[ ] Verify", "[x] Done"]\n---\nbody\n';
+    const doc = '---\ntitle: x\ntasks: ["[ ] Verify", "[x] Done"]\n---\nbody\n';
     expect(extractFrontmatter(doc).tasks).toEqual([
       { text: "Verify", done: false },
       { text: "Done", done: true },
@@ -168,12 +167,12 @@ describe("extractFrontmatter", () => {
   });
 
   it("unquotes both quote styles for title", () => {
-    expect(
-      extractFrontmatter("---\ntitle: 'single quoted'\n---\n").title,
-    ).toBe("single quoted");
-    expect(
-      extractFrontmatter('---\ntitle: "double quoted"\n---\n').title,
-    ).toBe("double quoted");
+    expect(extractFrontmatter("---\ntitle: 'single quoted'\n---\n").title).toBe(
+      "single quoted",
+    );
+    expect(extractFrontmatter('---\ntitle: "double quoted"\n---\n').title).toBe(
+      "double quoted",
+    );
   });
 
   it("treats `abstract: |` block-scalar marker as undefined (Rust slice-1)", () => {
@@ -186,8 +185,9 @@ describe("extractFrontmatter", () => {
   });
 
   it("treats `abstract: >` folded-scalar marker as undefined", () => {
-    expect(extractFrontmatter("---\nabstract: >\n  folded\n---\n").abstract)
-      .toBeUndefined();
+    expect(
+      extractFrontmatter("---\nabstract: >\n  folded\n---\n").abstract,
+    ).toBeUndefined();
   });
 
   it("returns title undefined when blank / empty-quoted (Rust slice-1)", () => {
@@ -196,7 +196,7 @@ describe("extractFrontmatter", () => {
     // (`'   '`) survives as-is — pickH1Title trims it downstream
     // before falling back through firstHeading → filename.
     expect(extractFrontmatter("---\ntitle: \n---\n").title).toBeUndefined();
-    expect(extractFrontmatter("---\ntitle: \"\"\n---\n").title).toBeUndefined();
+    expect(extractFrontmatter('---\ntitle: ""\n---\n').title).toBeUndefined();
     expect(extractFrontmatter("---\ntitle: ''\n---\n").title).toBeUndefined();
   });
 
@@ -250,7 +250,7 @@ describe("extractFrontmatter — error path (V6 cenário 6)", () => {
   });
 
   it("flags `tasks:` block-list shape", () => {
-    const doc = "---\ntasks:\n  - \"[ ] do thing\"\n---\n";
+    const doc = '---\ntasks:\n  - "[ ] do thing"\n---\n';
     expect(extractFrontmatter(doc).error).toBeDefined();
   });
 
@@ -273,7 +273,7 @@ describe("extractFrontmatter — error path (V6 cenário 6)", () => {
 
   it("does not flag a valid frontmatter", () => {
     const doc =
-      "---\ntitle: x\nabstract: y\ntags: [a, b]\ntasks: [\"[ ] z\"]\n---\nbody\n";
+      '---\ntitle: x\nabstract: y\ntags: [a, b]\ntasks: ["[ ] z"]\n---\nbody\n';
     expect(extractFrontmatter(doc).error).toBeUndefined();
   });
 
@@ -291,52 +291,48 @@ describe("extractFrontmatter — status (V6 cenário 8)", () => {
   });
 
   it("extracts status: archived", () => {
-    expect(
-      extractFrontmatter("---\nstatus: archived\n---\n").status,
-    ).toBe("archived");
+    expect(extractFrontmatter("---\nstatus: archived\n---\n").status).toBe(
+      "archived",
+    );
   });
 
   it("normalizes case and trims whitespace", () => {
-    expect(
-      extractFrontmatter("---\nstatus:   ARCHIVED   \n---\n").status,
-    ).toBe("archived");
+    expect(extractFrontmatter("---\nstatus:   ARCHIVED   \n---\n").status).toBe(
+      "archived",
+    );
   });
 
   it("preserves forward-compat unknown values (lower-cased)", () => {
-    expect(
-      extractFrontmatter("---\nstatus: review\n---\n").status,
-    ).toBe("review");
+    expect(extractFrontmatter("---\nstatus: review\n---\n").status).toBe(
+      "review",
+    );
   });
 
   it("unquotes both quote styles", () => {
-    expect(
-      extractFrontmatter('---\nstatus: "archived"\n---\n').status,
-    ).toBe("archived");
-    expect(
-      extractFrontmatter("---\nstatus: 'draft'\n---\n").status,
-    ).toBe("draft");
+    expect(extractFrontmatter('---\nstatus: "archived"\n---\n').status).toBe(
+      "archived",
+    );
+    expect(extractFrontmatter("---\nstatus: 'draft'\n---\n").status).toBe(
+      "draft",
+    );
   });
 
   it("first-wins on duplicate status: lines", () => {
     expect(
-      extractFrontmatter(
-        "---\nstatus: draft\nstatus: archived\n---\n",
-      ).status,
+      extractFrontmatter("---\nstatus: draft\nstatus: archived\n---\n").status,
     ).toBe("draft");
   });
 });
 
 describe("extractFrontmatterArchived", () => {
   it("true when status: archived", () => {
-    expect(
-      extractFrontmatterArchived("---\nstatus: archived\n---\n"),
-    ).toBe(true);
+    expect(extractFrontmatterArchived("---\nstatus: archived\n---\n")).toBe(
+      true,
+    );
   });
 
   it("false for any other status (or none)", () => {
-    expect(
-      extractFrontmatterArchived("---\nstatus: draft\n---\n"),
-    ).toBe(false);
+    expect(extractFrontmatterArchived("---\nstatus: draft\n---\n")).toBe(false);
     expect(extractFrontmatterArchived("---\ntitle: x\n---\n")).toBe(false);
     expect(extractFrontmatterArchived("# no fence\n")).toBe(false);
   });

--- a/httui-desktop/src/lib/blocks/__tests__/outline.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/outline.test.ts
@@ -13,15 +13,11 @@ describe("extractOutline", () => {
 
   it("captures a single H1", () => {
     const r = extractOutline("# Hello world\n");
-    expect(r).toEqual([
-      { level: 1, text: "Hello world", line: 1, offset: 0 },
-    ]);
+    expect(r).toEqual([{ level: 1, text: "Hello world", line: 1, offset: 0 }]);
   });
 
   it("captures H1 / H2 / H3 by default and rejects H4+", () => {
-    const r = extractOutline(
-      "# A\n## B\n### C\n#### D\n##### E\n###### F\n",
-    );
+    const r = extractOutline("# A\n## B\n### C\n#### D\n##### E\n###### F\n");
     expect(r.map((e) => e.level)).toEqual([1, 2, 3]);
     expect(r.map((e) => e.text)).toEqual(["A", "B", "C"]);
   });
@@ -52,7 +48,9 @@ describe("extractOutline", () => {
   });
 
   it("only matches a fence-close with the same marker", () => {
-    const r = extractOutline("```\n# fake-inside-block\n~~~ bogus\n```\n# real\n");
+    const r = extractOutline(
+      "```\n# fake-inside-block\n~~~ bogus\n```\n# real\n",
+    );
     expect(r.map((e) => e.text)).toEqual(["real"]);
   });
 

--- a/httui-desktop/src/lib/blocks/__tests__/preflight-checks.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/preflight-checks.test.ts
@@ -79,8 +79,7 @@ describe("extractPreflightChecks", () => {
   });
 
   it("tolerates blank lines inside the block", () => {
-    const doc =
-      "---\npreflight:\n  - connection: a\n\n  - env_var: B\n---\n";
+    const doc = "---\npreflight:\n  - connection: a\n\n  - env_var: B\n---\n";
     expect(extractPreflightChecks(doc)).toEqual<PreflightCheck[]>([
       { kind: "connection", value: "a" },
       { kind: "env_var", value: "B" },
@@ -124,8 +123,7 @@ describe("updateFrontmatterPreflightChecks", () => {
   });
 
   it("replaces an existing block in place", () => {
-    const before =
-      "---\npreflight:\n  - connection: old\n---\nbody\n";
+    const before = "---\npreflight:\n  - connection: old\n---\nbody\n";
     const next = updateFrontmatterPreflightChecks(before, [
       { kind: "connection", value: "new" },
       { kind: "env_var", value: "X" },

--- a/httui-desktop/src/lib/blocks/__tests__/quick-open-query.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/quick-open-query.test.ts
@@ -136,9 +136,7 @@ describe("applyTagQuery", () => {
   });
 
   it("applyTagQuery returns [] for non-tag queries", () => {
-    expect(
-      applyTagQuery({ kind: "fuzzy", value: "x" }, byTag),
-    ).toEqual([]);
+    expect(applyTagQuery({ kind: "fuzzy", value: "x" }, byTag)).toEqual([]);
     expect(applyTagQuery({ kind: "empty" }, byTag)).toEqual([]);
   });
 

--- a/httui-desktop/src/lib/blocks/__tests__/run-history-trim.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/run-history-trim.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { HistoryEntry } from "@/lib/tauri/commands";
 
-import {
-  KEEP_PER_BLOCK,
-  pickKeepN,
-  trimToKeepN,
-} from "../run-history-trim";
+import { KEEP_PER_BLOCK, pickKeepN, trimToKeepN } from "../run-history-trim";
 
 function entry(over: Partial<HistoryEntry> = {}): HistoryEntry {
   return {

--- a/httui-desktop/src/lib/blocks/__tests__/serialize-explain-plan.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/serialize-explain-plan.test.ts
@@ -15,8 +15,7 @@ describe("serializeExplainPlan", () => {
     // The 200 KB cap path stores the truncated text as Value::String
     // on the Rust side. The wire delivers a plain string; we keep
     // it as-is so the consumer sees the truncation marker.
-    const truncated =
-      "[".padEnd(190_000, "x") + "[explain payload truncated]";
+    const truncated = "[".padEnd(190_000, "x") + "[explain payload truncated]";
     expect(serializeExplainPlan(truncated)).toBe(truncated);
   });
 

--- a/httui-desktop/src/lib/blocks/__tests__/update-frontmatter.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/update-frontmatter.test.ts
@@ -64,9 +64,7 @@ describe("updateFrontmatterTitle", () => {
   });
 
   it("trims leading/trailing whitespace before writing", () => {
-    expect(updateFrontmatterTitle("", "   Hello   ")).toContain(
-      "title: Hello",
-    );
+    expect(updateFrontmatterTitle("", "   Hello   ")).toContain("title: Hello");
   });
 
   it("handles CRLF documents", () => {
@@ -82,18 +80,14 @@ describe("updateFrontmatterTitle", () => {
     // Indented `title:` is not a top-level key per the slice-1 schema.
     const before = "---\nmeta:\n  title: nested\n---\nbody\n";
     const after = updateFrontmatterTitle(before, "Top");
-    expect(after).toBe(
-      "---\ntitle: Top\nmeta:\n  title: nested\n---\nbody\n",
-    );
+    expect(after).toBe("---\ntitle: Top\nmeta:\n  title: nested\n---\nbody\n");
   });
 
   it("only modifies the first occurrence of `title:`", () => {
     // Malformed input with duplicate keys — first wins, mirrors parser.
     const before = "---\ntitle: First\ntitle: Second\n---\nbody\n";
     const after = updateFrontmatterTitle(before, "Renamed");
-    expect(after).toBe(
-      "---\ntitle: Renamed\ntitle: Second\n---\nbody\n",
-    );
+    expect(after).toBe("---\ntitle: Renamed\ntitle: Second\n---\nbody\n");
   });
 });
 
@@ -216,9 +210,7 @@ describe("updateFrontmatterTags", () => {
 describe("updateFrontmatterTasks", () => {
   it("inserts a fresh frontmatter when adding items to a doc with none", () => {
     expect(
-      updateFrontmatterTasks("body\n", [
-        { text: "First", done: false },
-      ]),
+      updateFrontmatterTasks("body\n", [{ text: "First", done: false }]),
     ).toBe('---\ntasks: ["[ ] First"]\n---\n\nbody\n');
   });
 
@@ -228,8 +220,7 @@ describe("updateFrontmatterTasks", () => {
   });
 
   it("removes the line when the new list is empty", () => {
-    const before =
-      '---\ntitle: x\ntasks: ["[ ] foo"]\n---\nbody\n';
+    const before = '---\ntitle: x\ntasks: ["[ ] foo"]\n---\nbody\n';
     expect(updateFrontmatterTasks(before, [])).toBe(
       "---\ntitle: x\n---\nbody\n",
     );
@@ -248,12 +239,9 @@ describe("updateFrontmatterTasks", () => {
   });
 
   it("replaces an existing tasks line in place", () => {
-    const before =
-      '---\ntasks: ["[ ] old"]\n---\nbody\n';
-    expect(
-      updateFrontmatterTasks(before, [
-        { text: "new", done: true },
-      ]),
-    ).toBe('---\ntasks: ["[x] new"]\n---\nbody\n');
+    const before = '---\ntasks: ["[ ] old"]\n---\nbody\n';
+    expect(updateFrontmatterTasks(before, [{ text: "new", done: true }])).toBe(
+      '---\ntasks: ["[x] new"]\n---\nbody\n',
+    );
   });
 });

--- a/httui-desktop/src/lib/blocks/doc-db-blocks.ts
+++ b/httui-desktop/src/lib/blocks/doc-db-blocks.ts
@@ -54,7 +54,12 @@ export function findDocDbBlocks(content: string): DocDbBlock[] {
   const out: DocDbBlock[] = [];
   let offset = bodyStart;
   let lineNo = bodyLine;
-  let openFence: { tag: string; line: number; offset: number; meta: DbBlockMetadata | null } | null = null;
+  let openFence: {
+    tag: string;
+    line: number;
+    offset: number;
+    meta: DbBlockMetadata | null;
+  } | null = null;
 
   while (offset < content.length) {
     const eol = content.indexOf("\n", offset);

--- a/httui-desktop/src/lib/blocks/explain-support.ts
+++ b/httui-desktop/src/lib/blocks/explain-support.ts
@@ -30,7 +30,9 @@ export const EXPLAIN_BODY_CAP = 200_000;
  *  capture as a JSON plan (Postgres / MySQL family). False for
  *  SQLite / BigQuery / Snowflake / Mongo / unknown — those map to
  *  `ExplainError::Unsupported` in the backend. */
-export function driverSupportsExplain(driver: string | null | undefined): boolean {
+export function driverSupportsExplain(
+  driver: string | null | undefined,
+): boolean {
   if (!driver) return false;
   return EXPLAIN_SUPPORTED_DRIVERS.has(driver.trim().toLowerCase());
 }

--- a/httui-desktop/src/lib/blocks/extract-frontmatter-tags.ts
+++ b/httui-desktop/src/lib/blocks/extract-frontmatter-tags.ts
@@ -24,10 +24,7 @@
 // _for_block_list_or_other_shapes` in the Rust tests + the matching
 // "returns [] on block-list shape" test below.
 
-import {
-  parseTaskItem,
-  type TaskItem,
-} from "./task-item";
+import { parseTaskItem, type TaskItem } from "./task-item";
 
 export interface FrontmatterShape {
   title?: string;
@@ -125,10 +122,7 @@ export function extractFrontmatter(content: string): FrontmatterShape {
     } else if (key === "tasks") {
       seen.add(key);
       tasks = parseFlowList(valuePart).map(parseTaskItem);
-      if (
-        tasks.length === 0 &&
-        isMalformedListValue(lines, i, valuePart)
-      ) {
+      if (tasks.length === 0 && isMalformedListValue(lines, i, valuePart)) {
         listError = ERR_LIST_NOT_FLOW;
       }
     }

--- a/httui-desktop/src/lib/blocks/outline.ts
+++ b/httui-desktop/src/lib/blocks/outline.ts
@@ -60,9 +60,7 @@ export function extractOutline(
     while (scanFrom < content.length) {
       const eol = content.indexOf("\n", scanFrom);
       const lineEnd = eol === -1 ? content.length : eol;
-      const lineText = content
-        .slice(scanFrom, lineEnd)
-        .replace(/\r$/, "");
+      const lineText = content.slice(scanFrom, lineEnd).replace(/\r$/, "");
       if (lineText === "---") {
         bodyStartOffset = lineEnd + 1;
         bodyStartLine = scanLine + 1;

--- a/httui-desktop/src/lib/blocks/quick-open-query.ts
+++ b/httui-desktop/src/lib/blocks/quick-open-query.ts
@@ -37,11 +37,7 @@ export function parseQuickOpenQuery(raw: string): QuickOpenQuery {
     const operands = tokens.filter((_, i) => i % 2 === 0);
     const ops = new Set(operators.map((o) => o.toLowerCase()));
     const allTagTokens = operands.every((o) => TAG_PATTERN.test(o));
-    if (
-      allTagTokens &&
-      ops.size === 1 &&
-      (ops.has("or") || ops.has("and"))
-    ) {
+    if (allTagTokens && ops.size === 1 && (ops.has("or") || ops.has("and"))) {
       const op = ops.has("or") ? "or" : "and";
       const tags = operands.map((o) => o.replace(/^#/, ""));
       return { kind: "tag-bool", op, tags };

--- a/httui-desktop/src/lib/blocks/update-frontmatter.ts
+++ b/httui-desktop/src/lib/blocks/update-frontmatter.ts
@@ -11,10 +11,7 @@
 // style). The DocHeader's editable fields call into these on commit so
 // the source of truth stays the `.md` file, not React state.
 
-import {
-  stringifyTaskItem,
-  type TaskItem,
-} from "./task-item";
+import { stringifyTaskItem, type TaskItem } from "./task-item";
 
 interface SplitDoc {
   before: string;
@@ -270,7 +267,8 @@ export function updateFrontmatterTags(
     if (!range) return content;
     const lineEnd = range.to + 1; // include the trailing \n
     const trimmedTo = Math.min(lineEnd, split.fmBody.length);
-    const next = split.fmBody.slice(0, range.from) + split.fmBody.slice(trimmedTo);
+    const next =
+      split.fmBody.slice(0, range.from) + split.fmBody.slice(trimmedTo);
     return split.before + next + split.after;
   }
 
@@ -285,9 +283,7 @@ export function updateFrontmatterTags(
   }
 
   const insertion =
-    split.fmBody.length === 0
-      ? `${newLine}\n`
-      : `${split.fmBody}${newLine}\n`;
+    split.fmBody.length === 0 ? `${newLine}\n` : `${split.fmBody}${newLine}\n`;
   return split.before + insertion + split.after;
 }
 
@@ -337,8 +333,6 @@ export function updateFrontmatterTasks(
   }
 
   const insertion =
-    split.fmBody.length === 0
-      ? `${newLine}\n`
-      : `${split.fmBody}${newLine}\n`;
+    split.fmBody.length === 0 ? `${newLine}\n` : `${split.fmBody}${newLine}\n`;
   return split.before + insertion + split.after;
 }

--- a/httui-desktop/src/lib/changelog/__tests__/find-blocks.test.ts
+++ b/httui-desktop/src/lib/changelog/__tests__/find-blocks.test.ts
@@ -28,11 +28,7 @@ describe("findFencedBlocks", () => {
   });
 
   it("finds a DB block with the connection id baked into the kind tag", () => {
-    const md = [
-      "```db-payments alias=q1",
-      "SELECT 1",
-      "```",
-    ].join("\n");
+    const md = ["```db-payments alias=q1", "SELECT 1", "```"].join("\n");
     const blocks = findFencedBlocks(md);
     expect(blocks).toHaveLength(1);
     expect(blocks[0]!.kind).toBe("db");
@@ -80,15 +76,9 @@ describe("findFencedBlocks", () => {
   });
 
   it("ignores plain code fences (```ts, ```rust, plain ```)", () => {
-    const md = [
-      "```ts",
-      "const x = 1",
-      "```",
-      "",
-      "```",
-      "plain",
-      "```",
-    ].join("\n");
+    const md = ["```ts", "const x = 1", "```", "", "```", "plain", "```"].join(
+      "\n",
+    );
     expect(findFencedBlocks(md)).toEqual([]);
   });
 

--- a/httui-desktop/src/lib/changelog/find-blocks.ts
+++ b/httui-desktop/src/lib/changelog/find-blocks.ts
@@ -31,7 +31,12 @@ const FENCE_REGEX = /^```(http|db-[A-Za-z0-9_-]+|sh|ws|gql)(?:\s+(.+))?$/;
 export function findFencedBlocks(content: string): FencedBlock[] {
   const lines = content.split("\n");
   const blocks: FencedBlock[] = [];
-  let open: { kind: BlockKind; infoString: string; alias: string | null; start: number } | null = null;
+  let open: {
+    kind: BlockKind;
+    infoString: string;
+    alias: string | null;
+    start: number;
+  } | null = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
     if (open === null) {
@@ -42,7 +47,9 @@ export function findFencedBlocks(content: string): FencedBlock[] {
         const kind: BlockKind = tag.startsWith("db-")
           ? "db"
           : (tag as BlockKind);
-        const infoString = tag.startsWith("db-") ? `${tag} ${rest}`.trim() : rest;
+        const infoString = tag.startsWith("db-")
+          ? `${tag} ${rest}`.trim()
+          : rest;
         const alias = parseAliasFromInfoString(rest);
         open = {
           kind,

--- a/httui-desktop/src/lib/codemirror/__tests__/cm-doc-header.test.ts
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-doc-header.test.ts
@@ -137,10 +137,7 @@ describe("DocHeader nav keymap (M3)", () => {
 
   it("does NOT focus the input when cursor is below the body's first line", () => {
     const idRef = { current: "" };
-    const view = createView(
-      "---\ntitle: x\n---\nline one\nline two\n",
-      idRef,
-    );
+    const view = createView("---\ntitle: x\n---\nline one\nline two\n", idRef);
 
     const fakeInput = document.createElement("input");
     document.body.appendChild(fakeInput);

--- a/httui-desktop/src/lib/codemirror/__tests__/cm-merge-conflict.test.tsx
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-merge-conflict.test.tsx
@@ -22,9 +22,7 @@ const CONFLICT = [
 describe("parseConflictRegions", () => {
   it("finds a well-formed hunk", () => {
     const r = parseConflictRegions(lines(CONFLICT));
-    expect(r).toEqual([
-      { oursMarker: 2, separator: 4, theirsMarker: 6 },
-    ]);
+    expect(r).toEqual([{ oursMarker: 2, separator: 4, theirsMarker: 6 }]);
   });
 
   it("returns nothing for a clean doc", () => {
@@ -74,9 +72,7 @@ describe("mergeConflict extension", () => {
     expect(view.dom.querySelector(".cm-conflict-ours")).toBeTruthy();
     expect(view.dom.querySelector(".cm-conflict-theirs")).toBeTruthy();
     expect(view.dom.querySelector(".cm-conflict-sep")).toBeTruthy();
-    expect(
-      view.dom.querySelectorAll(".cm-conflict-marker"),
-    ).toHaveLength(2);
+    expect(view.dom.querySelectorAll(".cm-conflict-marker")).toHaveLength(2);
     expect(view.dom.querySelector(".cm-conflict-toolbar")).toBeTruthy();
   });
 

--- a/httui-desktop/src/lib/codemirror/__tests__/cm-numbered-headings.test.ts
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-numbered-headings.test.ts
@@ -40,7 +40,9 @@ describe("buildHeadingDecorations", () => {
   });
 
   it("skips headings inside fenced code blocks", () => {
-    const doc = asLines("# A\n\n```\n# inside-fence\n## inside-fence-2\n```\n\n# B\n");
+    const doc = asLines(
+      "# A\n\n```\n# inside-fence\n## inside-fence-2\n```\n\n# B\n",
+    );
     const result = buildHeadingDecorations(doc);
     expect(result.count).toBe(2);
     expect(numbers(result)).toEqual([1, 2]);

--- a/httui-desktop/src/lib/codemirror/cm-doc-header-state.ts
+++ b/httui-desktop/src/lib/codemirror/cm-doc-header-state.ts
@@ -18,10 +18,7 @@ import {
   EditorSelection,
   type StateField,
 } from "@codemirror/state";
-import {
-  EditorView,
-  type DecorationSet,
-} from "@codemirror/view";
+import { EditorView, type DecorationSet } from "@codemirror/view";
 
 import { extractFrontmatter } from "@/lib/blocks/extract-frontmatter-tags";
 import type { DocHeaderFrontmatter } from "@/components/layout/docheader/docheader-derive";
@@ -171,7 +168,8 @@ function frontmatterEqual(
   const aTags = a.tags ?? [];
   const bTags = b.tags ?? [];
   if (aTags.length !== bTags.length) return false;
-  for (let i = 0; i < aTags.length; i++) if (aTags[i] !== bTags[i]) return false;
+  for (let i = 0; i < aTags.length; i++)
+    if (aTags[i] !== bTags[i]) return false;
   const aTasks = a.tasks ?? [];
   const bTasks = b.tasks ?? [];
   if (aTasks.length !== bTasks.length) return false;

--- a/httui-desktop/src/lib/codemirror/cm-doc-header.tsx
+++ b/httui-desktop/src/lib/codemirror/cm-doc-header.tsx
@@ -371,12 +371,7 @@ export function createDocHeaderExtension(): DocHeaderExtensionHandle {
   });
 
   return {
-    extension: [
-      field,
-      guard,
-      updateListener,
-      Prec.high(keymap.of(navKeymap)),
-    ],
+    extension: [field, guard, updateListener, Prec.high(keymap.of(navKeymap))],
     instanceId,
   };
 }

--- a/httui-desktop/src/lib/codemirror/cm-merge-conflict.tsx
+++ b/httui-desktop/src/lib/codemirror/cm-merge-conflict.tsx
@@ -79,11 +79,7 @@ function resolveRegion(
   const ours = slice(region.oursMarker + 1, region.separator - 1);
   const theirs = slice(region.separator + 1, region.theirsMarker - 1);
   const insert =
-    side === "ours"
-      ? ours
-      : side === "theirs"
-        ? theirs
-        : `${ours}\n${theirs}`;
+    side === "ours" ? ours : side === "theirs" ? theirs : `${ours}\n${theirs}`;
   view.dispatch({ changes: { from, to, insert } });
 }
 

--- a/httui-desktop/src/lib/share/__tests__/share-url.test.ts
+++ b/httui-desktop/src/lib/share/__tests__/share-url.test.ts
@@ -137,9 +137,7 @@ describe("composeCompareUrl", () => {
       "feat/x",
     );
     if (!r.ok) throw new Error("expected ok");
-    expect(r.url).toBe(
-      "https://github.com/owner/repo/compare/main...feat/x",
-    );
+    expect(r.url).toBe("https://github.com/owner/repo/compare/main...feat/x");
   });
 
   it("composes a GitLab compare URL with /-/compare/ shape", () => {
@@ -163,11 +161,7 @@ describe("composeCompareUrl", () => {
   });
 
   it("returns the manual hint for Bitbucket / Gitea / Other", () => {
-    const r = composeCompareUrl(
-      parsed("git@bitbucket.org:t/r.git"),
-      "a",
-      "b",
-    );
+    const r = composeCompareUrl(parsed("git@bitbucket.org:t/r.git"), "a", "b");
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.fallback).toBe("https://bitbucket.org/t/r");

--- a/httui-desktop/src/lib/tauri/__tests__/files.test.ts
+++ b/httui-desktop/src/lib/tauri/__tests__/files.test.ts
@@ -67,8 +67,8 @@ describe("files Tauri wrappers", () => {
     mockTauriCommand("set_file_docheader_compact", () => {
       throw new Error("vault not writable");
     });
-    await expect(
-      setFileDocheaderCompact("/v", "a.md", true),
-    ).rejects.toThrow(/vault not writable/);
+    await expect(setFileDocheaderCompact("/v", "a.md", true)).rejects.toThrow(
+      /vault not writable/,
+    );
   });
 });

--- a/httui-desktop/src/lib/tauri/__tests__/streamedExecution.test.ts
+++ b/httui-desktop/src/lib/tauri/__tests__/streamedExecution.test.ts
@@ -239,9 +239,7 @@ describe("executeDbStreamed", () => {
   });
 
   it("maps an error chunk to an error outcome", async () => {
-    streamChunks("execute_db_streamed", [
-      { kind: "error", message: "boom" },
-    ]);
+    streamChunks("execute_db_streamed", [{ kind: "error", message: "boom" }]);
     const out = await executeDbStreamed({
       executionId: "e1",
       params: { connection_id: "c1", query: "x" },

--- a/httui-desktop/src/lib/tauri/git.ts
+++ b/httui-desktop/src/lib/tauri/git.ts
@@ -140,10 +140,7 @@ export function gitCommit(
   return invoke("git_commit_cmd", { vaultPath, message, amend });
 }
 
-export function gitFetch(
-  vaultPath: string,
-  remote?: string,
-): Promise<string> {
+export function gitFetch(vaultPath: string, remote?: string): Promise<string> {
   return invoke("git_fetch_cmd", { vaultPath, remote: remote ?? null });
 }
 

--- a/httui-desktop/src/lib/tauri/streamedExecution.ts
+++ b/httui-desktop/src/lib/tauri/streamedExecution.ts
@@ -25,9 +25,7 @@ export function applyConnectionOverride(
 ): Record<string, unknown> {
   const connId = params.connection_id;
   if (typeof connId !== "string" || connId === "") return params;
-  const ov = useConnectionSessionOverrideStore
-    .getState()
-    .getOverride(connId);
+  const ov = useConnectionSessionOverrideStore.getState().getOverride(connId);
   if (!ov || (ov.host === undefined && ov.port === undefined)) return params;
   const next = { ...params };
   if (ov.host !== undefined) next.session_host_override = ov.host;

--- a/httui-desktop/src/lib/tauri/vault-ops.ts
+++ b/httui-desktop/src/lib/tauri/vault-ops.ts
@@ -60,9 +60,6 @@ export function createVault(
  * first-run secrets modal. Empty key/value pairs are rejected at
  * the backend.
  */
-export function saveSecret(
-  keychainKey: string,
-  value: string,
-): Promise<void> {
+export function saveSecret(keychainKey: string, value: string): Promise<void> {
   return invoke("save_secret_cmd", { keychainKey, value });
 }

--- a/httui-desktop/src/stores/__tests__/captureStore.test.ts
+++ b/httui-desktop/src/stores/__tests__/captureStore.test.ts
@@ -156,7 +156,9 @@ describe("useCaptureStore", () => {
   it("loadFromCacheJson is a no-op when top-level isn't an object", () => {
     useCaptureStore.getState().setBlockCaptures("a.md", "x", { a: 1 });
     const before = useCaptureStore.getState().values;
-    useCaptureStore.getState().loadFromCacheJson("a.md", JSON.stringify([1, 2]));
+    useCaptureStore
+      .getState()
+      .loadFromCacheJson("a.md", JSON.stringify([1, 2]));
     expect(useCaptureStore.getState().values).toBe(before);
     useCaptureStore.getState().loadFromCacheJson("a.md", JSON.stringify(null));
     expect(useCaptureStore.getState().values).toBe(before);

--- a/httui-desktop/src/stores/__tests__/settings.test.ts
+++ b/httui-desktop/src/stores/__tests__/settings.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/theme/apply", () => ({
 
 import { useSettingsStore } from "@/stores/settings";
 import { applyTheme } from "@/lib/theme/apply";
+import type { UserConfigFile, UserUiPrefs } from "@/lib/tauri/commands";
 
 const DEFAULT_SETTINGS = {
   autoSaveMs: 1000,
@@ -17,7 +18,7 @@ const DEFAULT_SETTINGS = {
   historyRetention: 10,
 };
 
-function userFile(uiOverrides: Record<string, unknown> = {}) {
+function userFile(uiOverrides: Partial<UserUiPrefs> = {}): UserConfigFile {
   return {
     version: "1",
     ui: {
@@ -41,7 +42,7 @@ function userFile(uiOverrides: Record<string, unknown> = {}) {
   };
 }
 
-function mockUserConfig(uiOverrides: Record<string, unknown> = {}) {
+function mockUserConfig(uiOverrides: Partial<UserUiPrefs> = {}) {
   let current = userFile(uiOverrides);
   mockTauriCommand("get_user_config", () => current);
   mockTauriCommand("set_user_config", (args) => {
@@ -385,9 +386,9 @@ describe("settingsStore", () => {
 
   describe("autoUpdateIncludePrereleases", () => {
     it("defaults to false", () => {
-      expect(
-        useSettingsStore.getState().autoUpdateIncludePrereleases,
-      ).toBe(false);
+      expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(
+        false,
+      );
     });
 
     it("setAutoUpdateIncludePrereleases(true) updates state and persists", async () => {
@@ -395,9 +396,9 @@ describe("settingsStore", () => {
 
       useSettingsStore.getState().setAutoUpdateIncludePrereleases(true);
 
-      expect(
-        useSettingsStore.getState().autoUpdateIncludePrereleases,
-      ).toBe(true);
+      expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(
+        true,
+      );
       await flushPersist();
       expect(read().ui.auto_update_include_prereleases).toBe(true);
     });
@@ -409,9 +410,9 @@ describe("settingsStore", () => {
 
       useSettingsStore.getState().setAutoUpdateIncludePrereleases(false);
 
-      expect(
-        useSettingsStore.getState().autoUpdateIncludePrereleases,
-      ).toBe(false);
+      expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(
+        false,
+      );
       await flushPersist();
       expect(read().ui.auto_update_include_prereleases).toBe(false);
     });
@@ -421,9 +422,9 @@ describe("settingsStore", () => {
 
       await useSettingsStore.getState().loadSettings();
 
-      expect(
-        useSettingsStore.getState().autoUpdateIncludePrereleases,
-      ).toBe(true);
+      expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(
+        true,
+      );
     });
 
     it("falls back to false when the key is omitted", async () => {
@@ -431,9 +432,9 @@ describe("settingsStore", () => {
 
       await useSettingsStore.getState().loadSettings();
 
-      expect(
-        useSettingsStore.getState().autoUpdateIncludePrereleases,
-      ).toBe(false);
+      expect(useSettingsStore.getState().autoUpdateIncludePrereleases).toBe(
+        false,
+      );
     });
   });
 });

--- a/httui-desktop/src/stores/__tests__/tagIndex.test.ts
+++ b/httui-desktop/src/stores/__tests__/tagIndex.test.ts
@@ -222,7 +222,9 @@ describe("tagIndex store", () => {
 
   it("refreshTagsForFile parses content and indexes the tags", () => {
     const content = "---\ntags: [payments, debug]\n---\nbody\n";
-    const tags = useTagIndexStore.getState().refreshTagsForFile("a.md", content);
+    const tags = useTagIndexStore
+      .getState()
+      .refreshTagsForFile("a.md", content);
     expect(tags).toEqual(["payments", "debug"]);
     const s = useTagIndexStore.getState();
     expect(s.getFilesByTag("payments")).toEqual(["a.md"]);
@@ -315,10 +317,7 @@ describe("tagIndex store", () => {
 
     it("archived + tagged in same file: both indexed, both cleared on remove", () => {
       const s = useTagIndexStore.getState();
-      s.refreshTagsForFile(
-        "a.md",
-        "---\nstatus: archived\ntags: [api]\n---\n",
-      );
+      s.refreshTagsForFile("a.md", "---\nstatus: archived\ntags: [api]\n---\n");
       const after = useTagIndexStore.getState();
       expect(after.isArchived("a.md")).toBe(true);
       expect(after.getFilesByTag("api")).toEqual(["a.md"]);

--- a/httui-desktop/src/stores/connectionSessionOverride.ts
+++ b/httui-desktop/src/stores/connectionSessionOverride.ts
@@ -84,8 +84,7 @@ export const useConnectionSessionOverrideStore =
             "connOverride/clear",
           ),
 
-        clearAll: () =>
-          set({ overrides: {} }, false, "connOverride/clearAll"),
+        clearAll: () => set({ overrides: {} }, false, "connOverride/clearAll"),
 
         getOverride: (connectionId) => get().overrides[connectionId],
       }),

--- a/httui-desktop/src/stores/environment.ts
+++ b/httui-desktop/src/stores/environment.ts
@@ -131,8 +131,9 @@ export const useEnvironmentStore = create<EnvironmentState>()(
         // top of the resolved values so block runs see the TEMPORARY
         // value the user set, not the vault-stored one.
         const overrides =
-          useSessionOverrideStore.getState().overrides[activeEnvironment.name] ??
-          {};
+          useSessionOverrideStore.getState().overrides[
+            activeEnvironment.name
+          ] ?? {};
         return { ...resolved, ...overrides };
       },
     }),

--- a/httui-desktop/src/stores/pane.ts
+++ b/httui-desktop/src/stores/pane.ts
@@ -158,16 +158,10 @@ export function replacePaneInLayout(
 
 // --- Singleton tab helper ---
 
-type SingletonTabKind =
-  | "connections"
-  | "variables"
-  | "environments"
-  | "git";
+type SingletonTabKind = "connections" | "variables" | "environments" | "git";
 
 function openSingletonTab(
-  set: (
-    fn: (state: PaneState) => PaneState | Partial<PaneState>,
-  ) => void,
+  set: (fn: (state: PaneState) => PaneState | Partial<PaneState>) => void,
   get: () => PaneState,
   kind: SingletonTabKind,
   filePath: string,
@@ -563,7 +557,9 @@ export function useLayoutAndActive() {
  * tabs (cold start / empty vault).
  */
 export function selectActiveTabPath(s: PaneState): string | null {
-  function find(node: PaneLayout): { filePath: string; unsaved: boolean } | null {
+  function find(
+    node: PaneLayout,
+  ): { filePath: string; unsaved: boolean } | null {
     if (node.type === "split") {
       return find(node.children[0]) ?? find(node.children[1]);
     }

--- a/httui-desktop/src/stores/pendingSecrets.ts
+++ b/httui-desktop/src/stores/pendingSecrets.ts
@@ -35,8 +35,7 @@ export const usePendingSecretsStore = create<PendingSecretsState>()(
       pending: [],
       modalOpen: false,
 
-      setPending: (refs) =>
-        set({ pending: refs, modalOpen: refs.length > 0 }),
+      setPending: (refs) => set({ pending: refs, modalOpen: refs.length > 0 }),
 
       removePending: (keychainKey) =>
         set((state) => {

--- a/httui-desktop/src/stores/tagIndex.ts
+++ b/httui-desktop/src/stores/tagIndex.ts
@@ -178,7 +178,11 @@ export const useTagIndexStore = create<TagIndexState>()(
           // Defensive: ignore entries the backend mis-shaped (extra
           // walker calls might surface a future bug here without
           // crashing the whole store load).
-          if (!entry || typeof entry.path !== "string" || !Array.isArray(entry.tags)) {
+          if (
+            !entry ||
+            typeof entry.path !== "string" ||
+            !Array.isArray(entry.tags)
+          ) {
             continue;
           }
           // Dedup tags within a file before indexing — covers

--- a/httui-mcp/src/main.rs
+++ b/httui-mcp/src/main.rs
@@ -26,8 +26,7 @@ fn resolve_db_path(db_arg: Option<&str>) -> Result<PathBuf> {
     if let Some(db) = db_arg {
         return Ok(PathBuf::from(db));
     }
-    httui_core::paths::default_data_dir()
-        .map_err(|e| anyhow::anyhow!("resolve data dir: {e}"))
+    httui_core::paths::default_data_dir().map_err(|e| anyhow::anyhow!("resolve data dir: {e}"))
 }
 
 /// Initialise the global tracing subscriber for the MCP process.
@@ -83,9 +82,10 @@ struct McpRegistry {
 
 fn build_registry(vault: &str, pool: sqlx::SqlitePool) -> Result<McpRegistry> {
     let conn_lookup = httui_core::vault_config::ConnectionsStore::new(vault.to_string());
-    let conn_manager = Arc::new(
-        httui_core::db::connections::PoolManager::new_standalone(conn_lookup, pool.clone()),
-    );
+    let conn_manager = Arc::new(httui_core::db::connections::PoolManager::new_standalone(
+        conn_lookup,
+        pool.clone(),
+    ));
     let mut executors = httui_core::executor::ExecutorRegistry::new();
     executors.register(Box::new(httui_core::executor::http::HttpExecutor::new()));
     executors.register(Box::new(httui_core::executor::db::DbExecutor::new(
@@ -111,14 +111,9 @@ mod tests {
 
     #[test]
     fn args_parses_with_vault_and_db() {
-        let args = Args::try_parse_from([
-            "httui-mcp",
-            "--vault",
-            "/tmp/v",
-            "--db",
-            "/tmp/notes.db",
-        ])
-        .expect("vault+db should parse");
+        let args =
+            Args::try_parse_from(["httui-mcp", "--vault", "/tmp/v", "--db", "/tmp/notes.db"])
+                .expect("vault+db should parse");
         assert_eq!(args.vault, "/tmp/v");
         assert_eq!(args.db.as_deref(), Some("/tmp/notes.db"));
     }
@@ -151,10 +146,7 @@ mod tests {
         let path = dir.path().join("notes.db");
         let pool = init_pool(&path).await.expect("init_pool should succeed");
         // The pool can answer trivial queries, proving migrations ran.
-        let row: (i64,) = sqlx::query_as("SELECT 1")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT 1").fetch_one(&pool).await.unwrap();
         assert_eq!(row.0, 1);
         // The database file exists on disk after init.
         assert!(path.exists());

--- a/httui-mcp/src/main.rs
+++ b/httui-mcp/src/main.rs
@@ -166,6 +166,14 @@ mod tests {
         assert!(res.is_err(), "run with invalid db_path should error");
     }
 
+    #[test]
+    fn init_tracing_installs_stderr_subscriber() {
+        // Covers the tracing bootstrap (stderr writer, ANSI off).
+        // This is the only test in the binary that installs a global
+        // subscriber, so `.init()` won't hit the double-install panic.
+        init_tracing();
+    }
+
     #[tokio::test]
     async fn build_registry_constructs_http_and_db_executors() {
         // Pool isn't actually used by registry construction (the DbExecutor

--- a/httui-tui/src/app.rs
+++ b/httui-tui/src/app.rs
@@ -862,8 +862,7 @@ impl App {
         // Lookup pulls connection records from the vault's
         // `connections.toml` (Epic 19 Story 02 Phase 3 cutover);
         // legacy SQLite-only lookup is no longer used.
-        let conn_lookup =
-            httui_core::vault_config::ConnectionsStore::new(resolved.vault.clone());
+        let conn_lookup = httui_core::vault_config::ConnectionsStore::new(resolved.vault.clone());
         let pool_manager = Arc::new(PoolManager::new_standalone(conn_lookup, app_pool));
         let connection_names = load_connection_names(pool_manager.app_pool());
         let mut app = Self {


### PR DESCRIPTION
## Why

`main` has been CI-red for ~2 weeks (last green run predates the
TS 6.0 / rustfmt-1.95 drift). The Rust (macOS smoke) job only runs
`cargo check`, so the breakage hid there while every PR — including
the 13 open Dependabot PRs — inherited a red `main`. None of the
Dependabot bumps caused these failures.

`main` is unprotected (no required checks), which is how red commits
kept landing.

## What this fixes

**Rust (Linux)** — `a7cb512`, `65ab02f`
- `cargo fmt --check`: repo-wide rustfmt-1.95 drift → `cargo fmt --all` (no behavior change)
- `cargo clippy -D warnings`: `manual_clamp`, `while_let_on_iterator`, `needless_return` ×3, `get().is_some()`, `err().expect()`
- `cargo test`: git tests assumed initial branch `main`; the Linux runner's git defaults to `master`. `init_repo`/inline inits now pin `-b main` / `--initial-branch=main`; removed the dead post-init `init.defaultBranch` config
- Added an `init_tracing` test so the coverage gate (which only *runs* once Rust+Frontend are green) clears on the fmt-touched `httui-mcp/src/main.rs`

**Frontend** — `aa9fdd9`, `d23d69a`, `936eaac`
- `tsc --noEmit`: 51 pre-existing type errors surfaced by the merged TS 5.9→6.0 Dependabot bump (6f82840). Code-only fixes, no tsconfig/dependency changes — chiefly Chakra v3 polymorphic `as` → the repo's existing `chakra.*` factory idiom; test fixtures realigned to current types
- `prettier --check`: widespread pre-existing drift → `prettier --write` over the exact CI glob (mechanical)
- Coverage gate: the mandatory reformat "touched" 3 pre-existing low-coverage connection components — added behavior-level tests (100% / 95.9% / 100%); no production code changed

**conventional-commits** — `e0ea038`
- `dependabot.yml` emits the `ci` prefix for the github-actions group, but the PR-title gate / CONTRIBUTING didn't allow `ci` → #4/#5/#6 fail on their own titles. Added `ci` to both (takes effect for those PRs once this merges to `main`)

## Verified locally (all green)

`cargo fmt --check` · `cargo clippy -D warnings` · `cargo test --workspace` (1653) · `tsc --noEmit` (0 errors) · `eslint` desktop+web (0 errors) · `vitest unit` (3126 passed) · `prettier --check` · `httui-web` + `httui-sidecar` builds · `scripts/coverage-check.sh` (BASE_REF=origin/main) all touched files ≥80%.

## Notes

- This PR's own `conventional-commits` check runs `pr-title.yml` from the **base** (`main`), so it's titled `fix:` (the new `ci` type only applies after merge).
- Pure-mechanical reformat lives in its own commit (`d23d69a`) to keep review sane; substantive changes are isolated in the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)