### PR TITLE
chore: bump httui-lang to 0.2.0 for prev and numeric refs

### DIFF
--- a/httui-desktop/src-tauri/Cargo.toml
+++ b/httui-desktop/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ documentation.workspace = true
 
 [package.metadata.httui]
 # Read by scripts/prepare-bundle-bins.sh.
-lang-version = "0.1.0"
+lang-version = "0.2.0"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
Bundles httui-lsp v0.2.0: `{{$prev.path}}` and numeric dotted segments (`results.0.rows.0.id`) now get typed hover, field completion and typo squiggles. Validated: the pinned asset downloads and reports serverInfo version 0.2.0.