### PR TITLE
feat(desktop): bundle httui-lsp language server in the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,19 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # tauri.conf.json → bundle.externalBin lists httui-tui + the
-      # httui launcher. tauri-build's resource validator checks the
-      # files exist before letting `cargo check/test` proceed. CI
-      # doesn't bundle, so 0-byte placeholders satisfy the gate without
-      # the cost of a full release compile of those crates.
+      # tauri.conf.json → bundle.externalBin lists httui-tui, the
+      # httui launcher and the httui-lsp language server. tauri-build's
+      # resource validator checks the files exist before letting
+      # `cargo check/test` proceed. CI doesn't bundle, so 0-byte
+      # placeholders satisfy the gate without the cost of a full
+      # release compile (or release download) of those binaries.
       - name: Stage bundle binary placeholders
         run: |
           triple=$(rustc -vV | sed -n 's|host: ||p')
           mkdir -p httui-desktop/src-tauri/binaries
           touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
-                "httui-desktop/src-tauri/binaries/httui-$triple"
+                "httui-desktop/src-tauri/binaries/httui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-lsp-$triple"
 
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
@@ -173,7 +175,8 @@ jobs:
           triple=$(rustc -vV | sed -n 's|host: ||p')
           mkdir -p httui-desktop/src-tauri/binaries
           touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
-                "httui-desktop/src-tauri/binaries/httui-$triple"
+                "httui-desktop/src-tauri/binaries/httui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-lsp-$triple"
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           cd httui-sidecar && bun install && bun run build
 
-      - name: Stage TUI + launcher binaries for the bundle
+      - name: Stage TUI + launcher + language server binaries for the bundle
         shell: bash
         run: |
           # tauri.conf.json → bundle.externalBin expects pre-built

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,10 @@ sidecar:
 bundle-bins:
 	./scripts/prepare-bundle-bins.sh
 
-# Build de producao (com bundle .app para macOS)
+# Production build (.app bundle on macOS). Direct workspace invocation:
+# nested `npm run` layers swallow --bundles.
 build: sidecar bundle-bins
-	npm run tauri build -- --bundles app
+	npm --workspace httui-desktop run tauri -- build --bundles app
 
 # Instalar dependencias
 install-deps:

--- a/httui-desktop/src-tauri/src/lsp_sidecar.rs
+++ b/httui-desktop/src-tauri/src/lsp_sidecar.rs
@@ -17,13 +17,36 @@ struct Running {
 
 static STATE: Mutex<Option<Running>> = Mutex::new(None);
 
-/// `HTTUI_LSP_BIN` overrides for development; otherwise the launcher
-/// convention applies (binary on PATH, shipped next to the app).
+/// `HTTUI_LSP_BIN` > bundled sibling > PATH. Debug builds skip the
+/// sibling: tauri-build copies staged binaries/ into target/debug/,
+/// which may be stale next to the dev PATH symlink.
 fn resolve_binary() -> String {
-    match std::env::var("HTTUI_LSP_BIN") {
-        Ok(p) if !p.is_empty() => p,
-        _ => "httui-lsp".to_string(),
+    let exe_dir = if cfg!(debug_assertions) {
+        None
+    } else {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    };
+    resolve_binary_from(std::env::var("HTTUI_LSP_BIN").ok(), exe_dir)
+}
+
+fn resolve_binary_from(
+    env_override: Option<String>,
+    exe_dir: Option<std::path::PathBuf>,
+) -> String {
+    if let Some(p) = env_override {
+        if !p.is_empty() {
+            return p;
+        }
     }
+    if let Some(dir) = exe_dir {
+        let sibling = dir.join("httui-lsp");
+        if sibling.is_file() {
+            return sibling.to_string_lossy().into_owned();
+        }
+    }
+    "httui-lsp".to_string()
 }
 
 /// Wrap a JSON message in LSP Content-Length framing.
@@ -133,6 +156,30 @@ mod tests {
     fn read_framed_handles_eof_mid_body() {
         let mut input = Cursor::new(b"Content-Length: 10\r\n\r\nab".to_vec());
         assert_eq!(read_framed(&mut input), None);
+    }
+
+    #[test]
+    fn resolution_prefers_override_then_sibling_then_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("httui-lsp"), "").unwrap();
+        let sibling = dir.path().join("httui-lsp").to_string_lossy().into_owned();
+
+        assert_eq!(
+            resolve_binary_from(Some("/x/lsp".into()), Some(dir.path().into())),
+            "/x/lsp",
+            "explicit override wins over an existing sibling"
+        );
+        assert_eq!(
+            resolve_binary_from(Some(String::new()), Some(dir.path().into())),
+            sibling,
+            "empty override is ignored"
+        );
+        assert_eq!(
+            resolve_binary_from(None, Some(dir.path().join("missing"))),
+            "httui-lsp",
+            "no sibling file falls back to PATH"
+        );
+        assert_eq!(resolve_binary_from(None, None), "httui-lsp");
     }
 
     // env-var handling is asserted inside the round-trip test below:

--- a/httui-desktop/src-tauri/tauri.conf.json
+++ b/httui-desktop/src-tauri/tauri.conf.json
@@ -53,7 +53,7 @@
       "icons/icon.ico"
     ],
     "resources": ["resources/claude-sidecar.mjs"],
