### PR TITLE
feat(desktop): typed ref hovers, field completion and shape refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,17 @@ jobs:
 
       - name: cargo test
         if: ${{ !cancelled() }}
-        run: cargo test --workspace
+        # tauri-build copies the staged sidecar placeholder over
+        # target/debug/httui — the launcher's own output. With a warm
+        # cache the launcher is not relinked afterwards, so its
+        # integration tests would spawn the 0-byte placeholder
+        # (EACCES). Relink it after the workspace build so the tests
+        # spawn the real binary.
+        run: |
+          cargo build --workspace --all-targets
+          touch httui-launcher/src/main.rs
+          cargo build -p httui-launcher
+          cargo test --workspace
 
       - name: cargo check (all targets)
         if: ${{ !cancelled() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1195,7 +1195,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1405,7 +1405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2267,7 +2267,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "httui-core"
 version = "0.1.0"
-source = "git+https://github.com/httuicom/httui-core?rev=af75dbea47d59c195081469e096b33b8d231ecf9#af75dbea47d59c195081469e096b33b8d231ecf9"
+source = "git+https://github.com/httuicom/httui-core?rev=6e2f97db9f3201d931c59fe1c4da93904355f73f#6e2f97db9f3201d931c59fe1c4da93904355f73f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3344,7 +3344,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4321,7 +4321,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4849,7 +4849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4906,7 +4906,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6418,7 +6418,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7540,7 +7540,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/lang-xml": "^6.1.0",
         "@codemirror/language-data": "^6.5.2",
+        "@codemirror/lsp-client": "^6.2.5",
         "@codemirror/merge": "^6.12.1",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@dnd-kit/core": "^6.3.1",
@@ -76,31 +77,6 @@
       "devDependencies": {
         "@types/node": "^25.8.0",
         "typescript": "^6.0.3",
-      },
-    },
-    "httui-web": {
-      "name": "httui-landing",
-      "dependencies": {
-        "@chakra-ui/react": "^3.34.0",
-        "@emotion/react": "^11.14.0",
-        "lowlight": "^3.3.0",
-        "next-themes": "^0.4.6",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
-        "react-icons": "^5.6.0",
-        "react-markdown": "^10.1.0",
-        "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^4.0.1",
-      },
-      "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "@types/react": "^19.2.0",
-        "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^6.0.2",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.3",
-        "vite": "^8.0.13",
       },
     },
   },
@@ -252,6 +228,8 @@
     "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
 
     "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/lsp-client": ["@codemirror/lsp-client@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.20.0", "@codemirror/language": "^6.11.0", "@codemirror/lint": "^6.8.5", "@codemirror/state": "^6.5.2", "@codemirror/view": "^6.37.0", "@lezer/highlight": "^1.2.1", "marked": "^15.0.12", "vscode-languageserver-protocol": "^3.17.5" } }, "sha512-1EqhGRmCZOV7Me+rRuwwkTuvkNoD4Nz6UcE1yx5gdwTVTLD4D9xIy48MJc0LeBQGFLn/HNRW/pHmet4EAEkJFQ=="],
 
     "@codemirror/merge": ["@codemirror/merge@6.12.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/highlight": "^1.0.0", "style-mod": "^4.1.0" } }, "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w=="],
 
@@ -541,7 +519,7 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.10.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.1", "@tauri-apps/cli-darwin-x64": "2.10.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1", "@tauri-apps/cli-linux-arm64-gnu": "2.10.1", "@tauri-apps/cli-linux-arm64-musl": "2.10.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-musl": "2.10.1", "@tauri-apps/cli-win32-arm64-msvc": "2.10.1", "@tauri-apps/cli-win32-ia32-msvc": "2.10.1", "@tauri-apps/cli-win32-x64-msvc": "2.10.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g=="],
 
@@ -1161,7 +1139,7 @@
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1198,8 +1176,6 @@
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "httui-landing": ["httui-landing@workspace:httui-web"],
 
     "httui-notes": ["httui-notes@workspace:httui-desktop"],
 
@@ -1325,7 +1301,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@16.4.2", "", { "bin": "bin/marked.js" }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -1575,7 +1551,7 @@
 
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
-    "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1741,15 +1717,23 @@
 
     "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
+    "@emotion/babel-plugin/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
     "@emotion/babel-plugin/stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
 
     "@emotion/cache/stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@tauri-apps/plugin-dialog/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+    "@tauri-apps/plugin-notification/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
-    "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+    "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-shell/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-sql/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
@@ -1775,17 +1759,17 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": "bin/marked.js" }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "tsconfck/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/httui-desktop/src-tauri/Cargo.toml
+++ b/httui-desktop/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ documentation.workspace = true
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-httui-core = { git = "https://github.com/httuicom/httui-core", rev = "af75dbea47d59c195081469e096b33b8d231ecf9" }
+httui-core = { git = "https://github.com/httuicom/httui-core", rev = "6e2f97db9f3201d931c59fe1c4da93904355f73f" }
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"

--- a/httui-desktop/src-tauri/src/commands/blocks.rs
+++ b/httui-desktop/src-tauri/src/commands/blocks.rs
@@ -67,6 +67,21 @@ pub async fn execute_block(
     registry.execute(req).await.map_err(|e| e.to_string())
 }
 
