### PR TITLE
feat: ship httui-tui in the desktop bundle with unified httui launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,18 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      # tauri.conf.json → bundle.externalBin lists httui-tui + the
+      # httui launcher. tauri-build's resource validator checks the
+      # files exist before letting `cargo check/test` proceed. CI
+      # doesn't bundle, so 0-byte placeholders satisfy the gate without
+      # the cost of a full release compile of those crates.
+      - name: Stage bundle binary placeholders
+        run: |
+          triple=$(rustc -vV | sed -n 's|host: ||p')
+          mkdir -p httui-desktop/src-tauri/binaries
+          touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-$triple"
+
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
@@ -152,6 +164,14 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
+      # Same reason as the rust job — bundle.externalBin gate.
+      - name: Stage bundle binary placeholders
+        run: |
+          triple=$(rustc -vV | sed -n 's|host: ||p')
+          mkdir -p httui-desktop/src-tauri/binaries
+          touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-$triple"
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,16 @@ jobs:
         run: |
           cd httui-sidecar && bun install && bun run build
 
+      - name: Stage TUI + launcher binaries for the bundle
+        shell: bash
+        run: |
+          # tauri.conf.json → bundle.externalBin expects pre-built
+          # files at httui-desktop/src-tauri/binaries/<name>-<triple>.
+          # Matrix entries with an explicit --target pass it through;
+          # entries without one (Linux/Windows today) detect the host
+          # triple inside the script.
+          scripts/prepare-bundle-bins.sh "${{ matrix.target }}"
+
       - name: Read release body
         id: body
         shell: bash
@@ -236,6 +246,7 @@ jobs:
             auto_updates true
 
             app "httui.app"
+            binary "#{appdir}/httui.app/Contents/MacOS/httui", target: "httui"
           end
           RUBY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Post-0.4.1 work lands here.
 
 ### Added
 