-    "externalBin": ["binaries/httui-tui", "binaries/httui"],
+    "externalBin": ["binaries/httui-tui", "binaries/httui", "binaries/httui-lsp"],
     "macOS": {
       "entitlements": "Entitlements.plist",
       "minimumSystemVersion": "10.15"

--- a/httui-desktop/src-tauri/tauri.windows.conf.json
+++ b/httui-desktop/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": ["binaries/httui-tui", "binaries/httui"]
+  }
+}

--- a/scripts/prepare-bundle-bins.sh
+++ b/scripts/prepare-bundle-bins.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
-# Builds httui-tui and httui-launcher in release mode and stages them
-# under httui-desktop/src-tauri/binaries/<name>-<triple> so the Tauri
+# Builds httui-tui and httui-launcher in release mode, stages the
+# httui-lsp language server, and places everything under
+# httui-desktop/src-tauri/binaries/<name>-<triple> so the Tauri
 # bundler picks them up via `bundle.externalBin` in tauri.conf.json.
 #
 # Used by the Makefile (`make build`) and the GitHub Actions release
 # workflow. Pass a target triple as $1 to cross-compile; with no
 # argument the host triple is detected via rustc.
+#
+# httui-lsp is an OCaml binary released by httuicom/httui-lang; it is
+# downloaded at the version pinned below. Set HTTUI_LSP_BUNDLE_BIN to a
+# local build (e.g. httui-lang/_build/default/bin/httui-lsp/httui_lsp.exe)
+# to skip the download. Windows targets skip the server entirely — the
+# desktop degrades gracefully without it.
 
 set -euo pipefail
+
+# Pinned httui-lang release providing the httui-lsp assets.
+HTTUI_LANG_VERSION="0.1.0"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$REPO_ROOT/httui-desktop/src-tauri/binaries"
@@ -50,6 +60,27 @@ cp "$SRC_DIR/httui$SUFFIX"     "$OUT_DIR/httui-$TARGET$SUFFIX"
 # non-executable and `httui` in $PATH errors with "Permission denied".
 chmod +x "$OUT_DIR/httui-tui-$TARGET$SUFFIX" "$OUT_DIR/httui-$TARGET$SUFFIX"
 
+if [[ "$TARGET" == *windows* ]]; then
+  echo "skipping httui-lsp: no Windows build yet (desktop degrades gracefully)"
+else
+  LSP_DEST="$OUT_DIR/httui-lsp-$TARGET"
+  # rm first: dune outputs are read-only and block in-place overwrite.
+  rm -f "$LSP_DEST"
+  if [[ -n "${HTTUI_LSP_BUNDLE_BIN:-}" ]]; then
+    echo "staging httui-lsp from HTTUI_LSP_BUNDLE_BIN: $HTTUI_LSP_BUNDLE_BIN"
+    cp "$HTTUI_LSP_BUNDLE_BIN" "$LSP_DEST"
+  else
+    LSP_URL="https://github.com/httuicom/httui-lang/releases/download/v${HTTUI_LANG_VERSION}/httui-lsp-${TARGET}"
+    echo "downloading httui-lsp ${HTTUI_LANG_VERSION} for $TARGET"
+    # -f: a missing asset must fail the release, never ship without lsp.
+    curl -fL --retry 3 -o "$LSP_DEST" "$LSP_URL"
+  fi
+  chmod 755 "$LSP_DEST"
+fi
+
 echo "staged:"
 echo "  $OUT_DIR/httui-tui-$TARGET$SUFFIX"
 echo "  $OUT_DIR/httui-$TARGET$SUFFIX"
+if [[ "$TARGET" != *windows* ]]; then
+  echo "  $OUT_DIR/httui-lsp-$TARGET"
+fi


### PR DESCRIPTION
## What

Ships the `httui-lsp` language server in the desktop bundle so installed apps (cask/.deb/.rpm) get diagnostics, typed hovers and field completion — until now the server only existed through a dev symlink.

- `prepare-bundle-bins.sh` stages `httui-lsp-<triple>`: from `HTTUI_LSP_BUNDLE_BIN` (local builds) or downloaded from the pinned `httuicom/httui-lang` release (v0.1.0). Hard failure on a missing asset; Windows targets skip the server (the desktop degrades gracefully without it — `tauri.windows.conf.json` drops it from `externalBin`).
- `lsp_sidecar` resolution: `HTTUI_LSP_BIN` → bundled sibling next to the executable (release builds only — debug keeps resolving through PATH so dev never picks up a stale staged copy) → PATH.
- CI stages a third placeholder for the tauri-build validator.
- `make build` fix: with two `npm run` layers the inner npm swallowed `--bundles`, so tauri received `build app`.

## Validation

Local end-to-end on macOS arm64: download path exercised by `make build`, `httui.app/Contents/MacOS/httui-lsp` present and answering the initialize handshake, and the app installed in /Applications spawns the bundled binary (`/Applications/httui.app/Contents/MacOS/httui-lsp --db …`). 112 tests in the tauri crate (sibling resolution covered), clippy, actionlint and shellcheck green.