+/// Latest cached result for `(file_path, alias)` regardless of content
+/// hash. Read-side resolution (`{{alias.response.…}}` hover/autocomplete)
+/// must use this: the write side keys HTTP rows by a request+env hash
+/// the document scanner cannot reproduce.
+#[tauri::command]
+pub async fn get_latest_block_result_by_alias(
+    pool: State<'_, SqlitePool>,
+    file_path: String,
+    alias: String,
+) -> Result<Option<CachedBlockResult>, String> {
+    block_results::get_latest_block_result_by_alias(&pool, &file_path, &alias)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Look up a previously cached `BlockResult` by `(file_path, block_hash)`.
 /// Returns `None` if no cached row matches.
 #[tauri::command]
@@ -82,20 +97,25 @@ pub async fn get_block_result(
 
 /// Persist the terminal outcome of a block execution into the cache so
 /// the next run with the same content + env context can short-circuit.
+/// When `alias` is present, a successful save also refreshes the
+/// inferred response shape that ref resolution reads.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn save_block_result(
     pool: State<'_, SqlitePool>,
     file_path: String,
     block_hash: String,
+    alias: Option<String>,
     status: String,
     response: String,
     elapsed_ms: i64,
     total_rows: Option<i64>,
 ) -> Result<(), String> {
-    block_results::save_block_result(
+    block_results::save_block_result_with_alias(
         &pool,
         &file_path,
         &block_hash,
+        alias.as_deref(),
         &status,
         &response,
         elapsed_ms,

--- a/httui-desktop/src-tauri/src/main.rs
+++ b/httui-desktop/src-tauri/src/main.rs
@@ -411,6 +411,7 @@ fn main() {
             httui_notes::commands::blocks::delete_block_example,
             httui_notes::commands::blocks::purge_block_examples,
             httui_notes::commands::blocks::get_block_result,
+            httui_notes::commands::blocks::get_latest_block_result_by_alias,
             httui_notes::commands::blocks::save_block_result,
             httui_notes::commands::blocks::compute_block_hash,
             httui_notes::commands::settings::get_config,

--- a/httui-desktop/src/components/blocks/db/fenced/DbFencedPanel.tsx
+++ b/httui-desktop/src/components/blocks/db/fenced/DbFencedPanel.tsx
@@ -23,7 +23,6 @@ import {
   type DbPortalEntry,
 } from "@/lib/codemirror/cm-db-block";
 import {
-  parseLegacyDbBody,
   stringifyDbFenceInfo,
   type DbBlockMetadata,
 } from "@/lib/blocks/db-fence";
@@ -36,7 +35,7 @@ import {
   type DbResponse,
 } from "@/components/blocks/db/types";
 import { computeDbCacheHash } from "@/lib/blocks/hash";
-import { getBlockResult, saveBlockResult } from "@/lib/tauri/commands";
+import { saveBlockResult } from "@/lib/tauri/commands";
 import { notifyBlockRan } from "@/lib/lsp/client";
 import { listConnections, type Connection } from "@/lib/tauri/connections";
 import { resolveRefsToBindParams } from "@/lib/blocks/references";
@@ -63,6 +62,10 @@ import { DbStatusBar } from "./DbStatusBar";
 import { DbResult } from "./DbResultTabs";
 import { DbSettingsDrawer as DbDrawer } from "./DbSettingsDrawer";
 import { ConfirmRunDialog } from "./ConfirmRunDialog";
+import { useDbLegacyMigration } from "./useDbLegacyMigration";
+import { useDbCacheHydrate } from "./useDbCacheHydrate";
+import { useDbExplain } from "./useDbExplain";
+import { useDbLoadMore } from "./useDbLoadMore";
 
 // ───── Main panel ─────
 
@@ -98,10 +101,6 @@ export const DbFencedPanel = memo(function DbFencedPanel({
   const [resolvedBindings, setResolvedBindings] = useState<
     { placeholder: string; raw: string; value: unknown }[]
   >([]);
-  // Load-more dedup guard. A ref (not state) so clicking the button does
-  // not trigger a re-render of the panel — the setResponse that appends
-  // the new rows is the only render needed.
-  const loadingMoreRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const activeConnection = useMemo(
@@ -173,90 +172,21 @@ export const DbFencedPanel = memo(function DbFencedPanel({
     };
   }, [executionState]);
 
-  // ── Legacy JSON body conversion ──
-  // Vaults written before stage 4 store a JSON object in the body instead
-  // of raw SQL. Convert the block in-place on the document: replace the
-  // body with the extracted query and merge connection/limit/timeout into
-  // the info string. This runs at most once per (blockId + body-hash)
-  // combination to prevent re-entry after the dispatch mutates the doc.
-  const migratedRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (migratedRef.current === block.body) return;
-    const legacy = parseLegacyDbBody(block.body);
-    if (!legacy) return;
-    migratedRef.current = block.body;
-
-    const mergedMetadata: DbBlockMetadata = { ...block.metadata };
-    if (legacy.connectionId && !mergedMetadata.connection) {
-      mergedMetadata.connection = legacy.connectionId;
-    }
-    if (legacy.limit !== undefined && mergedMetadata.limit === undefined) {
-      mergedMetadata.limit = legacy.limit;
-    }
-    if (
-      legacy.timeoutMs !== undefined &&
-      mergedMetadata.timeoutMs === undefined
-    ) {
-      mergedMetadata.timeoutMs = legacy.timeoutMs;
-    }
-
-    const newInfoLine = "```" + stringifyDbFenceInfo(mergedMetadata);
-    const openLine = view.state.doc.lineAt(block.openLineFrom);
-
-    // Replace the open fence (to update info) AND the body (to turn JSON
-    // into raw SQL), leaving fence close untouched.
-    view.dispatch({
-      changes: [
-        {
-          from: openLine.from,
-          to: openLine.to,
-          insert: newInfoLine,
-        },
-        {
-          from: block.bodyFrom,
-          to: block.bodyTo,
-          insert: legacy.query,
-        },
-      ],
-    });
-  }, [
-    block.body,
-    block.bodyFrom,
-    block.bodyTo,
-    block.metadata,
-    block.openLineFrom,
-    view,
-  ]);
+  // Legacy JSON body conversion (pre-redesign vaults) — sibling hook.
+  useDbLegacyMigration(block, view);
 
   // Load cached result on mount / when block body + connection change
-  useEffect(() => {
-    if (!filePath) return;
-    const connId = activeConnection?.id ?? block.metadata.connection ?? "";
-    if (!connId || !block.body.trim()) return;
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const envVars = await useEnvironmentStore
-          .getState()
-          .getActiveVariables();
-        const hash = await computeDbCacheHash(block.body, connId, envVars);
-        const row = await getBlockResult(filePath, hash);
-        if (cancelled || !row) return;
-        const parsed = JSON.parse(row.response) as DbResponse;
-        setResponse(parsed);
-        setDurationMs(row.elapsed_ms ?? null);
-        setCached(true);
-        if (row.status === "success") setExecutionState("success");
-        else setExecutionState("error");
-      } catch {
-        // Cache miss or corrupt — stay idle.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [filePath, block.body, activeConnection?.id, block.metadata.connection]);
+  useDbCacheHydrate({
+    filePath,
+    body: block.body,
+    connId: activeConnection?.id ?? block.metadata.connection ?? "",
+    onHit: ({ response: parsed, elapsedMs, state }) => {
+      setResponse(parsed);
+      setDurationMs(elapsedMs);
+      setCached(true);
+      setExecutionState(state);
+    },
+  });
 
   // ── Execution ──
   // Internal: actually dispatches the backend call. `runBlock` (below)
@@ -420,251 +350,34 @@ export const DbFencedPanel = memo(function DbFencedPanel({
     void cancelBlockExecution(`db_${blockId}`);
   }, [blockId]);
 
-  // ── EXPLAIN ──
-  // Runs ONLY the first SQL statement wrapped in an EXPLAIN prefix, as a
-  // one-off (no cache), and folds the plan rows into the current
-  // response's `plan` field so the Plan tab lights up.
-  //
-  // Why only the first statement: backend splits on `;` and treats each
-  // chunk as its own driver call. If we prefix the whole body with
-  // `EXPLAIN ` only the first chunk is explained — the rest run for real.
-  // That's a footgun on multi-statement bodies, so we drop everything
-  // after the first `;` for the EXPLAIN run only. Body is unchanged.
-  //
-  // ANALYZE is intentionally omitted: in Postgres it executes the query
-  // for real, which would make clicking ▦ on an UPDATE/DELETE a latent
-  // footgun. The non-analyze plan is enough for 90% of debugging.
-  const runExplain = useCallback(async () => {
-    if (executionState === "running") return;
-    const connId = activeConnection?.id;
-    if (!connId) return;
-    const body = block.body.trim();
-    if (!body) return;
-
-    // First non-empty statement only. Naive `;` split is good enough for
-    // EXPLAIN — strings/identifiers containing `;` are vanishingly rare in
-    // a query someone is debugging.
-    const firstStatement =
-      body
-        .split(";")
-        .map((s) => s.trim())
-        .find((s) => s.length > 0) ?? body;
-
-    // Pick the EXPLAIN flavour from the actual driver, falling back to
-    // the fence dialect, then to plain `EXPLAIN`. The fence dialect alone
-    // is unreliable: a `db` (generic) fence pointing at a SQLite
-    // connection would otherwise emit `EXPLAIN <sql>` and return raw VDBE
-    // bytecode, which is useless for 99% of users debugging a query.
-    // For SQLite we want `EXPLAIN QUERY PLAN` (SCAN/SEARCH/USING INDEX).
-    // Postgres/MySQL plain `EXPLAIN` returns the human plan already.
-    const dialect = block.metadata.dialect;
-    const driver = activeConnection?.driver;
-    const isSqlite = driver === "sqlite" || dialect === "sqlite";
-    const prefix = isSqlite ? "EXPLAIN QUERY PLAN " : "EXPLAIN ";
-    // Skip wrapping if the user already typed EXPLAIN themselves — double
-    // EXPLAIN is a syntax error everywhere.
-    const alreadyExplain = /^\s*EXPLAIN\b/i.test(firstStatement);
-
-    setError(null);
-    setExecutionState("running");
-    const abort = new AbortController();
-    abortRef.current = abort;
-    const executionId = `db_${blockId}_explain_${Date.now()}`;
-    const startedAt = performance.now();
-
-    try {
-      const blocksAbove = await collectBlocksAboveCM(
-        view.state.doc,
-        block.from,
-        filePath,
-      );
-      const envVars = await useEnvironmentStore.getState().getActiveVariables();
-      const {
-        sql: resolvedBody,
-        bindValues,
-        errors: refErrors,
-      } = resolveRefsToBindParams(
-        firstStatement,
-        blocksAbove,
-        block.from,
-        envVars,
-      );
-      if (refErrors.length > 0) {
-        setError(`Reference errors:\n${refErrors.join("\n")}`);
-        setExecutionState("error");
-        return;
-      }
-      const finalSql = alreadyExplain ? resolvedBody : prefix + resolvedBody;
-
-      const params: Record<string, unknown> = {
-        connection_id: connId,
-        query: finalSql,
-        bind_values: bindValues,
-        offset: 0,
-        fetch_size: 1000,
-      };
-      if (block.metadata.timeoutMs !== undefined) {
-        params.timeout_ms = block.metadata.timeoutMs;
-      }
-
-      const outcome = await executeDbStreamed({
-        executionId,
-        params,
-        signal: abort.signal,
-      });
-      const elapsed = Math.round(performance.now() - startedAt);
-
-      if (outcome.status === "cancelled") {
-        setExecutionState("cancelled");
-        setDurationMs(elapsed);
-        return;
-      }
-      if (outcome.status === "error") {
-        setError(outcome.message);
-        setExecutionState("error");
-        setDurationMs(elapsed);
-        return;
-      }
-
-      // Surface SQL-level errors (kind: "error" inside a result) the same
-      // way as a regular run — they belong in the error state, not stuffed
-      // into the Plan tab as JSON noise.
-      const firstResult = outcome.response.results[0];
-      if (firstResult && firstResult.kind === "error") {
-        setError(firstResult.message);
-        setExecutionState("error");
-        setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
-        return;
-      }
-
-      // Only populate plan when we actually have plan rows to show.
-      // SELECT result with rows = real plan output (sqlite EXPLAIN returns
-      // bytecode rows, postgres EXPLAIN returns a single text-column
-      // table, etc — all selectable). Anything else (mutation? empty?)
-      // means the driver didn't return a plan; fall through to "no plan".
-      const explainResult =
-        firstResult && firstResult.kind === "select" ? firstResult : null;
-      if (!explainResult || explainResult.rows.length === 0) {
-        setError(
-          "EXPLAIN didn't return a plan — the driver may not support EXPLAIN for this query.",
-        );
-        setExecutionState("error");
-        setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
-        return;
-      }
-
-      setResponse((prev) => {
-        const base: DbResponse = prev ?? {
-          results: [],
-          messages: [],
-          stats: { elapsed_ms: 0 },
-        };
-        return {
-          ...base,
-          plan: explainResult.rows,
-          stats: {
-            ...base.stats,
-            elapsed_ms: outcome.response.stats.elapsed_ms || elapsed,
-          },
-        };
-      });
-      setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
-      setCached(false);
-      setExecutionState("success");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setExecutionState("error");
-    } finally {
-      abortRef.current = null;
-    }
-  }, [
-    activeConnection?.id,
-    activeConnection?.driver,
-    block.body,
-    block.from,
-    block.metadata.dialect,
-    block.metadata.timeoutMs,
-    blockId,
+  // EXPLAIN (first statement only, no cache) — sibling hook.
+  const runExplain = useDbExplain({
     executionState,
-    filePath,
-    view,
-  ]);
-
-  // ── Load more: append the next page of rows to the current select
-  // result. Uses the same query + bindings as the initial run, but with
-  // offset = rows already fetched. The in-flight guard is a ref (not
-  // state); ResultTable runs its own local loading state for the button
-  // spinner so this callback doesn't force a panel re-render on click.
-  const loadMore = useCallback(async () => {
-    if (loadingMoreRef.current) return;
-    const connId = activeConnection?.id;
-    if (!connId || !response) return;
-    const first = firstSelectResult(response);
-    if (!first || !first.has_more) return;
-
-    loadingMoreRef.current = true;
-    try {
-      const blocksAbove = await collectBlocksAboveCM(
-        view.state.doc,
-        block.from,
-        filePath,
-      );
-      const envVars = await useEnvironmentStore.getState().getActiveVariables();
-      const { sql, bindValues } = resolveRefsToBindParams(
-        block.body,
-        blocksAbove,
-        block.from,
-        envVars,
-      );
-
-      const params: Record<string, unknown> = {
-        connection_id: connId,
-        query: sql,
-        bind_values: bindValues,
-        offset: first.rows.length,
-        fetch_size: block.metadata.limit ?? 100,
-      };
-      if (block.metadata.timeoutMs !== undefined) {
-        params.timeout_ms = block.metadata.timeoutMs;
-      }
-
-      const outcome = await executeDbStreamed({
-        executionId: `db_${blockId}_more_${Date.now()}`,
-        params,
-      });
-      if (outcome.status !== "success") return;
-
-      const next = firstSelectResult(outcome.response);
-      if (!next) return;
-
-      setResponse((prev) => {
-        if (!prev) return outcome.response;
-        const prevFirst = firstSelectResult(prev);
-        if (!prevFirst) return outcome.response;
-        const idx = prev.results.findIndex((r) => r.kind === "select");
-        const mergedFirst = {
-          ...prevFirst,
-          rows: [...prevFirst.rows, ...next.rows],
-          has_more: next.has_more,
-        };
-        const mergedResults = [...prev.results];
-        mergedResults[idx] = mergedFirst;
-        return { ...prev, results: mergedResults };
-      });
-    } finally {
-      loadingMoreRef.current = false;
-    }
-  }, [
-    activeConnection?.id,
-    block.body,
-    block.from,
-    block.metadata.limit,
-    block.metadata.timeoutMs,
+    activeConnection,
+    block,
     blockId,
+    view,
+    filePath,
+    abortRef,
+    setters: {
+      setExecutionState,
+      setError,
+      setDurationMs,
+      setResponse,
+      setCached,
+    },
+  });
+
+  // Next-page append for the current select result — sibling hook.
+  const loadMore = useDbLoadMore({
+    activeConnection,
+    block,
+    blockId,
+    view,
     filePath,
     response,
-    view,
-  ]);
+    setResponse,
+  });
 
   // Register actions with the registry so ⌘↵ / ⌘. / ⌘⇧E can dispatch
   useEffect(() => {

--- a/httui-desktop/src/components/blocks/db/fenced/DbFencedPanel.tsx
+++ b/httui-desktop/src/components/blocks/db/fenced/DbFencedPanel.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/blocks/db/types";
 import { computeDbCacheHash } from "@/lib/blocks/hash";
 import { getBlockResult, saveBlockResult } from "@/lib/tauri/commands";
+import { notifyBlockRan } from "@/lib/lsp/client";
 import { listConnections, type Connection } from "@/lib/tauri/connections";
 import { resolveRefsToBindParams } from "@/lib/blocks/references";
 import { collectBlocksAboveCM } from "@/lib/blocks/document";
@@ -360,7 +361,11 @@ export const DbFencedPanel = memo(function DbFencedPanel({
           JSON.stringify(outcome.response),
           outcome.response.stats.elapsed_ms || elapsed,
           sel ? sel.rows.length : null,
+          block.metadata.alias ?? null,
         );
+        // An aliased success refreshes the inferred shape — let the
+        // language server republish field diagnostics against it.
+        if (block.metadata.alias) notifyBlockRan();
       } catch {
         // Cache write is best-effort.
       }

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/DbFencedPanel.test.tsx
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/DbFencedPanel.test.tsx
@@ -1,0 +1,399 @@
+// Coverage for the DB block orchestrator panel. Mounts the panel with
+// every heavy dependency mocked and drives the actions registered in
+// the cm-db-block registry to exercise: run gating (no connection /
+// empty body / ref errors / dangerous-query confirm), the streamed run
+// outcomes (success + persist with alias + lsp notify, error,
+// cancelled), squiggle marks from SQL error results, cache hydrate
+// wiring, info-string editing and block deletion.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { renderWithProviders, cleanup } from "@/test/render";
+
+// ── Mocks: cm-db-block registry (capture actions + error marks) ──
+const setActionsCalls: { id: string; actions: Record<string, unknown> }[] = [];
+const setErrorsCalls: unknown[][] = [];
+vi.mock("@/lib/codemirror/cm-db-block", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/codemirror/cm-db-block")
+  >("@/lib/codemirror/cm-db-block");
+  return {
+    ...actual,
+    setDbBlockActions: (id: string, actions: Record<string, unknown>) => {
+      setActionsCalls.push({ id, actions });
+    },
+    setDbBlockErrors: (...args: unknown[]) => {
+      setErrorsCalls.push(args);
+    },
+  };
+});
+
+// ── Mocks: sibling hooks (separately tested) ──
+vi.mock("../useDbLegacyMigration", () => ({
+  useDbLegacyMigration: vi.fn(),
+}));
+const hydrateOpts: { current: Record<string, unknown> | null } = {
+  current: null,
+};
+vi.mock("../useDbCacheHydrate", () => ({
+  useDbCacheHydrate: (opts: Record<string, unknown>) => {
+    hydrateOpts.current = opts;
+  },
+}));
+const runExplainMock = vi.fn();
+vi.mock("../useDbExplain", () => ({
+  useDbExplain: () => runExplainMock,
+}));
+const loadMoreMock = vi.fn();
+vi.mock("../useDbLoadMore", () => ({
+  useDbLoadMore: () => loadMoreMock,
+}));
+
+// ── Mocks: IO ──
+const executeDbStreamed = vi.fn();
+const cancelBlockExecution = vi.fn();
+vi.mock("@/lib/tauri/streamedExecution", () => ({
+  executeDbStreamed: (...args: unknown[]) => executeDbStreamed(...args),
+  cancelBlockExecution: (...args: unknown[]) => cancelBlockExecution(...args),
+}));
+vi.mock("@/lib/tauri/commands", () => ({
+  saveBlockResult: vi.fn(async () => undefined),
+}));
+const notifyBlockRanMock = vi.fn();
+vi.mock("@/lib/lsp/client", () => ({
+  notifyBlockRan: () => notifyBlockRanMock(),
+}));
+vi.mock("@/lib/tauri/connections", () => ({
+  listConnections: vi.fn(async () => [
+    {
+      id: "c1",
+      name: "local",
+      driver: "postgres",
+      is_readonly: false,
+    },
+  ]),
+}));
+vi.mock("@/lib/blocks/document", () => ({
+  collectBlocksAboveCM: vi.fn(async () => []),
+}));
+vi.mock("@/lib/blocks/hash", () => ({
+  computeDbCacheHash: vi.fn(async () => "hash1"),
+}));
+vi.mock("@/stores/environment", () => ({
+  useEnvironmentStore: {
+    getState: () => ({ getActiveVariables: async () => ({}) }),
+  },
+}));
+const ensureLoaded = vi.fn();
+vi.mock("@/stores/schemaCache", () => ({
+  useSchemaCacheStore: {
+    getState: () => ({ ensureLoaded }),
+  },
+}));
+
+// ── Mocks: sub-components — stubs that capture props ──
+const toolbarProps: Record<string, unknown> = {};
+vi.mock("../DbToolbar", () => ({
+  DbToolbar: (props: Record<string, unknown>) => {
+    Object.assign(toolbarProps, props);
+    return <div data-testid="db-toolbar" />;
+  },
+}));
+const resultProps: Record<string, unknown> = {};
+vi.mock("../DbResultTabs", () => ({
+  DbResult: (props: Record<string, unknown>) => {
+    Object.assign(resultProps, props);
+    return <div data-testid="db-result" />;
+  },
+}));
+vi.mock("../DbStatusBar", () => ({
+  DbStatusBar: () => <div data-testid="db-statusbar" />,
+}));
+const drawerProps: Record<string, unknown> = {};
+vi.mock("../DbSettingsDrawer", () => ({
+  DbSettingsDrawer: (props: Record<string, unknown>) => {
+    Object.assign(drawerProps, props);
+    return <div data-testid="db-settings-drawer" />;
+  },
+}));
+const confirmProps: Record<string, unknown> = {};
+vi.mock("../ConfirmRunDialog", () => ({
+  ConfirmRunDialog: (props: Record<string, unknown>) => {
+    Object.assign(confirmProps, props);
+    return <div data-testid="db-confirm-dialog" />;
+  },
+}));
+
+// ── SUT ──
+import { DbFencedPanel } from "../DbFencedPanel";
+import type { DbPortalEntry } from "@/lib/codemirror/cm-db-block";
+import { saveBlockResult } from "@/lib/tauri/commands";
+import { makeDbBlock, makeView, selectResponse } from "./helpers";
+import type { DbBlockMetadata } from "@/lib/blocks/db-fence";
+
+function mountPanel(meta: Partial<DbBlockMetadata> = {}, body = "SELECT 1;") {
+  const view = makeView("");
+  const block = makeDbBlock(
+    view,
+    { connection: "c1", alias: "q1", ...meta },
+    body,
+  );
+  const entry = {
+    blockId: "db_idx_0",
+    block,
+    actions: {},
+    toolbar: document.createElement("div"),
+    result: document.createElement("div"),
+    statusbar: document.createElement("div"),
+  } as DbPortalEntry;
+  const utils = renderWithProviders(
+    <DbFencedPanel
+      blockId="db_idx_0"
+      block={block}
+      entry={entry}
+      view={view}
+      filePath="f.md"
+    />,
+  );
+  const actions = () => setActionsCalls.at(-1)!.actions;
+  // The run gate needs the connection list, which loads in an effect —
+  // wait for the toolbar to receive the resolved connection.
+  const connected = () =>
+    vi.waitFor(() => expect(toolbarProps.activeConnection).toBeTruthy());
+  return { view, block, entry, actions, connected, ...utils };
+}
+
+async function flushRun(actions: () => Record<string, unknown>) {
+  await act(async () => {
+    (actions().onRun as () => void)();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  setActionsCalls.length = 0;
+  setErrorsCalls.length = 0;
+  executeDbStreamed.mockReset();
+  cancelBlockExecution.mockReset();
+  notifyBlockRanMock.mockClear();
+  vi.mocked(saveBlockResult).mockClear();
+  hydrateOpts.current = null;
+  for (const o of [toolbarProps, resultProps, drawerProps, confirmProps]) {
+    for (const k of Object.keys(o)) delete o[k];
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DbFencedPanel", () => {
+  it("registers run/cancel/explain/settings actions and renders the portals", async () => {
+    const { entry } = mountPanel();
+    const a = setActionsCalls.at(-1)!;
+    expect(a.id).toBe("db_idx_0");
+    expect(Object.keys(a.actions)).toEqual(
+      expect.arrayContaining([
+        "onRun",
+        "onCancel",
+        "onOpenSettings",
+        "onExplain",
+      ]),
+    );
+    expect(
+      entry.toolbar!.querySelector("[data-testid=db-toolbar]"),
+    ).not.toBeNull();
+    expect(
+      entry.result!.querySelector("[data-testid=db-result]"),
+    ).not.toBeNull();
+    expect(
+      entry.statusbar!.querySelector("[data-testid=db-statusbar]"),
+    ).not.toBeNull();
+  });
+
+  it("runs the query, persists with the alias and pings the language server", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ id: 1 }]),
+    });
+    const { actions, connected } = mountPanel();
+    await connected();
+
+    await flushRun(actions);
+
+    await vi.waitFor(() => expect(resultProps.executionState).toBe("success"));
+    expect(vi.mocked(saveBlockResult).mock.calls[0][6]).toBe("q1");
+    expect(notifyBlockRanMock).toHaveBeenCalled();
+  });
+
+  it("does not notify the language server for an alias-less block", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ id: 1 }]),
+    });
+    const { actions, connected } = mountPanel({ alias: undefined });
+    await connected();
+
+    await flushRun(actions);
+
+    await vi.waitFor(() => expect(resultProps.executionState).toBe("success"));
+    expect(vi.mocked(saveBlockResult).mock.calls[0][6]).toBeNull();
+    expect(notifyBlockRanMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces execution errors and cancellation", async () => {
+    executeDbStreamed.mockResolvedValue({ status: "error", message: "boom" });
+    const { actions, connected } = mountPanel();
+    await connected();
+    await flushRun(actions);
+    await vi.waitFor(() => expect(resultProps.executionState).toBe("error"));
+    expect(resultProps.error).toBe("boom");
+
+    executeDbStreamed.mockResolvedValue({ status: "cancelled" });
+    await flushRun(actions);
+    await vi.waitFor(() =>
+      expect(resultProps.executionState).toBe("cancelled"),
+    );
+  });
+
+  it("errors without running when no connection resolves", async () => {
+    const { actions } = mountPanel({ connection: "ghost" });
+    await vi.waitFor(() => expect(setActionsCalls.length).toBeGreaterThan(0));
+    await flushRun(actions);
+
+    await vi.waitFor(() => expect(resultProps.executionState).toBe("error"));
+    expect(String(resultProps.error)).toContain("No connection");
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+
+  it("errors on an empty query body", async () => {
+    const { actions, connected } = mountPanel({}, "   ");
+    await connected();
+    await flushRun(actions);
+
+    await vi.waitFor(() =>
+      expect(String(resultProps.error)).toContain("empty"),
+    );
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+
+  it("reports unresolved references instead of dispatching", async () => {
+    const { actions, connected } = mountPanel(
+      {},
+      "SELECT {{ghost.response.id}};",
+    );
+    await connected();
+    await flushRun(actions);
+
+    await vi.waitFor(() =>
+      expect(String(resultProps.error)).toContain("Reference errors"),
+    );
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+
+  it("gates a dangerous query behind the confirm dialog", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([]),
+    });
+    const { actions, connected, getByTestId } = mountPanel(
+      {},
+      "UPDATE t SET x = 1;",
+    );
+    await connected();
+
+    await act(async () => {
+      (actions().onRun as () => void)();
+    });
+    expect(getByTestId("db-confirm-dialog")).toBeTruthy();
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+
+    await act(async () => {
+      (confirmProps.onConfirm as () => void)();
+    });
+    await vi.waitFor(() => expect(executeDbStreamed).toHaveBeenCalled());
+  });
+
+  it("paints squiggle marks for SQL errors with a location", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: {
+        results: [{ kind: "error", message: "bad token", line: 2, column: 5 }],
+        messages: [],
+        stats: { elapsed_ms: 1 },
+      },
+    });
+    const { actions, connected } = mountPanel();
+    await connected();
+    await flushRun(actions);
+
+    await vi.waitFor(() =>
+      expect(
+        setErrorsCalls.some(
+          (call) =>
+            Array.isArray(call[2]) && (call[2] as unknown[]).length === 1,
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("cancels through the backend as a best effort", async () => {
+    const { actions } = mountPanel();
+    await vi.waitFor(() => expect(setActionsCalls.length).toBeGreaterThan(0));
+    await act(async () => {
+      (actions().onCancel as () => void)();
+    });
+    expect(cancelBlockExecution).toHaveBeenCalledWith("db_db_idx_0");
+  });
+
+  it("applies cached rows surfaced by the hydrate hook", async () => {
+    mountPanel();
+    await vi.waitFor(() => expect(hydrateOpts.current).not.toBeNull());
+
+    await act(async () => {
+      (
+        hydrateOpts.current!.onHit as (hit: {
+          response: unknown;
+          elapsedMs: number | null;
+          state: string;
+        }) => void
+      )({
+        response: selectResponse([{ id: 7 }]),
+        elapsedMs: 4,
+        state: "success",
+      });
+    });
+
+    expect(resultProps.cached).toBe(true);
+    expect(resultProps.executionState).toBe("success");
+  });
+
+  it("rewrites the info string from the settings drawer", async () => {
+    const { actions, view, getByTestId } = mountPanel();
+    await vi.waitFor(() => expect(setActionsCalls.length).toBeGreaterThan(0));
+
+    await act(async () => {
+      (actions().onOpenSettings as () => void)();
+    });
+    expect(getByTestId("db-settings-drawer")).toBeTruthy();
+
+    await act(async () => {
+      (drawerProps.onUpdate as (p: Record<string, unknown>) => void)({
+        limit: 5,
+      });
+    });
+    expect(view.state.doc.line(1).text).toContain("limit=5");
+  });
+
+  it("deletes the whole block from the document", async () => {
+    const { actions, view } = mountPanel();
+    await vi.waitFor(() => expect(setActionsCalls.length).toBeGreaterThan(0));
+
+    await act(async () => {
+      (actions().onOpenSettings as () => void)();
+    });
+    await act(async () => {
+      (drawerProps.onDelete as () => void)();
+    });
+    expect(view.state.doc.toString()).toBe("");
+  });
+});

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/helpers.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/helpers.ts
@@ -1,0 +1,99 @@
+// Shared fixtures for the db fenced panel + sibling hook tests.
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+import type { DbPortalEntry } from "@/lib/codemirror/cm-db-block";
+import type { DbBlockMetadata } from "@/lib/blocks/db-fence";
+import type { Connection } from "@/lib/tauri/connections";
+import type { DbResponse, DbRow } from "@/components/blocks/db/types";
+
+export function makeView(doc: string): EditorView {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return new EditorView({
+    state: EditorState.create({ doc }),
+    parent: container,
+  });
+}
+
+/** Builds a db block + view whose doc is "```db-postgres …\n<body>\n```". */
+export function makeDbBlock(
+  view: EditorView,
+  meta: Partial<DbBlockMetadata> = {},
+  body = "SELECT 1;",
+): DbPortalEntry["block"] {
+  const infoTokens = Object.entries({
+    alias: meta.alias,
+    connection: meta.connection,
+  })
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => ` ${k}=${v}`)
+    .join("");
+  const open = "```db-postgres" + infoTokens;
+  const docText = `${open}\n${body}\n\`\`\``;
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: docText },
+  });
+  const openLineFrom = 0;
+  const openLineTo = open.length;
+  const bodyFrom = openLineTo + 1;
+  const bodyTo = bodyFrom + body.length;
+  const closeLineFrom = bodyTo + 1;
+  const closeLineTo = closeLineFrom + 3;
+  return {
+    from: 0,
+    to: closeLineTo,
+    info: infoTokens.trim(),
+    lang: "db-postgres",
+    openLineFrom,
+    openLineTo,
+    bodyFrom,
+    bodyTo,
+    closeLineFrom,
+    closeLineTo,
+    body,
+    metadata: { dialect: "postgres", ...meta },
+  };
+}
+
+export function makeConnection(over: Partial<Connection> = {}): Connection {
+  return {
+    id: "c1",
+    name: "local",
+    driver: "postgres",
+    host: "localhost",
+    port: 5432,
+    database_name: "db",
+    username: "u",
+    has_password: false,
+    ssl_mode: null,
+    timeout_ms: 30000,
+    query_timeout_ms: 30000,
+    ttl_seconds: 300,
+    max_pool_size: 5,
+    is_readonly: false,
+    last_tested_at: null,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  };
+}
+
+export function selectResponse(
+  rows: DbRow[],
+  opts: { hasMore?: boolean; elapsedMs?: number } = {},
+): DbResponse {
+  const names = rows.length > 0 ? Object.keys(rows[0]) : ["x"];
+  return {
+    results: [
+      {
+        kind: "select",
+        columns: names.map((name) => ({ name, type: "text" })),
+        rows,
+        has_more: opts.hasMore ?? false,
+      },
+    ],
+    messages: [],
+    stats: { elapsed_ms: opts.elapsedMs ?? 7 },
+  };
+}

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbCacheHydrate.test.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbCacheHydrate.test.ts
@@ -1,0 +1,98 @@
+// Cache hydration must only fire for a complete (file, conn, body)
+// triple and must surface the cached row's status faithfully.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const getBlockResult = vi.fn();
+vi.mock("@/lib/tauri/commands", () => ({
+  getBlockResult: (...args: unknown[]) => getBlockResult(...args),
+}));
+vi.mock("@/lib/blocks/hash", () => ({
+  computeDbCacheHash: vi.fn(async () => "hash1"),
+}));
+vi.mock("@/stores/environment", () => ({
+  useEnvironmentStore: {
+    getState: () => ({ getActiveVariables: async () => ({}) }),
+  },
+}));
+
+import { useDbCacheHydrate } from "../useDbCacheHydrate";
+
+beforeEach(() => {
+  getBlockResult.mockReset();
+});
+
+const base = { filePath: "f.md", body: "SELECT 1;", connId: "c1" };
+
+describe("useDbCacheHydrate", () => {
+  it("surfaces a cached success row", async () => {
+    getBlockResult.mockResolvedValue({
+      status: "success",
+      response: JSON.stringify({
+        results: [],
+        messages: [],
+        stats: { elapsed_ms: 3 },
+      }),
+      elapsed_ms: 3,
+    });
+    const onHit = vi.fn();
+    renderHook(() => useDbCacheHydrate({ ...base, onHit }));
+
+    await waitFor(() => expect(onHit).toHaveBeenCalled());
+    expect(getBlockResult).toHaveBeenCalledWith("f.md", "hash1");
+    expect(onHit.mock.calls[0][0]).toMatchObject({
+      elapsedMs: 3,
+      state: "success",
+    });
+  });
+
+  it("maps a cached error row to the error state", async () => {
+    getBlockResult.mockResolvedValue({
+      status: "error",
+      response: JSON.stringify({
+        results: [],
+        messages: [],
+        stats: { elapsed_ms: 1 },
+      }),
+      elapsed_ms: null,
+    });
+    const onHit = vi.fn();
+    renderHook(() => useDbCacheHydrate({ ...base, onHit }));
+
+    await waitFor(() => expect(onHit).toHaveBeenCalled());
+    expect(onHit.mock.calls[0][0]).toMatchObject({
+      elapsedMs: null,
+      state: "error",
+    });
+  });
+
+  it("stays idle on cache miss", async () => {
+    getBlockResult.mockResolvedValue(null);
+    const onHit = vi.fn();
+    renderHook(() => useDbCacheHydrate({ ...base, onHit }));
+
+    await waitFor(() => expect(getBlockResult).toHaveBeenCalled());
+    expect(onHit).not.toHaveBeenCalled();
+  });
+
+  it("stays idle on a corrupt cached response", async () => {
+    getBlockResult.mockResolvedValue({
+      status: "success",
+      response: "not-json",
+      elapsed_ms: 1,
+    });
+    const onHit = vi.fn();
+    renderHook(() => useDbCacheHydrate({ ...base, onHit }));
+
+    await waitFor(() => expect(getBlockResult).toHaveBeenCalled());
+    expect(onHit).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a connection or with an empty body", () => {
+    const onHit = vi.fn();
+    renderHook(() => useDbCacheHydrate({ ...base, connId: "", onHit }));
+    renderHook(() => useDbCacheHydrate({ ...base, body: "   ", onHit }));
+
+    expect(getBlockResult).not.toHaveBeenCalled();
+  });
+});

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbExplain.test.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbExplain.test.ts
@@ -1,0 +1,184 @@
+// EXPLAIN runner: first statement only, dialect-aware prefix, plan rows
+// folded into the existing response, SQL errors surfaced as panel
+// errors — never as Plan-tab noise.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const executeDbStreamed = vi.fn();
+vi.mock("@/lib/tauri/streamedExecution", () => ({
+  executeDbStreamed: (...args: unknown[]) => executeDbStreamed(...args),
+}));
+vi.mock("@/lib/blocks/document", () => ({
+  collectBlocksAboveCM: vi.fn(async () => []),
+}));
+vi.mock("@/stores/environment", () => ({
+  useEnvironmentStore: {
+    getState: () => ({ getActiveVariables: async () => ({}) }),
+  },
+}));
+
+import { useDbExplain, type DbRunStateSetters } from "../useDbExplain";
+import type { Connection } from "@/lib/tauri/connections";
+import type { DbResponse } from "@/components/blocks/db/types";
+import type { ExecutionState } from "../shared";
+import {
+  makeConnection,
+  makeDbBlock,
+  makeView,
+  selectResponse,
+} from "./helpers";
+
+beforeEach(() => {
+  executeDbStreamed.mockReset();
+});
+
+function setup(opts: {
+  body?: string;
+  connection?: Connection | null;
+  executionState?: ExecutionState;
+  response?: DbResponse | null;
+}) {
+  const view = makeView("");
+  const block = makeDbBlock(view, { alias: "q1" }, opts.body ?? "SELECT 1;");
+  let response: DbResponse | null = opts.response ?? null;
+  const states: ExecutionState[] = [];
+  const errors: (string | null)[] = [];
+  const setters: DbRunStateSetters = {
+    setExecutionState: (s) => states.push(s),
+    setError: (e) => errors.push(e),
+    setDurationMs: vi.fn(),
+    setResponse: (updater) => {
+      response = updater(response);
+    },
+    setCached: vi.fn(),
+  };
+  const abortRef = { current: null as AbortController | null };
+  const { result } = renderHook(() =>
+    useDbExplain({
+      executionState: opts.executionState ?? "idle",
+      activeConnection:
+        opts.connection === undefined ? makeConnection() : opts.connection,
+      block,
+      blockId: "db_idx_0",
+      view,
+      filePath: "f.md",
+      abortRef,
+      setters,
+    }),
+  );
+  return {
+    runExplain: result.current,
+    states,
+    errors,
+    getResponse: () => response,
+  };
+}
+
+describe("useDbExplain", () => {
+  it("wraps the first statement and folds plan rows into the response", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ plan: "Seq Scan" }]),
+    });
+    const { runExplain, states, getResponse } = setup({
+      body: "SELECT 1;\nSELECT 2;",
+    });
+
+    await runExplain();
+
+    const call = executeDbStreamed.mock.calls[0][0];
+    expect(call.params.query).toBe("EXPLAIN SELECT 1");
+    expect(getResponse()?.plan).toEqual([{ plan: "Seq Scan" }]);
+    expect(states.at(-1)).toBe("success");
+  });
+
+  it("uses EXPLAIN QUERY PLAN for sqlite drivers", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ detail: "SCAN t" }]),
+    });
+    const { runExplain } = setup({
+      connection: makeConnection({ driver: "sqlite" }),
+    });
+
+    await runExplain();
+
+    expect(executeDbStreamed.mock.calls[0][0].params.query).toBe(
+      "EXPLAIN QUERY PLAN SELECT 1",
+    );
+  });
+
+  it("does not double-wrap a query the user already explained", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ plan: "x" }]),
+    });
+    const { runExplain } = setup({ body: "EXPLAIN SELECT 9;" });
+
+    await runExplain();
+
+    expect(executeDbStreamed.mock.calls[0][0].params.query).toBe(
+      "EXPLAIN SELECT 9",
+    );
+  });
+
+  it("surfaces a SQL-level error result as a panel error", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: {
+        results: [{ kind: "error", message: "syntax error" }],
+        messages: [],
+        stats: { elapsed_ms: 2 },
+      },
+    });
+    const { runExplain, states, errors } = setup({});
+
+    await runExplain();
+
+    expect(errors.at(-1)).toBe("syntax error");
+    expect(states.at(-1)).toBe("error");
+  });
+
+  it("errors when the driver returns no plan rows", async () => {
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([]),
+    });
+    const { runExplain, states, errors } = setup({});
+
+    await runExplain();
+
+    expect(errors.at(-1)).toContain("didn't return a plan");
+    expect(states.at(-1)).toBe("error");
+  });
+
+  it("propagates an execution error", async () => {
+    executeDbStreamed.mockResolvedValue({ status: "error", message: "down" });
+    const { runExplain, states, errors } = setup({});
+
+    await runExplain();
+
+    expect(errors.at(-1)).toBe("down");
+    expect(states.at(-1)).toBe("error");
+  });
+
+  it("maps a cancelled outcome to the cancelled state", async () => {
+    executeDbStreamed.mockResolvedValue({ status: "cancelled" });
+    const { runExplain, states } = setup({});
+
+    await runExplain();
+
+    expect(states.at(-1)).toBe("cancelled");
+  });
+
+  it("is a no-op while running, without a connection, or with an empty body", async () => {
+    const running = setup({ executionState: "running" });
+    await running.runExplain();
+    const noConn = setup({ connection: null });
+    await noConn.runExplain();
+    const empty = setup({ body: "   " });
+    await empty.runExplain();
+
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+});

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbLegacyMigration.test.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbLegacyMigration.test.ts
@@ -1,0 +1,66 @@
+// Legacy JSON bodies must be rewritten in place exactly once; raw SQL
+// bodies must never be touched.
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useDbLegacyMigration } from "../useDbLegacyMigration";
+import { makeDbBlock, makeView } from "./helpers";
+
+describe("useDbLegacyMigration", () => {
+  it("rewrites a legacy JSON body into raw SQL + info string", () => {
+    const view = makeView("");
+    const legacyBody = JSON.stringify({
+      connectionId: "prod",
+      query: "SELECT * FROM users",
+      limit: 50,
+      timeoutMs: 9000,
+    });
+    const block = makeDbBlock(view, {}, legacyBody);
+
+    renderHook(() => useDbLegacyMigration(block, view));
+
+    const doc = view.state.doc.toString();
+    expect(doc).toContain("SELECT * FROM users");
+    expect(doc).not.toContain('"connectionId"');
+    expect(doc).toContain("connection=prod");
+    expect(doc).toContain("limit=50");
+    expect(doc).toContain("timeout=9000");
+  });
+
+  it("keeps explicit metadata over legacy values", () => {
+    const view = makeView("");
+    const legacyBody = JSON.stringify({
+      connectionId: "legacy-conn",
+      query: "SELECT 1",
+    });
+    const block = makeDbBlock(view, { connection: "explicit" }, legacyBody);
+
+    renderHook(() => useDbLegacyMigration(block, view));
+
+    const doc = view.state.doc.toString();
+    expect(doc).toContain("connection=explicit");
+    expect(doc).not.toContain("legacy-conn");
+  });
+
+  it("leaves raw SQL bodies untouched", () => {
+    const view = makeView("");
+    const block = makeDbBlock(view, {}, "SELECT 1;");
+    const before = view.state.doc.toString();
+
+    renderHook(() => useDbLegacyMigration(block, view));
+
+    expect(view.state.doc.toString()).toBe(before);
+  });
+
+  it("does not re-run for the same body", () => {
+    const view = makeView("");
+    const legacyBody = JSON.stringify({ connectionId: "p", query: "SELECT 2" });
+    const block = makeDbBlock(view, {}, legacyBody);
+
+    const { rerender } = renderHook(() => useDbLegacyMigration(block, view));
+    const afterFirst = view.state.doc.toString();
+    rerender();
+
+    expect(view.state.doc.toString()).toBe(afterFirst);
+  });
+});