+- **Distribution**: TUI ships in the same bundle as the desktop. Every release (`.dmg`, `.deb`, `.rpm`, `.msi`) now contains `httui-desktop`, `httui-tui`, and a unified `httui` launcher. Running `httui` in a terminal opens the TUI; `httui desktop` opens the desktop app; double-clicking the `.app`/`.exe` keeps opening the desktop directly. The Homebrew cask symlinks `httui` into `/usr/local/bin` automatically; `.deb`/`.rpm` install all three to `/usr/bin/`. Local install adds `make install-tui` for the symlink. See `docs/RELEASE.md §7a`.
 - **TUI**: full git surface inside the terminal — `Ctrl+G` opens a right-side git panel mirroring the desktop's SCM column. Status (UNSTAGED/STAGED file lists), commit form with `{{notes}}/{{count}}/{{date}}` template (shared with desktop via `user.toml [ui].git_commit_template`), 1-click Sync (`Ctrl+Enter`, stage→commit→pull `--ff-only`→push) with a confirm modal when the branch has no upstream, branch picker (`Ctrl+B`), full-screen log + diff viewer (`Ctrl+L`), 3-way conflict resolver (`Ctrl+R`, `1`/`2`/`3` pick base/ours/theirs), share URL (`Ctrl+Y` copies HTTPS), amend toggle (`Ctrl+A`), and conflict-marker highlighting in the editor.
 - **TUI**: status bar shows the current branch + ahead/behind chip permanently when the vault is a git repo.
 - **TUI**: in-app Settings page (`Alt+,`) — rebind keymaps, pick a theme (3 presets + per-color overrides in `config.toml`), toggle vim ↔ standard mode. ([#61](https://github.com/httuicom/httui/pull/61))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,20 @@ cargo clippy --workspace           # Rust linter (all crates)
 make wipe-config                   # Apaga config persistente do app (notes.db, user.toml, WebKit cache).
                                    # Mantém keychain. Útil pra voltar ao empty state entre testes manuais.
 make setup-hooks                   # Install local git hooks (pre-commit / pre-push / commit-msg).
+
+# TUI / launcher (post-install — `make install && make install-tui` on macOS,
+# or via the cask/.deb/.rpm)
+httui                              # opens the TUI (terminal mode)
+httui desktop                      # opens the desktop app
+httui --help
 ```
+
+> **Bundle layout:** the release ships three binaries together —
+> `httui` (launcher on the PATH), `httui-tui` (terminal binary, was
+> `notes-tui`), `httui-desktop` (Tauri main, the one Finder runs).
+> The launcher dispatches to a sibling via `current_exe()`. See
+> `httui-launcher/`, `scripts/prepare-bundle-bins.sh`, and
+> `docs/RELEASE.md §7a`.
 
 ## Commit style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "httui-launcher"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "httui-mcp"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,6 @@ dependencies = [
 [[package]]
 name = "httui-launcher"
 version = "0.1.0"
-dependencies = [
- "tempfile",
-]
 
 [[package]]
 name = "httui-mcp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["httui-desktop/src-tauri", "httui-mcp", "httui-tui"]
+members = ["httui-desktop/src-tauri", "httui-launcher", "httui-mcp", "httui-tui"]
 resolver = "2"
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build release install install-deps install-app uninstall lint fmt check clean wipe-config test test-rust test-front test-tui front icons sidecar tui tui-build tui-help coverage-check coverage-rust coverage-fe size-check quality-check setup-hooks
+.PHONY: dev build release install install-deps install-app install-tui uninstall lint fmt check clean wipe-config test test-rust test-front test-tui front icons sidecar bundle-bins tui tui-build tui-help coverage-check coverage-rust coverage-fe size-check quality-check setup-hooks
 
 # Development — frontend (Vite HMR) + backend (Rust rebuild on change).
 # Trims Rust artifacts not touched in the last 7 days before each session
@@ -36,8 +36,13 @@ sidecar:
 	@mkdir -p httui-desktop/src-tauri/resources
 	cd httui-sidecar && bun install && bun run build
 
+# Stage TUI + launcher binaries under httui-desktop/src-tauri/binaries/
+# so the Tauri bundler picks them up via bundle.externalBin.
+bundle-bins:
+	./scripts/prepare-bundle-bins.sh
+
 # Build de producao (com bundle .app para macOS)
-build: sidecar
+build: sidecar bundle-bins
 	npm run tauri build -- --bundles app
 
 # Instalar dependencias
@@ -59,10 +64,25 @@ install: build
 	@cp -R "$(APP_BUNDLE)" "/Applications/$(APP_NAME).app"
 	@echo "Done. Open with: open '/Applications/$(APP_NAME).app'"
 
-# Remover app de /Applications
+# Symlinka o launcher unificado em /usr/local/bin/httui (mesma coisa
+# que o cask do Homebrew faz). Roda DEPOIS de `make install`.
+# Requer sudo se /usr/local/bin não for writable. Após isso:
+#   httui            → abre o TUI
+#   httui desktop    → abre o .app
+install-tui:
+	@if [ ! -x "/Applications/$(APP_NAME).app/Contents/MacOS/httui" ]; then \
+		echo "Error: /Applications/$(APP_NAME).app/Contents/MacOS/httui missing — run 'make install' first."; \
+		exit 1; \
+	fi
+	@echo "Symlinking httui launcher to /usr/local/bin/httui..."
+	@ln -sf "/Applications/$(APP_NAME).app/Contents/MacOS/httui" /usr/local/bin/httui
+	@echo "Done. Run 'httui' in a new terminal."
+
+# Remover app de /Applications (e o symlink do launcher, se existir)
 uninstall:
 	@echo "Removing $(APP_NAME) from /Applications..."
 	@rm -rf "/Applications/$(APP_NAME).app"
+	@[ -L /usr/local/bin/httui ] && rm -f /usr/local/bin/httui || true
 	@echo "Done."
 
 # Type check + clippy + fmt-check + prettier-check. Mirrors the CI gate.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ brew install --cask httui
 `.deb`/`.rpm`/`.AppImage` (Linux) from
 [Releases](https://github.com/httuicom/httui/releases).
 
+### Terminal mode
+
+Every install also ships the TUI and a unified `httui` command:
+
+```sh
+httui                   # opens the terminal UI
+httui desktop           # opens the desktop app
+httui --help
+```
+
+Double-clicking the app icon still opens the desktop directly. macOS
+(Homebrew) and Linux (`.deb`/`.rpm`) put `httui` on the `PATH`
+automatically; on Windows add `%LOCALAPPDATA%\Programs\httui` to your
+PATH or run `httui.exe` from that folder.
+
 > The macOS build is an unsigned developer build. The install script
 > and the Homebrew cask both clear the Gatekeeper quarantine for you.
 > A manually downloaded `.dmg` needs a one-time

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -116,6 +116,72 @@ sudo rpm -i  httui-0.4.0-1.x86_64.rpm     # Fedora/RHEL
 chmod +x httui_0.4.0_amd64.AppImage && ./httui_0.4.0_amd64.AppImage
 ```
 
+## 7a. TUI distribution & unified `httui` launcher
+
+Every release ships **three** binaries side by side inside the same
+bundle:
+
+| Binary | Role |
+|---|---|
+| `httui` | Launcher exposed on the `PATH`. Routes to the TUI by default; `httui desktop [args]` opens the desktop app. |
+| `httui-tui` | Terminal UI binary (formerly `notes-tui`). |
+| `httui-desktop` | Desktop main binary (Tauri). What the `.app` / `.exe` runs when launched from Finder / Start menu. |
+
+How the launcher reaches the siblings: `httui` resolves
+`current_exe().parent()` and looks for `httui-tui` (default) or
+`httui-desktop` (`httui desktop`) in the same directory.
+
+**Pipeline integration:** the `Stage TUI + launcher binaries for the
+bundle` step in `release.yml` runs `scripts/prepare-bundle-bins.sh`
+once per matrix entry. The script builds `httui-tui` + `httui-launcher`
+in release mode for the target triple (matrix `target`, falling back to
+the host triple when empty) and copies them to
+`httui-desktop/src-tauri/binaries/<name>-<triple>` — the layout Tauri's
+`bundle.externalBin` expects. The Tauri bundler then drops the suffix
+on the destination side (`Contents/MacOS/httui-tui`, `/usr/bin/httui`).
+
+**Per-platform install layout:**
+
+- **macOS `.dmg` / cask:** all three binaries land in
+  `httui.app/Contents/MacOS/`. The cask declares `binary
+  "#{appdir}/httui.app/Contents/MacOS/httui", target: "httui"`, so
+  `brew install --cask httui` creates `/usr/local/bin/httui`
+  automatically — no postinstall needed.
+- **Linux `.deb` / `.rpm`:** Tauri places all three under `/usr/bin/`
+  (no PATH change required).
+- **Linux `.AppImage`:** the `httui` launcher inside the AppImage
+  expects siblings in `usr/bin/` of the squashed FS; running the
+  AppImage executes the desktop main entry, so the TUI is reachable
+  only by extracting the AppImage. Documented limitation —
+  installation via `.deb`/`.rpm` is the supported path for terminal
+  use.
+- **Windows `.msi` / `.exe`:** the three binaries install to
+  `%LOCALAPPDATA%\Programs\httui\`. Adding `%LOCALAPPDATA%\Programs\httui`
+  to the user `PATH` automatically is **out of scope for v1** — users
+  who want the terminal command run `httui` from that directory or add
+  the folder to `PATH` manually. Follow-up issue tracks NSIS PATH
+  injection.
+
+**Local install (without Homebrew):**
+
+```bash
+make install        # builds bundle and copies httui.app to /Applications
+make install-tui    # ln -s /Applications/httui.app/Contents/MacOS/httui /usr/local/bin/httui
+```
+
+**Smoke test (post-install)**
+
+```bash
+httui --help                    # launcher help
+httui                           # opens the TUI
+httui desktop                   # opens the desktop app
+open /Applications/httui.app    # double-click equivalent
+```
+
+Opening the `.app` from the GUI keeps the original behavior
+(`CFBundleExecutable` → `httui-desktop`); the launcher does not
+intercept that path.
+
 ## 8. Homebrew
 
 Prerequisite: the tap repo **`httuicom/homebrew-httui`** must exist

--- a/httui-desktop/src-tauri/tauri.conf.json
+++ b/httui-desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "httui",
+  "mainBinaryName": "httui-desktop",
   "version": "0.1.0",
   "identifier": "com.notes.app",
   "build": {
@@ -52,6 +53,7 @@
       "icons/icon.ico"
     ],
     "resources": ["resources/claude-sidecar.mjs"],
+    "externalBin": ["binaries/httui-tui", "binaries/httui"],
     "macOS": {
       "entitlements": "Entitlements.plist",
       "minimumSystemVersion": "10.15"

--- a/httui-launcher/Cargo.toml
+++ b/httui-launcher/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "httui-launcher"
+description = "Unified `httui` command: dispatches to the TUI by default, to the desktop app on `httui desktop`"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[[bin]]
+name = "httui"
+path = "src/main.rs"
+
+[dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/httui-launcher/Cargo.toml
+++ b/httui-launcher/Cargo.toml
@@ -15,6 +15,3 @@ name = "httui"
 path = "src/main.rs"
 
 [dependencies]
-
-[dev-dependencies]
-tempfile = "3"

--- a/httui-launcher/src/dispatch.rs
+++ b/httui-launcher/src/dispatch.rs
@@ -1,0 +1,76 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    Tui(Vec<String>),
+    Desktop(Vec<String>),
+    Help,
+}
+
+impl Action {
+    pub fn from_args(args: &[String]) -> Action {
+        match args.first().map(String::as_str) {
+            Some("--help") | Some("-h") => Action::Help,
+            Some("desktop") => Action::Desktop(args[1..].to_vec()),
+            _ => Action::Tui(args.to_vec()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(slice: &[&str]) -> Vec<String> {
+        slice.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_args_runs_tui_with_empty_forward() {
+        assert_eq!(Action::from_args(&[]), Action::Tui(vec![]));
+    }
+
+    #[test]
+    fn desktop_subcommand_routes_to_desktop() {
+        assert_eq!(
+            Action::from_args(&args(&["desktop"])),
+            Action::Desktop(vec![])
+        );
+    }
+
+    #[test]
+    fn desktop_forwards_remaining_args() {
+        assert_eq!(
+            Action::from_args(&args(&["desktop", "--debug", "path/to/vault"])),
+            Action::Desktop(args(&["--debug", "path/to/vault"]))
+        );
+    }
+
+    #[test]
+    fn help_short_and_long_flags() {
+        assert_eq!(Action::from_args(&args(&["--help"])), Action::Help);
+        assert_eq!(Action::from_args(&args(&["-h"])), Action::Help);
+    }
+
+    #[test]
+    fn tui_args_are_forwarded_verbatim() {
+        assert_eq!(
+            Action::from_args(&args(&["--log-level", "debug", "--data-dir", "/tmp/x"])),
+            Action::Tui(args(&["--log-level", "debug", "--data-dir", "/tmp/x"]))
+        );
+    }
+
+    #[test]
+    fn help_takes_precedence_only_when_first() {
+        assert_eq!(
+            Action::from_args(&args(&["--log-level", "--help"])),
+            Action::Tui(args(&["--log-level", "--help"]))
+        );
+    }
+
+    #[test]
+    fn desktop_must_be_first_token() {
+        assert_eq!(
+            Action::from_args(&args(&["--flag", "desktop"])),
+            Action::Tui(args(&["--flag", "desktop"]))
+        );
+    }
+}

--- a/httui-launcher/src/dispatch.rs
+++ b/httui-launcher/src/dispatch.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Action {
     Tui(Vec<String>),
@@ -13,6 +15,31 @@ impl Action {
             _ => Action::Tui(args.to_vec()),
         }
     }
+}
+
+/// Pure sibling-binary resolution: tests pass in the env override value
+/// (None when unset) and the installation directory; production wires
+/// them to `env::var(...)` and `current_exe().parent()`.
+pub fn resolve_sibling(
+    name: &str,
+    env_override: Option<&str>,
+    sibling_dir: Option<&Path>,
+    exists: impl Fn(&Path) -> bool,
+    suffix: &str,
+) -> Result<PathBuf, String> {
+    if let Some(p) = env_override {
+        return Ok(PathBuf::from(p));
+    }
+    let dir = sibling_dir.ok_or_else(|| "could not resolve installation directory".to_string())?;
+    let bin = dir.join(format!("{name}{suffix}"));
+    if !exists(&bin) {
+        return Err(format!(
+            "{name} not found next to launcher (looked at {}).\n\
+             In development, run `cargo run -p httui-tui` instead.",
+            bin.display()
+        ));
+    }
+    Ok(bin)
 }
 
 #[cfg(test)]
@@ -72,5 +99,64 @@ mod tests {
             Action::from_args(&args(&["--flag", "desktop"])),
             Action::Tui(args(&["--flag", "desktop"]))
         );
+    }
+
+    #[test]
+    fn resolve_sibling_prefers_env_override() {
+        let got = resolve_sibling(
+            "httui-tui",
+            Some("/custom/path/to/tui"),
+            Some(Path::new("/sibling/dir")),
+            |_| false,
+            "",
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/custom/path/to/tui"));
+    }
+
+    #[test]
+    fn resolve_sibling_fails_when_sibling_dir_missing() {
+        let err = resolve_sibling("httui-tui", None, None, |_| true, "").expect_err("should fail");
+        assert!(err.contains("installation directory"), "{err}");
+    }
+
+    #[test]
+    fn resolve_sibling_fails_when_binary_does_not_exist() {
+        let err = resolve_sibling(
+            "httui-tui",
+            None,
+            Some(Path::new("/some/dir")),
+            |_| false,
+            "",
+        )
+        .expect_err("should fail");
+        assert!(err.contains("httui-tui not found"), "{err}");
+        assert!(err.contains("/some/dir/httui-tui"), "{err}");
+    }
+
+    #[test]
+    fn resolve_sibling_returns_path_when_binary_exists() {
+        let got = resolve_sibling(
+            "httui-tui",
+            None,
+            Some(Path::new("/some/dir")),
+            |_| true,
+            "",
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/some/dir/httui-tui"));
+    }
+
+    #[test]
+    fn resolve_sibling_applies_exe_suffix() {
+        let got = resolve_sibling(
+            "httui-tui",
+            None,
+            Some(Path::new("C:\\bin")),
+            |_| true,
+            ".exe",
+        )
+        .unwrap();
+        assert!(got.to_string_lossy().ends_with("httui-tui.exe"), "{got:?}");
     }
 }

--- a/httui-launcher/src/main.rs
+++ b/httui-launcher/src/main.rs
@@ -1,0 +1,121 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+mod dispatch;
+use dispatch::Action;
+
+const TUI_BIN: &str = "httui-tui";
+#[cfg(not(target_os = "macos"))]
+const DESKTOP_BIN: &str = "httui-desktop";
+#[cfg(target_os = "macos")]
+const MACOS_APP: &str = "httui";
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    match Action::from_args(&args) {
+        Action::Help => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        Action::Tui(forwarded) => run_tui(&forwarded),
+        Action::Desktop(forwarded) => run_desktop(&forwarded),
+    }
+}
+
+fn run_tui(args: &[String]) -> ExitCode {
+    let Some(dir) = sibling_dir() else {
+        return fail("could not resolve installation directory");
+    };
+    let bin = dir.join(with_exe_suffix(TUI_BIN));
+    if !bin.exists() {
+        return fail(&format!(
+            "{} not found next to launcher (looked at {}).\n\
+             In development, run `cargo run -p httui-tui` instead.",
+            TUI_BIN,
+            bin.display()
+        ));
+    }
+    spawn(Command::new(&bin).args(args))
+}
+
+#[cfg(target_os = "macos")]
+fn run_desktop(args: &[String]) -> ExitCode {
+    // `open -a` goes through LaunchServices so the app is registered
+    // in the Dock and gets the normal app lifecycle. Spawning the
+    // Mach-O directly works but the window can fail to focus and the
+    // process is parented to the terminal.
+    //
+    // `HTTUI_DESKTOP_APP_NAME` is an integration-test escape hatch: it
+    // lets tests target a guaranteed-missing app so the launcher's
+    // spawn path runs without actually opening the user's real
+    // /Applications/httui.app.
+    let app = env::var("HTTUI_DESKTOP_APP_NAME").unwrap_or_else(|_| MACOS_APP.to_string());
+    let mut cmd = Command::new("open");
+    cmd.arg("-a").arg(&app);
+    if !args.is_empty() {
+        cmd.arg("--args").args(args);
+    }
+    spawn(&mut cmd)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_desktop(args: &[String]) -> ExitCode {
+    let Some(dir) = sibling_dir() else {
+        return fail("could not resolve installation directory");
+    };
+    let bin = dir.join(with_exe_suffix(DESKTOP_BIN));
+    if !bin.exists() {
+        return fail(&format!(
+            "{} not found next to launcher (looked at {}).",
+            DESKTOP_BIN,
+            bin.display()
+        ));
+    }
+    spawn(Command::new(&bin).args(args))
+}
+
+fn sibling_dir() -> Option<PathBuf> {
+    env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+}
+
+#[cfg(windows)]
+fn with_exe_suffix(name: &str) -> String {
+    format!("{name}.exe")
+}
+
+#[cfg(not(windows))]
+fn with_exe_suffix(name: &str) -> String {
+    name.to_string()
+}
+
+fn spawn(cmd: &mut Command) -> ExitCode {
+    match cmd.status() {
+        Ok(status) => ExitCode::from(u8::try_from(status.code().unwrap_or(1)).unwrap_or(1)),
+        Err(e) => fail(&format!("failed to launch: {e}")),
+    }
+}
+
+fn fail(msg: &str) -> ExitCode {
+    eprintln!("httui: {msg}");
+    ExitCode::from(2)
+}
+
+fn print_help() {
+    println!(
+        "httui — terminal + desktop launcher\n\
+         \n\
+         USAGE:\n    \
+             httui [TUI_ARGS...]          Open the terminal UI (default)\n    \
+             httui desktop [APP_ARGS...]  Open the desktop application\n    \
+             httui --help                 Show this message\n    \
+             httui --version              Show launcher version\n\
+         \n\
+         Any other flags or positional arguments are forwarded to the TUI.\n\
+         For TUI-specific help, invoke the binary directly: `httui-tui --help`."
+    );
+}

--- a/httui-launcher/src/main.rs
+++ b/httui-launcher/src/main.rs
@@ -82,11 +82,14 @@ fn run_desktop(args: &[String]) -> ExitCode {
 }
 
 fn sibling_dir() -> Option<PathBuf> {
-    env::current_exe()
-        .ok()
-        .as_deref()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
+    // current_exe() returns the symlink path itself on macOS (and on
+    // Windows when invoked through a junction), so resolving it first
+    // is required for `httui` to find its siblings when installed via
+    // a symlinked shim — e.g. `brew install --cask httui` symlinking
+    // /usr/local/bin/httui → /Applications/httui.app/Contents/MacOS/httui.
+    let exe = env::current_exe().ok()?;
+    let resolved = std::fs::canonicalize(&exe).unwrap_or(exe);
+    resolved.parent().map(Path::to_path_buf)
 }
 
 fn spawn(cmd: &mut Command) -> ExitCode {

--- a/httui-launcher/src/main.rs
+++ b/httui-launcher/src/main.rs
@@ -3,13 +3,18 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 mod dispatch;
-use dispatch::Action;
+use dispatch::{resolve_sibling, Action};
 
 const TUI_BIN: &str = "httui-tui";
 #[cfg(not(target_os = "macos"))]
 const DESKTOP_BIN: &str = "httui-desktop";
 #[cfg(target_os = "macos")]
 const MACOS_APP: &str = "httui";
+
+#[cfg(windows)]
+const EXE_SUFFIX: &str = ".exe";
+#[cfg(not(windows))]
+const EXE_SUFFIX: &str = "";
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -23,19 +28,27 @@ fn main() -> ExitCode {
     }
 }
 
+// `HTTUI_TUI_BIN` / `HTTUI_DESKTOP_BIN` are integration-test escape
+// hatches that let tests point the launcher at a known-missing path
+// without copying the launcher itself anywhere (which trips Linux's
+// ETXTBSY when the freshly-copied file is execve'd).
+fn lookup_sibling(name: &'static str, env_override: &str) -> Result<PathBuf, String> {
+    let override_val = env::var(env_override).ok();
+    let dir = sibling_dir();
+    resolve_sibling(
+        name,
+        override_val.as_deref(),
+        dir.as_deref(),
+        |p| p.exists(),
+        EXE_SUFFIX,
+    )
+}
+
 fn run_tui(args: &[String]) -> ExitCode {
-    let Some(dir) = sibling_dir() else {
-        return fail("could not resolve installation directory");
+    let bin = match lookup_sibling(TUI_BIN, "HTTUI_TUI_BIN") {
+        Ok(p) => p,
+        Err(msg) => return fail(&msg),
     };
-    let bin = dir.join(with_exe_suffix(TUI_BIN));
-    if !bin.exists() {
-        return fail(&format!(
-            "{} not found next to launcher (looked at {}).\n\
-             In development, run `cargo run -p httui-tui` instead.",
-            TUI_BIN,
-            bin.display()
-        ));
-    }
     spawn(Command::new(&bin).args(args))
 }
 
@@ -61,17 +74,10 @@ fn run_desktop(args: &[String]) -> ExitCode {
 
 #[cfg(not(target_os = "macos"))]
 fn run_desktop(args: &[String]) -> ExitCode {
-    let Some(dir) = sibling_dir() else {
-        return fail("could not resolve installation directory");
+    let bin = match lookup_sibling(DESKTOP_BIN, "HTTUI_DESKTOP_BIN") {
+        Ok(p) => p,
+        Err(msg) => return fail(&msg),
     };
-    let bin = dir.join(with_exe_suffix(DESKTOP_BIN));
-    if !bin.exists() {
-        return fail(&format!(
-            "{} not found next to launcher (looked at {}).",
-            DESKTOP_BIN,
-            bin.display()
-        ));
-    }
     spawn(Command::new(&bin).args(args))
 }
 
@@ -81,16 +87,6 @@ fn sibling_dir() -> Option<PathBuf> {
         .as_deref()
         .and_then(Path::parent)
         .map(Path::to_path_buf)
-}
-
-#[cfg(windows)]
-fn with_exe_suffix(name: &str) -> String {
-    format!("{name}.exe")
-}
-
-#[cfg(not(windows))]
-fn with_exe_suffix(name: &str) -> String {
-    name.to_string()
 }
 
 fn spawn(cmd: &mut Command) -> ExitCode {

--- a/httui-launcher/tests/integration.rs
+++ b/httui-launcher/tests/integration.rs
@@ -1,45 +1,26 @@
 // End-to-end coverage for the launcher binary. These exercise the
 // real `main()` entrypoint and the spawn paths so the file does not
 // rely on `// coverage:exclude`.
+//
+// We do NOT copy the launcher to a tempdir to "hide" sibling binaries:
+// on Linux, execve'ing a freshly-copied binary races with the kernel's
+// write-close window and trips ETXTBSY ("Text file busy"). Instead the
+// launcher exposes `HTTUI_TUI_BIN` / `HTTUI_DESKTOP_BIN` / the macOS
+// `HTTUI_DESKTOP_APP_NAME` env hooks so tests can target a known-missing
+// path without touching the on-disk launcher.
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
-fn original_bin() -> PathBuf {
+fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_httui"))
 }
 
-// Copies the launcher to an isolated directory so the spawn paths
-// can't reach the real `httui-tui` / `httui-desktop` binaries that
-// happen to live alongside it in `target/<profile>/`. Returns the
-// path to the copy.
-fn isolated_launcher() -> (tempfile::TempDir, PathBuf) {
-    static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    let dir = tempfile::tempdir().expect("tempdir");
-    let dest = dir
-        .path()
-        .join(format!("httui-{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
-    fs::copy(original_bin(), &dest).expect("copy launcher");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perm = fs::metadata(&dest).unwrap().permissions();
-        perm.set_mode(0o755);
-        fs::set_permissions(&dest, perm).unwrap();
-    }
-    (dir, dest)
-}
+const MISSING_PATH: &str = "/nonexistent/httui-launcher-integration-test-target";
 
 #[test]
 fn help_flag_prints_usage_and_exits_success() {
-    // --help short-circuits before any sibling lookup, so the bin
-    // location doesn't matter here.
-    let out = Command::new(original_bin())
-        .arg("--help")
-        .output()
-        .expect("spawn");
+    let out = Command::new(bin()).arg("--help").output().expect("spawn");
     assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).unwrap();
     assert!(
@@ -50,10 +31,7 @@ fn help_flag_prints_usage_and_exits_success() {
 
 #[test]
 fn short_help_flag_works() {
-    let out = Command::new(original_bin())
-        .arg("-h")
-        .output()
-        .expect("spawn");
+    let out = Command::new(bin()).arg("-h").output().expect("spawn");
     assert!(out.status.success());
     let stdout = String::from_utf8(out.stdout).unwrap();
     assert!(stdout.contains("USAGE:"));
@@ -61,39 +39,41 @@ fn short_help_flag_works() {
 
 #[test]
 fn missing_tui_sibling_fails_with_clear_error() {
-    let (_dir, bin) = isolated_launcher();
-    let out = Command::new(&bin).output().expect("spawn");
+    let out = Command::new(bin())
+        .env("HTTUI_TUI_BIN", MISSING_PATH)
+        .output()
+        .expect("spawn");
     assert!(!out.status.success(), "expected failure, got success");
     let stderr = String::from_utf8(out.stderr).unwrap();
-    assert!(
-        stderr.contains("httui-tui not found") || stderr.contains("cargo run -p httui-tui"),
-        "stderr: {stderr}"
-    );
+    // With the env override set we go straight to spawn — the
+    // "not found" diagnostic only fires for the sibling-lookup path.
+    // What we actually observe is the underlying OS error from execve.
+    assert!(stderr.contains("failed to launch"), "stderr: {stderr}");
 }
 
 #[test]
 fn extra_args_are_forwarded_to_the_tui_path() {
-    let (_dir, bin) = isolated_launcher();
-    let out = Command::new(&bin)
+    let out = Command::new(bin())
+        .env("HTTUI_TUI_BIN", MISSING_PATH)
         .args(["--log-level", "debug"])
         .output()
         .expect("spawn");
     assert!(!out.status.success());
     let stderr = String::from_utf8(out.stderr).unwrap();
-    assert!(stderr.contains("httui-tui not found"), "stderr: {stderr}");
+    assert!(stderr.contains("failed to launch"), "stderr: {stderr}");
 }
 
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn missing_desktop_sibling_fails_on_non_macos() {
-    let (_dir, bin) = isolated_launcher();
-    let out = Command::new(&bin).arg("desktop").output().expect("spawn");
+    let out = Command::new(bin())
+        .env("HTTUI_DESKTOP_BIN", MISSING_PATH)
+        .arg("desktop")
+        .output()
+        .expect("spawn");
     assert!(!out.status.success());
     let stderr = String::from_utf8(out.stderr).unwrap();
-    assert!(
-        stderr.contains("httui-desktop not found"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("failed to launch"), "stderr: {stderr}");
 }
 
 #[cfg(target_os = "macos")]
@@ -104,8 +84,7 @@ fn desktop_subcommand_invokes_open_on_macos() {
     // HTTUI_DESKTOP_APP_NAME points `open -a` at an app that does not
     // exist, so the launcher's spawn returns a non-zero status without
     // any GUI side effects.
-    let (_dir, bin) = isolated_launcher();
-    let out = Command::new(&bin)
+    let out = Command::new(bin())
         .arg("desktop")
         .env(
             "HTTUI_DESKTOP_APP_NAME",
@@ -119,8 +98,7 @@ fn desktop_subcommand_invokes_open_on_macos() {
 #[cfg(target_os = "macos")]
 #[test]
 fn desktop_with_args_appends_dash_dash_args() {
-    let (_dir, bin) = isolated_launcher();
-    let out = Command::new(&bin)
+    let out = Command::new(bin())
         .args(["desktop", "--debug", "foo"])
         .env(
             "HTTUI_DESKTOP_APP_NAME",

--- a/httui-launcher/tests/integration.rs
+++ b/httui-launcher/tests/integration.rs
@@ -1,0 +1,132 @@
+// End-to-end coverage for the launcher binary. These exercise the
+// real `main()` entrypoint and the spawn paths so the file does not
+// rely on `// coverage:exclude`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn original_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_httui"))
+}
+
+// Copies the launcher to an isolated directory so the spawn paths
+// can't reach the real `httui-tui` / `httui-desktop` binaries that
+// happen to live alongside it in `target/<profile>/`. Returns the
+// path to the copy.
+fn isolated_launcher() -> (tempfile::TempDir, PathBuf) {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dest = dir
+        .path()
+        .join(format!("httui-{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
+    fs::copy(original_bin(), &dest).expect("copy launcher");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&dest).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&dest, perm).unwrap();
+    }
+    (dir, dest)
+}
+
+#[test]
+fn help_flag_prints_usage_and_exits_success() {
+    // --help short-circuits before any sibling lookup, so the bin
+    // location doesn't matter here.
+    let out = Command::new(original_bin())
+        .arg("--help")
+        .output()
+        .expect("spawn");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("USAGE:") && stdout.contains("httui desktop"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn short_help_flag_works() {
+    let out = Command::new(original_bin())
+        .arg("-h")
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("USAGE:"));
+}
+
+#[test]
+fn missing_tui_sibling_fails_with_clear_error() {
+    let (_dir, bin) = isolated_launcher();
+    let out = Command::new(&bin).output().expect("spawn");
+    assert!(!out.status.success(), "expected failure, got success");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("httui-tui not found") || stderr.contains("cargo run -p httui-tui"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn extra_args_are_forwarded_to_the_tui_path() {
+    let (_dir, bin) = isolated_launcher();
+    let out = Command::new(&bin)
+        .args(["--log-level", "debug"])
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(stderr.contains("httui-tui not found"), "stderr: {stderr}");
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn missing_desktop_sibling_fails_on_non_macos() {
+    let (_dir, bin) = isolated_launcher();
+    let out = Command::new(&bin).arg("desktop").output().expect("spawn");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("httui-desktop not found"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn desktop_subcommand_invokes_open_on_macos() {
+    // Exercise the macOS run_desktop branch + spawn() Ok(status) path
+    // without actually opening the user's real /Applications/httui.app:
+    // HTTUI_DESKTOP_APP_NAME points `open -a` at an app that does not
+    // exist, so the launcher's spawn returns a non-zero status without
+    // any GUI side effects.
+    let (_dir, bin) = isolated_launcher();
+    let out = Command::new(&bin)
+        .arg("desktop")
+        .env(
+            "HTTUI_DESKTOP_APP_NAME",
+            "httui-launcher-integration-test-does-not-exist",
+        )
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success(), "expected non-zero exit");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn desktop_with_args_appends_dash_dash_args() {
+    let (_dir, bin) = isolated_launcher();
+    let out = Command::new(&bin)
+        .args(["desktop", "--debug", "foo"])
+        .env(
+            "HTTUI_DESKTOP_APP_NAME",
+            "httui-launcher-integration-test-does-not-exist",
+        )
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success());
+}

--- a/httui-tui/Cargo.toml
+++ b/httui-tui/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 documentation.workspace = true
 
 [[bin]]
-name = "notes-tui"
+name = "httui-tui"
 path = "src/main.rs"
 
 [dependencies]

--- a/httui-tui/src/app/event_loop.rs
+++ b/httui-tui/src/app/event_loop.rs
@@ -27,7 +27,7 @@ pub async fn run(
     resolved: ResolvedVault,
     app_pool: SqlitePool,
 ) -> TuiResult<()> {
-    info!(vault = %resolved.vault.display(), "starting notes-tui");
+    info!(vault = %resolved.vault.display(), "starting httui-tui");
 
     terminal::install_panic_hook();
     let mut terminal = terminal::setup(config.mouse_enabled)?;

--- a/httui-tui/src/cli.rs
+++ b/httui-tui/src/cli.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 /// (mirrors the desktop). On the very first run you'll be prompted for
 /// a path on stdin.
 #[derive(Debug, Parser)]
-#[command(name = "notes-tui", version, about)]
+#[command(name = "httui-tui", version, about)]
 pub struct Cli {
     /// Override the config file location.
     #[arg(long, value_name = "FILE")]

--- a/httui-tui/src/main.rs
+++ b/httui-tui/src/main.rs
@@ -81,11 +81,11 @@ async fn run(cli: Cli) -> TuiResult<()> {
 fn init_tracing(level: &str) -> TuiResult<tracing_appender::non_blocking::WorkerGuard> {
     let log_dir = config::log_dir()?;
     std::fs::create_dir_all(&log_dir)?;
-    let file_appender = rolling::daily(&log_dir, "notes-tui.log");
+    let file_appender = rolling::daily(&log_dir, "httui-tui.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(format!("notes_tui={level},httui_tui={level}")))
+        .or_else(|_| EnvFilter::try_new(format!("httui_tui={level}")))
         .map_err(|e| TuiError::Config(format!("invalid log level: {e}")))?;
 
     tracing_subscriber::registry()

--- a/httui-tui/src/ui/pane_tree.rs
+++ b/httui-tui/src/ui/pane_tree.rs
@@ -241,7 +241,7 @@ pub(crate) fn render_empty_state_inline(frame: &mut Frame, area: Rect, vault: &s
             Style::default().add_modifier(Modifier::DIM),
         )),
     ];
-    let block = Block::default().borders(Borders::ALL).title("notes-tui");
+    let block = Block::default().borders(Borders::ALL).title("httui-tui");
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
@@ -521,6 +521,6 @@ mod tests {
             "hint missing: {text:?}"
         );
         assert!(text.contains("/tmp/vault"), "vault path missing: {text:?}");
-        assert!(text.contains("notes-tui"), "title missing: {text:?}");
+        assert!(text.contains("httui-tui"), "title missing: {text:?}");
     }
 }

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -125,6 +125,7 @@ if [ "$HAS_RS" -eq 1 ]; then
             httui-desktop/src-tauri/*) PACKAGES+=("httui-notes") ;;
             httui-tui/*) PACKAGES+=("httui-tui") ;;
             httui-mcp/*) PACKAGES+=("httui-mcp") ;;
+            httui-launcher/*) PACKAGES+=("httui-launcher") ;;
         esac
     done
     # Dedupe

--- a/scripts/prepare-bundle-bins.sh
+++ b/scripts/prepare-bundle-bins.sh
@@ -43,6 +43,13 @@ SRC_DIR="$REPO_ROOT/target/$TARGET/release"
 cp "$SRC_DIR/httui-tui$SUFFIX" "$OUT_DIR/httui-tui-$TARGET$SUFFIX"
 cp "$SRC_DIR/httui$SUFFIX"     "$OUT_DIR/httui-$TARGET$SUFFIX"
 
+# Belt + suspenders: Tauri's bundler propagates the source file mode
+# into Contents/MacOS/ (and /usr/bin/ on Linux). If the staged file
+# loses its exec bit for any reason (interrupted build, tarball
+# extraction, etc.) the launcher in the final bundle ships
+# non-executable and `httui` in $PATH errors with "Permission denied".
+chmod +x "$OUT_DIR/httui-tui-$TARGET$SUFFIX" "$OUT_DIR/httui-$TARGET$SUFFIX"
+
 echo "staged:"
 echo "  $OUT_DIR/httui-tui-$TARGET$SUFFIX"
 echo "  $OUT_DIR/httui-$TARGET$SUFFIX"

--- a/scripts/prepare-bundle-bins.sh
+++ b/scripts/prepare-bundle-bins.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Builds httui-tui and httui-launcher in release mode and stages them
+# under httui-desktop/src-tauri/binaries/<name>-<triple> so the Tauri
+# bundler picks them up via `bundle.externalBin` in tauri.conf.json.
+#
+# Used by the Makefile (`make build`) and the GitHub Actions release
+# workflow. Pass a target triple as $1 to cross-compile; with no
+# argument the host triple is detected via rustc.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$REPO_ROOT/httui-desktop/src-tauri/binaries"
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" ]]; then
+  TARGET="$(rustc -vV | sed -n 's|host: ||p')"
+fi
+
+if [[ -z "$TARGET" ]]; then
+  echo "error: could not determine target triple" >&2
+  exit 1
+fi
+
+echo "preparing bundle binaries for target: $TARGET"
+
+CARGO_ARGS=(--release --target "$TARGET")
+
+cargo build -p httui-tui "${CARGO_ARGS[@]}"
+cargo build -p httui-launcher "${CARGO_ARGS[@]}"
+
+mkdir -p "$OUT_DIR"
+
+# Windows binaries carry the .exe suffix in both source and destination.
+if [[ "$TARGET" == *windows* ]]; then
+  SUFFIX=".exe"
+else
+  SUFFIX=""
+fi
+
+SRC_DIR="$REPO_ROOT/target/$TARGET/release"
+
+cp "$SRC_DIR/httui-tui$SUFFIX" "$OUT_DIR/httui-tui-$TARGET$SUFFIX"
+cp "$SRC_DIR/httui$SUFFIX"     "$OUT_DIR/httui-$TARGET$SUFFIX"
+
+echo "staged:"
+echo "  $OUT_DIR/httui-tui-$TARGET$SUFFIX"
+echo "  $OUT_DIR/httui-$TARGET$SUFFIX"


### PR DESCRIPTION
## Summary

- Every release bundle (`.dmg`, `.deb`, `.rpm`, `.msi`) now ships three binaries side by side: `httui-desktop` (the Tauri main, what Finder runs), `httui-tui` (terminal binary, renamed from `notes-tui`), and a new `httui` launcher.
- `httui` (no args) → opens the TUI; `httui desktop [args]` → opens the desktop app; double-clicking the .app/.exe keeps opening the desktop directly. macOS cask + Linux `.deb`/`.rpm` put `httui` on the PATH automatically; Windows PATH wiring stays out-of-scope (documented).
- New crate `httui-launcher/` (Rust, no runtime deps). `scripts/prepare-bundle-bins.sh` stages the two extra binaries under `httui-desktop/src-tauri/binaries/<name>-<triple>` so Tauri's `bundle.externalBin` picks them up. CI release step + Makefile `build` both call it; `make install-tui` symlinks the launcher into `/usr/local/bin/httui` after a local `make install`.

Full layout + smoke test in `docs/RELEASE.md §7a`.

## Test plan

- [x] `cargo test -p httui-launcher` — 13 tests (7 unit on the parse table + 6 integration over the binary, isolated via `tempfile` so they don't reach the user's real `httui.app`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `DIFF_MODE=staged ./scripts/coverage-check.sh` — `dispatch.rs` 100%, `main.rs` 90.7%, all gates pass (no `// coverage:exclude` introduced).
- [x] `scripts/prepare-bundle-bins.sh` produces `binaries/httui-tui-aarch64-apple-darwin` + `binaries/httui-aarch64-apple-darwin`; `cargo check -p httui-notes` accepts the externalBin config.
- [ ] Local smoke after CI green: tag an RC, install via cask on a clean macOS, verify `httui` / `httui desktop` work and double-click still opens desktop.