### PR TITLE
chore: bump httui-lang to 0.2.1 for hover value previews

### DIFF
--- a/httui-desktop/src-tauri/Cargo.toml
+++ b/httui-desktop/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ documentation.workspace = true
 
 [package.metadata.httui]
 # Read by scripts/prepare-bundle-bins.sh.
-lang-version = "0.2.0"
+lang-version = "0.2.1"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
Bundles httui-lsp v0.2.1: hover now previews the last response value at the hovered path (read-only from block_results, success rows only, 512 KB cap), plus the db numeric shortcut fix in shape resolution. Validated: pinned asset downloads and reports serverInfo 0.2.1.