--- a/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbLoadMore.test.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/__tests__/useDbLoadMore.test.ts
@@ -1,0 +1,118 @@
+// Load-more must reuse the original query with offset = rows fetched,
+// append the new page to the first select result, and dedup in-flight
+// clicks via the ref guard.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const executeDbStreamed = vi.fn();
+vi.mock("@/lib/tauri/streamedExecution", () => ({
+  executeDbStreamed: (...args: unknown[]) => executeDbStreamed(...args),
+}));
+vi.mock("@/lib/blocks/document", () => ({
+  collectBlocksAboveCM: vi.fn(async () => []),
+}));
+vi.mock("@/stores/environment", () => ({
+  useEnvironmentStore: {
+    getState: () => ({ getActiveVariables: async () => ({}) }),
+  },
+}));
+
+import { useDbLoadMore } from "../useDbLoadMore";
+import type { DbResponse } from "@/components/blocks/db/types";
+import {
+  makeConnection,
+  makeDbBlock,
+  makeView,
+  selectResponse,
+} from "./helpers";
+
+beforeEach(() => {
+  executeDbStreamed.mockReset();
+});
+
+function setup(response: DbResponse | null) {
+  const view = makeView("");
+  const block = makeDbBlock(view, { alias: "q1", limit: 2 });
+  let current = response;
+  const setResponse = vi.fn(
+    (updater: (prev: DbResponse | null) => DbResponse | null) => {
+      current = updater(current);
+    },
+  );
+  const { result } = renderHook(() =>
+    useDbLoadMore({
+      activeConnection: makeConnection(),
+      block,
+      blockId: "db_idx_0",
+      view,
+      filePath: "f.md",
+      response,
+      setResponse,
+    }),
+  );
+  return { loadMore: result.current, setResponse, get: () => current };
+}
+
+describe("useDbLoadMore", () => {
+  it("appends the next page with offset = fetched rows", async () => {
+    const { loadMore, get } = setup(
+      selectResponse([{ id: 1 }, { id: 2 }], { hasMore: true }),
+    );
+    executeDbStreamed.mockResolvedValue({
+      status: "success",
+      response: selectResponse([{ id: 3 }], { hasMore: false }),
+    });
+
+    await loadMore();
+
+    expect(executeDbStreamed).toHaveBeenCalledTimes(1);
+    const call = executeDbStreamed.mock.calls[0][0];
+    expect(call.params.offset).toBe(2);
+    expect(call.params.fetch_size).toBe(2);
+    const first = get()?.results[0];
+    expect(first?.kind === "select" && first.rows.map((r) => r.id)).toEqual([
+      1, 2, 3,
+    ]);
+    expect(first?.kind === "select" && first.has_more).toBe(false);
+  });
+
+  it("is a no-op when the result has no more rows", async () => {
+    const { loadMore } = setup(selectResponse([{ id: 1 }], { hasMore: false }));
+    await loadMore();
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op without a previous response", async () => {
+    const { loadMore } = setup(null);
+    await loadMore();
+    expect(executeDbStreamed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a failed page fetch", async () => {
+    const { loadMore, setResponse } = setup(
+      selectResponse([{ id: 1 }], { hasMore: true }),
+    );
+    executeDbStreamed.mockResolvedValue({ status: "error", message: "boom" });
+    await loadMore();
+    expect(setResponse).not.toHaveBeenCalled();
+  });
+
+  it("dedups concurrent clicks via the in-flight guard", async () => {
+    const { loadMore } = setup(selectResponse([{ id: 1 }], { hasMore: true }));
+    let release: (v: unknown) => void = () => {};
+    executeDbStreamed.mockImplementation(
+      () =>
+        new Promise((res) => {
+          release = res;
+        }),
+    );
+
+    const p1 = loadMore();
+    const p2 = loadMore();
+    await vi.waitFor(() => expect(executeDbStreamed).toHaveBeenCalled());
+    release({ status: "success", response: selectResponse([]) });
+    await Promise.all([p1, p2]);
+
+    expect(executeDbStreamed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/httui-desktop/src/components/blocks/db/fenced/useDbCacheHydrate.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/useDbCacheHydrate.ts
@@ -1,0 +1,53 @@
+// On-mount cache hydration: when a cached row exists for the current
+// (body, connection, env snapshot) hash, surface it as the panel's
+// result without running the query.
+import { useEffect } from "react";
+
+import { computeDbCacheHash } from "@/lib/blocks/hash";
+import { getBlockResult } from "@/lib/tauri/commands";
+import { useEnvironmentStore } from "@/stores/environment";
+import type { DbResponse } from "@/components/blocks/db/types";
+import { type ExecutionState } from "./shared";
+
+export function useDbCacheHydrate(opts: {
+  filePath: string;
+  body: string;
+  connId: string;
+  onHit: (hit: {
+    response: DbResponse;
+    elapsedMs: number | null;
+    state: ExecutionState;
+  }) => void;
+}) {
+  const { filePath, body, connId, onHit } = opts;
+  useEffect(() => {
+    if (!filePath) return;
+    if (!connId || !body.trim()) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const envVars = await useEnvironmentStore
+          .getState()
+          .getActiveVariables();
+        const hash = await computeDbCacheHash(body, connId, envVars);
+        const row = await getBlockResult(filePath, hash);
+        if (cancelled || !row) return;
+        const parsed = JSON.parse(row.response) as DbResponse;
+        onHit({
+          response: parsed,
+          elapsedMs: row.elapsed_ms ?? null,
+          state: row.status === "success" ? "success" : "error",
+        });
+      } catch {
+        // Cache miss or corrupt — stay idle.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // onHit is a stable setter bundle owned by the panel — deliberately
+    // not a dependency so a re-created callback can't re-trigger reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filePath, body, connId]);
+}

--- a/httui-desktop/src/components/blocks/db/fenced/useDbExplain.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/useDbExplain.ts
@@ -1,0 +1,216 @@
+// EXPLAIN runner. Runs ONLY the first SQL statement wrapped in an
+// EXPLAIN prefix, as a one-off (no cache), and folds the plan rows into
+// the current response's `plan` field so the Plan tab lights up.
+//
+// Why only the first statement: backend splits on `;` and treats each
+// chunk as its own driver call. If we prefix the whole body with
+// `EXPLAIN ` only the first chunk is explained — the rest run for real.
+// That's a footgun on multi-statement bodies, so we drop everything
+// after the first `;` for the EXPLAIN run only. Body is unchanged.
+//
+// ANALYZE is intentionally omitted: in Postgres it executes the query
+// for real, which would make clicking ▦ on an UPDATE/DELETE a latent
+// footgun. The non-analyze plan is enough for 90% of debugging.
+import { useCallback, type MutableRefObject } from "react";
+import { EditorView } from "@codemirror/view";
+
+import type { DbPortalEntry } from "@/lib/codemirror/cm-db-block";
+import { executeDbStreamed } from "@/lib/tauri/streamedExecution";
+import type { Connection } from "@/lib/tauri/connections";
+import { resolveRefsToBindParams } from "@/lib/blocks/references";
+import { collectBlocksAboveCM } from "@/lib/blocks/document";
+import { useEnvironmentStore } from "@/stores/environment";
+import type { DbResponse } from "@/components/blocks/db/types";
+import { type ExecutionState } from "./shared";
+
+export interface DbRunStateSetters {
+  setExecutionState: (s: ExecutionState) => void;
+  setError: (e: string | null) => void;
+  setDurationMs: (ms: number | null) => void;
+  setResponse: (
+    updater: (prev: DbResponse | null) => DbResponse | null,
+  ) => void;
+  setCached: (c: boolean) => void;
+}
+
+export function useDbExplain(opts: {
+  executionState: ExecutionState;
+  activeConnection: Connection | null;
+  block: DbPortalEntry["block"];
+  blockId: string;
+  view: EditorView;
+  filePath: string;
+  abortRef: MutableRefObject<AbortController | null>;
+  setters: DbRunStateSetters;
+}) {
+  const {
+    executionState,
+    activeConnection,
+    block,
+    blockId,
+    view,
+    filePath,
+    abortRef,
+    setters,
+  } = opts;
+  const { setExecutionState, setError, setDurationMs, setResponse, setCached } =
+    setters;
+
+  return useCallback(async () => {
+    if (executionState === "running") return;
+    const connId = activeConnection?.id;
+    if (!connId) return;
+    const body = block.body.trim();
+    if (!body) return;
+
+    // First non-empty statement only. Naive `;` split is good enough for
+    // EXPLAIN — strings/identifiers containing `;` are vanishingly rare in
+    // a query someone is debugging.
+    const firstStatement =
+      body
+        .split(";")
+        .map((s) => s.trim())
+        .find((s) => s.length > 0) ?? body;
+
+    // Pick the EXPLAIN flavour from the actual driver, falling back to
+    // the fence dialect, then to plain `EXPLAIN`. The fence dialect alone
+    // is unreliable: a `db` (generic) fence pointing at a SQLite
+    // connection would otherwise emit `EXPLAIN <sql>` and return raw VDBE
+    // bytecode, which is useless for 99% of users debugging a query.
+    // For SQLite we want `EXPLAIN QUERY PLAN` (SCAN/SEARCH/USING INDEX).
+    // Postgres/MySQL plain `EXPLAIN` returns the human plan already.
+    const dialect = block.metadata.dialect;
+    const driver = activeConnection?.driver;
+    const isSqlite = driver === "sqlite" || dialect === "sqlite";
+    const prefix = isSqlite ? "EXPLAIN QUERY PLAN " : "EXPLAIN ";
+    // Skip wrapping if the user already typed EXPLAIN themselves — double
+    // EXPLAIN is a syntax error everywhere.
+    const alreadyExplain = /^\s*EXPLAIN\b/i.test(firstStatement);
+
+    setError(null);
+    setExecutionState("running");
+    const abort = new AbortController();
+    abortRef.current = abort;
+    const executionId = `db_${blockId}_explain_${Date.now()}`;
+    const startedAt = performance.now();
+
+    try {
+      const blocksAbove = await collectBlocksAboveCM(
+        view.state.doc,
+        block.from,
+        filePath,
+      );
+      const envVars = await useEnvironmentStore.getState().getActiveVariables();
+      const {
+        sql: resolvedBody,
+        bindValues,
+        errors: refErrors,
+      } = resolveRefsToBindParams(
+        firstStatement,
+        blocksAbove,
+        block.from,
+        envVars,
+      );
+      if (refErrors.length > 0) {
+        setError(`Reference errors:\n${refErrors.join("\n")}`);
+        setExecutionState("error");
+        return;
+      }
+      const finalSql = alreadyExplain ? resolvedBody : prefix + resolvedBody;
+
+      const params: Record<string, unknown> = {
+        connection_id: connId,
+        query: finalSql,
+        bind_values: bindValues,
+        offset: 0,
+        fetch_size: 1000,
+      };
+      if (block.metadata.timeoutMs !== undefined) {
+        params.timeout_ms = block.metadata.timeoutMs;
+      }
+
+      const outcome = await executeDbStreamed({
+        executionId,
+        params,
+        signal: abort.signal,
+      });
+      const elapsed = Math.round(performance.now() - startedAt);
+
+      if (outcome.status === "cancelled") {
+        setExecutionState("cancelled");
+        setDurationMs(elapsed);
+        return;
+      }
+      if (outcome.status === "error") {
+        setError(outcome.message);
+        setExecutionState("error");
+        setDurationMs(elapsed);
+        return;
+      }
+
+      // Surface SQL-level errors (kind: "error" inside a result) the same
+      // way as a regular run — they belong in the error state, not stuffed
+      // into the Plan tab as JSON noise.
+      const firstResult = outcome.response.results[0];
+      if (firstResult && firstResult.kind === "error") {
+        setError(firstResult.message);
+        setExecutionState("error");
+        setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
+        return;
+      }
+
+      // Only populate plan when we actually have plan rows to show.
+      // SELECT result with rows = real plan output (sqlite EXPLAIN returns
+      // bytecode rows, postgres EXPLAIN returns a single text-column
+      // table, etc — all selectable). Anything else (mutation? empty?)
+      // means the driver didn't return a plan; fall through to "no plan".
+      const explainResult =
+        firstResult && firstResult.kind === "select" ? firstResult : null;
+      if (!explainResult || explainResult.rows.length === 0) {
+        setError(
+          "EXPLAIN didn't return a plan — the driver may not support EXPLAIN for this query.",
+        );
+        setExecutionState("error");
+        setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
+        return;
+      }
+
+      setResponse((prev) => {
+        const base: DbResponse = prev ?? {
+          results: [],
+          messages: [],
+          stats: { elapsed_ms: 0 },
+        };
+        return {
+          ...base,
+          plan: explainResult.rows,
+          stats: {
+            ...base.stats,
+            elapsed_ms: outcome.response.stats.elapsed_ms || elapsed,
+          },
+        };
+      });
+      setDurationMs(outcome.response.stats.elapsed_ms || elapsed);
+      setCached(false);
+      setExecutionState("success");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setExecutionState("error");
+    } finally {
+      abortRef.current = null;
+    }
+    // Setters are stable panel-owned state setters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    executionState,
+    activeConnection?.id,
+    activeConnection?.driver,
+    block.body,
+    block.from,
+    block.metadata.dialect,
+    block.metadata.timeoutMs,
+    blockId,
+    filePath,
+    view,
+  ]);
+}

--- a/httui-desktop/src/components/blocks/db/fenced/useDbLegacyMigration.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/useDbLegacyMigration.ts
@@ -1,0 +1,69 @@
+// Legacy JSON body conversion. Vaults written before the fenced
+// redesign store a JSON object in the body instead of raw SQL. Convert
+// the block in-place on the document: replace the body with the
+// extracted query and merge connection/limit/timeout into the info
+// string. Runs at most once per (blockId + body-hash) combination to
+// prevent re-entry after the dispatch mutates the doc.
+import { useEffect, useRef } from "react";
+import { EditorView } from "@codemirror/view";
+
+import type { DbPortalEntry } from "@/lib/codemirror/cm-db-block";
+import {
+  parseLegacyDbBody,
+  stringifyDbFenceInfo,
+  type DbBlockMetadata,
+} from "@/lib/blocks/db-fence";
+
+export function useDbLegacyMigration(
+  block: DbPortalEntry["block"],
+  view: EditorView,
+) {
+  const migratedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (migratedRef.current === block.body) return;
+    const legacy = parseLegacyDbBody(block.body);
+    if (!legacy) return;
+    migratedRef.current = block.body;
+
+    const mergedMetadata: DbBlockMetadata = { ...block.metadata };
+    if (legacy.connectionId && !mergedMetadata.connection) {
+      mergedMetadata.connection = legacy.connectionId;
+    }
+    if (legacy.limit !== undefined && mergedMetadata.limit === undefined) {
+      mergedMetadata.limit = legacy.limit;
+    }
+    if (
+      legacy.timeoutMs !== undefined &&
+      mergedMetadata.timeoutMs === undefined
+    ) {
+      mergedMetadata.timeoutMs = legacy.timeoutMs;
+    }
+
+    const newInfoLine = "```" + stringifyDbFenceInfo(mergedMetadata);
+    const openLine = view.state.doc.lineAt(block.openLineFrom);
+
+    // Replace the open fence (to update info) AND the body (to turn JSON
+    // into raw SQL), leaving fence close untouched.
+    view.dispatch({
+      changes: [
+        {
+          from: openLine.from,
+          to: openLine.to,
+          insert: newInfoLine,
+        },
+        {
+          from: block.bodyFrom,
+          to: block.bodyTo,
+          insert: legacy.query,
+        },
+      ],
+    });
+  }, [
+    block.body,
+    block.bodyFrom,
+    block.bodyTo,
+    block.metadata,
+    block.openLineFrom,
+    view,
+  ]);
+}

--- a/httui-desktop/src/components/blocks/db/fenced/useDbLoadMore.ts
+++ b/httui-desktop/src/components/blocks/db/fenced/useDbLoadMore.ts
@@ -1,0 +1,110 @@
+// Load more: append the next page of rows to the current select result.
+// Uses the same query + bindings as the initial run, but with
+// offset = rows already fetched. The in-flight guard is a ref (not
+// state); ResultTable runs its own local loading state for the button
+// spinner so this callback doesn't force a panel re-render on click.
+import { useCallback, useRef } from "react";
+import { EditorView } from "@codemirror/view";
+
+import type { DbPortalEntry } from "@/lib/codemirror/cm-db-block";
+import { executeDbStreamed } from "@/lib/tauri/streamedExecution";
+import type { Connection } from "@/lib/tauri/connections";
+import { resolveRefsToBindParams } from "@/lib/blocks/references";
+import { collectBlocksAboveCM } from "@/lib/blocks/document";
+import { useEnvironmentStore } from "@/stores/environment";
+import {
+  firstSelectResult,
+  type DbResponse,
+} from "@/components/blocks/db/types";
+
+export function useDbLoadMore(opts: {
+  activeConnection: Connection | null;
+  block: DbPortalEntry["block"];
+  blockId: string;
+  view: EditorView;
+  filePath: string;
+  response: DbResponse | null;
+  setResponse: (
+    updater: (prev: DbResponse | null) => DbResponse | null,
+  ) => void;
+}) {
+  const { activeConnection, block, blockId, view, filePath, response } = opts;
+  const { setResponse } = opts;
+  // Dedup guard. A ref (not state) so clicking the button does not
+  // trigger a re-render of the panel — the setResponse that appends the
+  // new rows is the only render needed.
+  const loadingMoreRef = useRef(false);
+
+  return useCallback(async () => {
+    if (loadingMoreRef.current) return;
+    const connId = activeConnection?.id;
+    if (!connId || !response) return;
+    const first = firstSelectResult(response);
+    if (!first || !first.has_more) return;
+
+    loadingMoreRef.current = true;
+    try {
+      const blocksAbove = await collectBlocksAboveCM(
+        view.state.doc,
+        block.from,
+        filePath,
+      );
+      const envVars = await useEnvironmentStore.getState().getActiveVariables();
+      const { sql, bindValues } = resolveRefsToBindParams(
+        block.body,
+        blocksAbove,
+        block.from,
+        envVars,
+      );
+
+      const params: Record<string, unknown> = {
+        connection_id: connId,
+        query: sql,
+        bind_values: bindValues,
+        offset: first.rows.length,
+        fetch_size: block.metadata.limit ?? 100,
+      };
+      if (block.metadata.timeoutMs !== undefined) {
+        params.timeout_ms = block.metadata.timeoutMs;
+      }
+
+      const outcome = await executeDbStreamed({
+        executionId: `db_${blockId}_more_${Date.now()}`,
+        params,
+      });
+      if (outcome.status !== "success") return;
+
+      const next = firstSelectResult(outcome.response);
+      if (!next) return;
+
+      setResponse((prev) => {
+        if (!prev) return outcome.response;
+        const prevFirst = firstSelectResult(prev);
+        if (!prevFirst) return outcome.response;
+        const idx = prev.results.findIndex((r) => r.kind === "select");
+        const mergedFirst = {
+          ...prevFirst,
+          rows: [...prevFirst.rows, ...next.rows],
+          has_more: next.has_more,
+        };
+        const mergedResults = [...prev.results];
+        mergedResults[idx] = mergedFirst;
+        return { ...prev, results: mergedResults };
+      });
+    } finally {
+      loadingMoreRef.current = false;
+    }
+    // setResponse is a stable panel-owned state setter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    activeConnection?.id,
+    block.body,
+    block.from,
+    block.metadata.limit,
+    block.metadata.timeoutMs,
+    blockId,
+    filePath,
+    response,
+    view,
+  ]);
+}

--- a/httui-desktop/src/components/blocks/http/fenced/HttpFencedPanel.tsx
+++ b/httui-desktop/src/components/blocks/http/fenced/HttpFencedPanel.tsx
@@ -65,6 +65,7 @@ import { computeHttpCacheHash } from "@/lib/blocks/hash";
 import { EditorView } from "@codemirror/view";
 
 import { saveBlockResult } from "@/lib/tauri/commands";
+import { notifyBlockRan } from "@/lib/lsp/client";
 import type { BlockContext } from "@/lib/blocks/references";
 
 interface HttpFencedPanelProps {
@@ -223,9 +224,13 @@ export const HttpFencedPanel = memo(function HttpFencedPanel({
         JSON.stringify(resp),
         elapsed,
         null,
+        block.metadata.alias ?? null,
       );
+      // An aliased success refreshes the inferred shape — let the
+      // language server republish field diagnostics against it.
+      if (block.metadata.alias) notifyBlockRan();
     },
-    [parsed, filePath],
+    [parsed, filePath, block.metadata.alias],
   );
 
   const onOutcome = useCallback(

--- a/httui-desktop/src/components/blocks/http/fenced/__tests__/HttpFencedPanel.test.tsx
+++ b/httui-desktop/src/components/blocks/http/fenced/__tests__/HttpFencedPanel.test.tsx
@@ -186,6 +186,11 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: (opts: unknown) => openDialogMock(opts),
 }));
 
+const notifyBlockRanMock = vi.fn();
+vi.mock("@/lib/lsp/client", () => ({
+  notifyBlockRan: () => notifyBlockRanMock(),
+}));
+
 vi.mock("@/components/ui/toaster", () => ({
   toaster: { create: vi.fn() },
 }));
@@ -447,6 +452,52 @@ describe("HttpFencedPanel — adapter callbacks", () => {
       { envVars: {} },
     );
     expect(saveBlockResult).toHaveBeenCalled();
+  });
+
+  it("persist with alias forwards it and pings the language server", async () => {
+    const view = makeView("");
+    const { block, entry, filePath } = makeEntry(view, { alias: "req1" });
+    renderWithProviders(
+      <HttpFencedPanel
+        blockId="http_idx_0"
+        block={block}
+        entry={entry}
+        view={view}
+        filePath={filePath}
+      />,
+    );
+    vi.mocked(saveBlockResult).mockClear();
+    notifyBlockRanMock.mockClear();
+    await cap.persist!(
+      { status_code: 200, size_bytes: 0, elapsed_ms: 5, headers: {}, body: "" },
+      5,
+      { envVars: {} },
+    );
+    expect(vi.mocked(saveBlockResult).mock.calls[0][6]).toBe("req1");
+    expect(notifyBlockRanMock).toHaveBeenCalled();
+  });
+
+  it("persist without alias saves a null alias and stays quiet", async () => {
+    const view = makeView("");
+    const { block, entry, filePath } = makeEntry(view);
+    renderWithProviders(
+      <HttpFencedPanel
+        blockId="http_idx_0"
+        block={block}
+        entry={entry}
+        view={view}
+        filePath={filePath}
+      />,
+    );
+    vi.mocked(saveBlockResult).mockClear();
+    notifyBlockRanMock.mockClear();
+    await cap.persist!(
+      { status_code: 200, size_bytes: 0, elapsed_ms: 5, headers: {}, body: "" },
+      5,
+      { envVars: {} },
+    );
+    expect(vi.mocked(saveBlockResult).mock.calls[0][6]).toBeNull();
+    expect(notifyBlockRanMock).not.toHaveBeenCalled();
   });
 
   it("onOutcome — success path triggers recordHistory with success outcome", () => {

--- a/httui-desktop/src/lib/blocks/__tests__/document.test.ts
+++ b/httui-desktop/src/lib/blocks/__tests__/document.test.ts
@@ -1,0 +1,81 @@
+// Read-side cache resolution for `{{alias…}}`: HTTP rows are keyed by a
+// request+env hash the scanner cannot reproduce, so blocks must resolve
+// by alias — a content-hash lookup would miss every row.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Text } from "@codemirror/state";
+
+const getBlockResult = vi.fn();
+const getLatestBlockResultByAlias = vi.fn();
+vi.mock("@/lib/tauri/commands", () => ({
+  getBlockResult: (...args: unknown[]) => getBlockResult(...args),
+  getLatestBlockResultByAlias: (...args: unknown[]) =>
+    getLatestBlockResultByAlias(...args),
+}));
+vi.mock("@/lib/tauri/connections", () => ({
+  listConnections: vi.fn(async () => []),
+}));
+vi.mock("@/stores/environment", () => ({
+  useEnvironmentStore: {
+    getState: () => ({ getActiveVariables: async () => ({}) }),
+  },
+}));
+
+import { collectBlocksAboveCM } from "../document";
+
+const row = {
+  status: "success",
+  response: '{"status_code":200}',
+  total_rows: null,
+  elapsed_ms: 5,
+  executed_at: "",
+};
+
+beforeEach(() => {
+  getBlockResult.mockReset();
+  getLatestBlockResultByAlias.mockReset();
+});
+
+describe("collectBlocksAboveCM", () => {
+  const doc = Text.of([
+    "```http alias=req1",
+    "GET https://api.example.com/users",
+    "```",
+    "",
+    "```http alias=req2",
+    "GET https://x.dev/{{req1.response.body.id}}",
+    "```",
+    "",
+  ]);
+
+  it("resolves http results by alias, not content hash", async () => {
+    getLatestBlockResultByAlias.mockResolvedValue(row);
+    const blocks = await collectBlocksAboveCM(doc, doc.length, "f.md");
+    expect(blocks.map((b) => b.alias)).toEqual(["req1", "req2"]);
+    expect(getLatestBlockResultByAlias).toHaveBeenCalledWith("f.md", "req1");
+    expect(getBlockResult).not.toHaveBeenCalled();
+    expect(blocks[0].cachedResult).toEqual({
+      status: "success",
+      response: '{"status_code":200}',
+    });
+  });
+
+  it("leaves cachedResult null when no row exists for the alias", async () => {
+    getLatestBlockResultByAlias.mockResolvedValue(null);
+    const blocks = await collectBlocksAboveCM(doc, doc.length, "f.md");
+    expect(blocks[0].cachedResult).toBeNull();
+  });
+
+  it("db block without a resolvable connection falls back to the alias row", async () => {
+    const dbDoc = Text.of([
+      "```db-postgres alias=q1 connection=ghost",
+      "SELECT 1;",
+      "```",
+      "",
+    ]);
+    getLatestBlockResultByAlias.mockResolvedValue(row);
+    const blocks = await collectBlocksAboveCM(dbDoc, dbDoc.length, "f.md");
+    expect(blocks).toHaveLength(1);
+    expect(getLatestBlockResultByAlias).toHaveBeenCalledWith("f.md", "q1");
+    expect(blocks[0].cachedResult?.status).toBe("success");
+  });
+});

--- a/httui-desktop/src/lib/blocks/document.ts
+++ b/httui-desktop/src/lib/blocks/document.ts
@@ -1,7 +1,10 @@
 import type { Text as CMText } from "@codemirror/state";
 import type { BlockContext } from "./references";
-import { getBlockResult } from "@/lib/tauri/commands";
-import { hashBlockContent, computeDbCacheHash } from "./hash";
+import {
+  getBlockResult,
+  getLatestBlockResultByAlias,
+} from "@/lib/tauri/commands";
+import { computeDbCacheHash } from "./hash";
 import { findFencedBlocks } from "@/lib/codemirror/cm-block-widgets";
 import { findDbBlocks } from "@/lib/codemirror/cm-db-block";
 import {
@@ -40,12 +43,13 @@ interface CollectedBlock extends BlockContext {
 }
 
 /**
- * Populate cached results for a list of collected blocks. For http/e2e
- * blocks the cache key is just `hashBlockContent(content)` (same as what
- * the write side computes). For DB blocks the key is `computeDbCacheHash`
- * which folds in the resolved connection UUID and a snapshot of the env
- * vars referenced by the query — both sides MUST match or the lookup
- * silently misses every cached row.
+ * Populate cached results for a list of collected blocks. HTTP blocks
+ * resolve by `(filePath, alias)` — the write side keys rows by a
+ * request+env hash this scanner cannot reproduce, so a hash lookup here
+ * would miss every row. DB blocks replicate the write-side key
+ * (`computeDbCacheHash` folds in the resolved connection UUID and a
+ * snapshot of the env vars referenced by the query); on a miss they
+ * also fall back to the alias row.
  */
 async function populateCachedResults(
   blocks: CollectedBlock[],
@@ -69,18 +73,24 @@ async function populateCachedResults(
     blocks.map(async (block) => {
       if (!block.content) return;
       try {
-        let hash: string;
+        let cached = null;
         if (block.blockType === "db") {
           const conn = resolveConnectionIdentifier(
             connections,
             block._dbConnectionIdentifier,
           );
-          if (!conn) return;
-          hash = await computeDbCacheHash(block.content, conn.id, envVars);
-        } else {
-          hash = await hashBlockContent(block.content);
+          if (conn) {
+            const hash = await computeDbCacheHash(
+              block.content,
+              conn.id,
+              envVars,
+            );
+            cached = await getBlockResult(filePath, hash);
+          }
         }
-        const cached = await getBlockResult(filePath, hash);
+        if (!cached) {
+          cached = await getLatestBlockResultByAlias(filePath, block.alias);
+        }
         if (cached) {
           block.cachedResult = {
             status: cached.status,

--- a/httui-desktop/src/lib/lsp/__tests__/client.test.ts
+++ b/httui-desktop/src/lib/lsp/__tests__/client.test.ts
@@ -1,0 +1,49 @@
+// notifyBlockRan must never spin the server up by itself: with no
+// editor-created client there are no open documents, so a refresh has
+// nothing to republish.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const notification = vi.fn();
+vi.mock("@codemirror/lsp-client", () => ({
+  LSPClient: class {
+    notification = notification;
+    connect() {
+      return this;
+    }
+  },
+  serverDiagnostics: () => [],
+}));
+vi.mock("../transport", () => ({
+  createTauriLspTransport: () => ({}),
+}));
+
+import {
+  fileUri,
+  getLspClient,
+  notifyBlockRan,
+  resetLspClient,
+} from "../client";
+
+afterEach(() => {
+  resetLspClient();
+  notification.mockClear();
+});
+
+describe("notifyBlockRan", () => {
+  it("is a no-op before any editor created the client", () => {
+    notifyBlockRan();
+    expect(notification).not.toHaveBeenCalled();
+  });
+
+  it("sends httui/refresh with object params once a client exists", () => {
+    getLspClient();
+    notifyBlockRan();
+    expect(notification).toHaveBeenCalledWith("httui/refresh", {});
+  });
+});
+
+describe("fileUri", () => {
+  it("joins vault and file into an absolute file uri", () => {
+    expect(fileUri("/v/ault", "notes/a.md")).toBe("file:///v/ault/notes/a.md");
+  });
+});

--- a/httui-desktop/src/lib/lsp/client.ts
+++ b/httui-desktop/src/lib/lsp/client.ts
@@ -20,6 +20,16 @@ export function resetLspClient() {
   client = null;
 }
 
+/**
+ * Tell the server a block ran: the inferred response shapes may have
+ * changed, so it republishes diagnostics for every open document.
+ * No-op while no editor has created the client — with no documents open
+ * there is nothing to republish.
+ */
+export function notifyBlockRan() {
+  client?.notification("httui/refresh", {});
+}
+
 export function fileUri(vaultPath: string, filePath: string): string {
   const joined = `${vaultPath}/${filePath}`.replace(/\/+/g, "/");
   return `file://${encodeURI(joined)}`;

--- a/httui-desktop/src/lib/tauri/env-block-commands.ts
+++ b/httui-desktop/src/lib/tauri/env-block-commands.ts
@@ -149,6 +149,22 @@ export function getBlockResult(
   });
 }
 
+/**
+ * Latest cached result for `(filePath, alias)` regardless of content
+ * hash. Read-side `{{alias…}}` resolution must use this for HTTP blocks:
+ * the write side keys rows by a request+env hash the document scanner
+ * cannot reproduce.
+ */
+export function getLatestBlockResultByAlias(
+  filePath: string,
+  alias: string,
+): Promise<CachedBlockResult | null> {
+  return invoke<CachedBlockResult | null>("get_latest_block_result_by_alias", {
+    filePath,
+    alias,
+  });
+}
+
 export function saveBlockResult(
   filePath: string,
   blockHash: string,
@@ -156,10 +172,12 @@ export function saveBlockResult(
   response: string,
   elapsedMs: number,
   totalRows?: number | null,
+  alias?: string | null,
 ): Promise<void> {
   return invoke<void>("save_block_result", {
     filePath,
     blockHash,
+    alias: alias ?? null,
     status,
     response,
     elapsedMs,

--- a/httui-mcp/Cargo.toml
+++ b/httui-mcp/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-httui-core = { git = "https://github.com/httuicom/httui-core", rev = "af75dbea47d59c195081469e096b33b8d231ecf9" }
+httui-core = { git = "https://github.com/httuicom/httui-core", rev = "6e2f97db9f3201d931c59fe1c4da93904355f73f" }
 rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/httui-tui/Cargo.toml
+++ b/httui-tui/Cargo.toml
@@ -15,7 +15,7 @@ name = "httui-tui"
 path = "src/main.rs"
 
 [dependencies]
-httui-core = { git = "https://github.com/httuicom/httui-core", rev = "af75dbea47d59c195081469e096b33b8d231ecf9" }
+httui-core = { git = "https://github.com/httuicom/httui-core", rev = "6e2f97db9f3201d931c59fe1c4da93904355f73f" }
 ropey = "1"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "tls-rustls"] }
 ratatui = "0.29"


### PR DESCRIPTION
## What

Desktop integration for typed `{{alias.path}}` resolution served by the language server:

- `save_block_result` (command + wrapper) now carries the block's alias, so successful runs land an inferred response shape; both block panels send the custom `httui/refresh` notification after an aliased save so the server republishes field diagnostics.
- Read-side `{{alias…}}` cache resolution now looks up the latest result by `(file_path, alias)` — the write side keys HTTP rows by a request+env hash the document scanner cannot reproduce, so the old content-hash lookup missed every row (hover always claimed the block had never run).
- `httui-core` bumped to pick up the WAL journal mode and the response shape cache.
- DB panel split into sibling hooks (explain, paging, cache hydrate, legacy migration) to clear the size gate; panel + hooks covered by new tests (48 checks in the db fenced suite).

## Validation

Manually verified in the app: hover shows the field type from the last run, `{{alias.response.` completes with real fields, and a field typo gets a warning squiggle with a suggestion. Full unit suite (3207), clippy and prettier green.