### PR TITLE
feat(tui): navigation and editing ergonomics for the terminal editor

### DIFF
--- a/httui-tui/src/app/impl_accessors.rs
+++ b/httui-tui/src/app/impl_accessors.rs
@@ -211,6 +211,24 @@ impl App {
         self.set_result_tab(block_id, next);
     }
 
+    /// Auto-pairing applies only where the user is typing CODE: a
+    /// block's raw body in DOC view, or a BLOCKS-view edit field.
+    /// Prose never pairs (apostrophes), and modals own their input.
+    pub fn auto_pairs_active(&self) -> bool {
+        if !self.config.editor.auto_pairs || self.modal.is_some() {
+            return false;
+        }
+        if matches!(self.view, crate::app::AppView::Blocks) {
+            return self
+                .active_pane()
+                .map(|p| p.block_edit.is_some())
+                .unwrap_or(false);
+        }
+        self.document()
+            .map(|d| matches!(d.cursor(), crate::buffer::Cursor::InBlock { .. }))
+            .unwrap_or(false)
+    }
+
     // ----- viewport refresh ----------------------------------------------
 
     /// Re-anchor the viewport so the cursor stays visible after a

--- a/httui-tui/src/buffer/autopairs.rs
+++ b/httui-tui/src/buffer/autopairs.rs
@@ -1,0 +1,148 @@
+//! IDE-style bracket/quote pairing decisions. Pure char logic — the
+//! applier reads the chars around the cursor, asks this module what
+//! the keystroke means, and performs the edits. Only applied in code
+//! contexts (block bodies, BLOCKS-view edit fields); prose never
+//! pairs, so apostrophes in text stay single keystrokes.
+
+/// What a typed character should do under auto-pairing.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PairOutcome {
+    /// Insert the typed char AND this closer, caret between them.
+    Pair(char),
+    /// The next char already is the typed closer — step over it
+    /// instead of inserting a duplicate.
+    Skip,
+    /// Plain insert, no pairing.
+    Plain,
+}
+
+fn closer_for(opener: char) -> Option<char> {
+    match opener {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '"' => Some('"'),
+        '\'' => Some('\''),
+        '`' => Some('`'),
+        _ => None,
+    }
+}
+
+fn is_closer(c: char) -> bool {
+    matches!(c, ')' | ']' | '}')
+}
+
+fn is_quote(c: char) -> bool {
+    matches!(c, '"' | '\'' | '`')
+}
+
+fn is_wordish(c: Option<char>) -> bool {
+    c.is_some_and(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Decision for typing `c` with `prev`/`next` being the chars around
+/// the caret.
+pub(crate) fn on_insert(c: char, prev: Option<char>, next: Option<char>) -> PairOutcome {
+    // Stepping over the closer one just typed past — covers both
+    // bracket closers and the closing half of a quote pair.
+    if (is_closer(c) || is_quote(c)) && next == Some(c) {
+        return PairOutcome::Skip;
+    }
+    if is_quote(c) {
+        // A quote right after a word char is an apostrophe / string
+        // continuation (`don't`, `it's`), and pairing before a word
+        // would swallow it (`"foo` → `"f"oo`). Both stay plain.
+        if is_wordish(prev) || is_wordish(next) {
+            return PairOutcome::Plain;
+        }
+        return PairOutcome::Pair(c);
+    }
+    if let Some(closer) = closer_for(c) {
+        // Opening bracket directly before a word would wrap nothing
+        // useful and surprises mid-edit typing (`{`foo → `{}foo`).
+        if is_wordish(next) {
+            return PairOutcome::Plain;
+        }
+        return PairOutcome::Pair(closer);
+    }
+    PairOutcome::Plain
+}
+
+/// Backspace between an empty pair removes both halves.
+pub(crate) fn deletes_pair(prev: Option<char>, next: Option<char>) -> bool {
+    match (prev, next) {
+        (Some(p), Some(n)) => closer_for(p) == Some(n),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openers_pair_with_their_closers() {
+        assert_eq!(on_insert('{', None, None), PairOutcome::Pair('}'));
+        assert_eq!(on_insert('(', Some(' '), None), PairOutcome::Pair(')'));
+        assert_eq!(on_insert('[', Some('='), Some(' ')), PairOutcome::Pair(']'));
+    }
+
+    #[test]
+    fn opener_before_word_stays_plain() {
+        assert_eq!(on_insert('{', None, Some('f')), PairOutcome::Plain);
+        assert_eq!(on_insert('(', Some(' '), Some('x')), PairOutcome::Plain);
+    }
+
+    #[test]
+    fn closer_over_matching_next_skips() {
+        assert_eq!(on_insert('}', Some('{'), Some('}')), PairOutcome::Skip);
+        assert_eq!(on_insert(')', Some('a'), Some(')')), PairOutcome::Skip);
+        assert_eq!(on_insert(']', None, Some(']')), PairOutcome::Skip);
+    }
+
+    #[test]
+    fn closer_without_matching_next_is_plain() {
+        assert_eq!(on_insert('}', Some('a'), Some(')')), PairOutcome::Plain);
+        assert_eq!(on_insert(')', None, None), PairOutcome::Plain);
+    }
+
+    #[test]
+    fn quotes_pair_in_neutral_context() {
+        assert_eq!(on_insert('"', None, None), PairOutcome::Pair('"'));
+        assert_eq!(on_insert('\'', Some(' '), None), PairOutcome::Pair('\''));
+        assert_eq!(on_insert('`', Some('('), Some(')')), PairOutcome::Pair('`'));
+    }
+
+    #[test]
+    fn quote_after_word_char_is_an_apostrophe() {
+        assert_eq!(on_insert('\'', Some('n'), Some('t')), PairOutcome::Plain);
+        assert_eq!(on_insert('"', Some('x'), None), PairOutcome::Plain);
+    }
+
+    #[test]
+    fn quote_before_word_char_stays_plain() {
+        assert_eq!(on_insert('"', Some(' '), Some('f')), PairOutcome::Plain);
+    }
+
+    #[test]
+    fn quote_over_its_own_closer_skips() {
+        assert_eq!(on_insert('"', Some('a'), Some('"')), PairOutcome::Skip);
+        assert_eq!(on_insert('\'', None, Some('\'')), PairOutcome::Skip);
+    }
+
+    #[test]
+    fn backspace_inside_empty_pair_deletes_both() {
+        assert!(deletes_pair(Some('{'), Some('}')));
+        assert!(deletes_pair(Some('('), Some(')')));
+        assert!(deletes_pair(Some('"'), Some('"')));
+        assert!(deletes_pair(Some('\''), Some('\'')));
+    }
+
+    #[test]
+    fn backspace_elsewhere_deletes_one() {
+        assert!(!deletes_pair(Some('{'), Some(')')));
+        assert!(!deletes_pair(Some('a'), Some('}')));
+        assert!(!deletes_pair(None, Some('}')));
+        assert!(!deletes_pair(Some('{'), None));
+    }
+}

--- a/httui-tui/src/buffer/document/edit.rs
+++ b/httui-tui/src/buffer/document/edit.rs
@@ -170,6 +170,68 @@ impl Document {
         }
     }
 
+    /// Char under the cursor (the one a forward delete would remove),
+    /// or `None` at end-of-text / in a result row.
+    pub fn char_at_cursor(&self) -> Option<char> {
+        let (rope, offset) = self.cursor_rope()?;
+        (offset < rope.len_chars()).then(|| rope.char(offset))
+    }
+
+    /// Char immediately before the cursor, or `None` at the start.
+    pub fn char_before_cursor(&self) -> Option<char> {
+        let (rope, offset) = self.cursor_rope()?;
+        let off = offset.min(rope.len_chars());
+        (off > 0).then(|| rope.char(off - 1))
+    }
+
+    /// Step the cursor one char right without mutating text (used by
+    /// auto-pair skip-over). Clamped at end-of-text.
+    pub fn advance_cursor_char(&mut self) {
+        let Some((rope, offset)) = self.cursor_rope() else {
+            return;
+        };
+        if offset >= rope.len_chars() {
+            return;
+        }
+        match self.cursor {
+            Cursor::InProse { segment_idx, .. } => {
+                self.cursor = Cursor::InProse {
+                    segment_idx,
+                    offset: offset + 1,
+                };
+            }
+            Cursor::InBlock { segment_idx, .. } => {
+                self.cursor = Cursor::InBlock {
+                    segment_idx,
+                    offset: offset + 1,
+                };
+            }
+            Cursor::InBlockResult { .. } => {}
+        }
+    }
+
+    /// Rope + char offset the cursor points into, for either prose or
+    /// block-raw segments.
+    fn cursor_rope(&self) -> Option<(&Rope, usize)> {
+        match self.cursor {
+            Cursor::InProse {
+                segment_idx,
+                offset,
+            } => match self.segments.get(segment_idx) {
+                Some(Segment::Prose(rope)) => Some((rope, offset)),
+                _ => None,
+            },
+            Cursor::InBlock {
+                segment_idx,
+                offset,
+            } => match self.segments.get(segment_idx) {
+                Some(Segment::Block(b)) => Some((&b.raw, offset)),
+                _ => None,
+            },
+            Cursor::InBlockResult { .. } => None,
+        }
+    }
+
     /// Read a substring (in chars) from a prose segment. Out-of-bounds
     /// indices are clamped. Returns an empty string for non-prose
     /// segments or invalid indices.
@@ -229,6 +291,79 @@ mod tests {
     use super::Document;
     use crate::buffer::cursor::Cursor;
     use crate::buffer::segment::Segment;
+
+    #[test]
+    fn cursor_peeks_read_around_the_caret_in_prose() {
+        let mut d = Document::from_markdown("ab\n").unwrap();
+        d.set_cursor(Cursor::InProse {
+            segment_idx: 0,
+            offset: 1,
+        });
+        assert_eq!(d.char_before_cursor(), Some('a'));
+        assert_eq!(d.char_at_cursor(), Some('b'));
+        d.set_cursor(Cursor::InProse {
+            segment_idx: 0,
+            offset: 0,
+        });
+        assert_eq!(d.char_before_cursor(), None);
+    }
+
+    #[test]
+    fn cursor_peeks_read_block_raw_text() {
+        let mut d = Document::from_markdown("```http alias=h\nGET https://x.com\n```\n").unwrap();
+        let seg = d
+            .segments()
+            .iter()
+            .position(|s| matches!(s, Segment::Block(_)))
+            .unwrap();
+        let raw = match &d.segments()[seg] {
+            Segment::Block(b) => b.raw.to_string(),
+            _ => unreachable!(),
+        };
+        let off = raw.find("GET").unwrap();
+        d.set_cursor(Cursor::InBlock {
+            segment_idx: seg,
+            offset: off,
+        });
+        assert_eq!(d.char_at_cursor(), Some('G'));
+        assert_eq!(d.char_before_cursor(), Some('\n'));
+    }
+
+    #[test]
+    fn advance_cursor_char_steps_right_and_clamps_at_end() {
+        let mut d = Document::from_markdown("ab\n").unwrap();
+        d.set_cursor(Cursor::InProse {
+            segment_idx: 0,
+            offset: 0,
+        });
+        d.advance_cursor_char();
+        assert_eq!(d.char_before_cursor(), Some('a'));
+        // Walk to the rope end — further advances are no-ops.
+        for _ in 0..10 {
+            d.advance_cursor_char();
+        }
+        assert_eq!(d.char_at_cursor(), None);
+        let before = d.cursor();
+        d.advance_cursor_char();
+        assert_eq!(d.cursor(), before, "clamped at end-of-text");
+    }
+
+    #[test]
+    fn cursor_peeks_in_result_rows_are_none() {
+        let mut d = Document::from_markdown("```db-postgres alias=q connection=c\nSELECT 1\n```\n")
+            .unwrap();
+        let seg = d
+            .segments()
+            .iter()
+            .position(|s| matches!(s, Segment::Block(_)))
+            .unwrap();
+        d.set_cursor(crate::buffer::cursor::Cursor::InBlockResult {
+            segment_idx: seg,
+            row: 0,
+        });
+        assert_eq!(d.char_at_cursor(), None);
+        assert_eq!(d.char_before_cursor(), None);
+    }
 
     #[test]
     fn delete_char_at_cursor_in_prose_removes_under_cursor() {

--- a/httui-tui/src/buffer/mod.rs
+++ b/httui-tui/src/buffer/mod.rs
@@ -12,6 +12,7 @@
 // not yet consumed; epic 19/21 will pick them up.
 #![allow(dead_code)]
 
+pub mod autopairs;
 pub mod block;
 pub mod cursor;
 pub mod document;

--- a/httui-tui/src/config.rs
+++ b/httui-tui/src/config.rs
@@ -92,6 +92,14 @@ pub struct EditorConfig {
     /// for the accepted grammar.
     #[serde(default = "default_toggle_mode_key")]
     pub toggle_mode_key: String,
+    /// Auto-close brackets and quotes while typing inside code (block
+    /// bodies, BLOCKS-view edit fields). Prose is never auto-paired.
+    #[serde(default = "default_auto_pairs")]
+    pub auto_pairs: bool,
+}
+
+fn default_auto_pairs() -> bool {
+    true
 }
 
 impl Default for EditorConfig {
@@ -99,6 +107,7 @@ impl Default for EditorConfig {
         Self {
             mode: EditorMode::default(),
             toggle_mode_key: default_toggle_mode_key(),
+            auto_pairs: default_auto_pairs(),
         }
     }
 }

--- a/httui-tui/src/input/apply/blocks_view/nav.rs
+++ b/httui-tui/src/input/apply/blocks_view/nav.rs
@@ -23,6 +23,17 @@ pub(crate) fn band_neighbor(block_type: &str, region: usize, dir: isize) -> Opti
     }
 }
 
+/// Region to land on when navigation enters the HTTP Request band
+/// without naming a sub-tab: the remembered one (`Headers → 1`,
+/// `Body → 2`). Without this, every band entry would land on Headers
+/// and overwrite the memory right away.
+fn request_band_entry(app: &App) -> usize {
+    match app.active_pane().map(|p| p.block_req_tab) {
+        Some(1) => 2,
+        _ => 1,
+    }
+}
+
 /// Move to the band above/below, landing on its bottom row going up and
 /// its top row going down (vim split-edge feel).
 pub(crate) fn move_band(app: &mut App, dir: isize) {
@@ -30,12 +41,16 @@ pub(crate) fn move_band(app: &mut App, dir: isize) {
         return;
     };
     let region = app.active_pane().map(|p| p.block_region).unwrap_or(0);
-    let Some(target) = band_neighbor(&bt, region, dir) else {
+    let Some(mut target) = band_neighbor(&bt, region, dir) else {
         return;
     };
+    if bt == "http" && target == 1 {
+        target = request_band_entry(app);
+    }
     if let Some(pane) = app.active_pane_mut() {
         pane.block_region = target;
         pane.block_col = 1;
+        pane.note_req_tab();
     }
     let count = active_region_row_count(app);
     if let Some(pane) = app.active_pane_mut() {
@@ -59,6 +74,7 @@ pub(crate) fn cycle_band_subtab(app: &mut App, delta: isize) {
                     pane.block_region = next;
                     pane.block_row = 0;
                     pane.block_col = 1;
+                    pane.note_req_tab();
                 }
             }
             3 => shift_response_subtab(app, delta),
@@ -344,6 +360,13 @@ pub(crate) fn shift_block(app: &mut App, delta: isize) {
 
 pub(crate) fn set_region(app: &mut App, index: usize) {
     let count = active_block_region_count(app);
+    // The digit chord names the BAND, not the sub-tab — entering the
+    // HTTP Request band resolves to the remembered sub-tab's region.
+    let index = if index == 1 && active_block_type(app).as_deref() == Some("http") {
+        request_band_entry(app)
+    } else {
+        index
+    };
     let Some(pane) = app.active_pane_mut() else {
         return;
     };
@@ -354,6 +377,7 @@ pub(crate) fn set_region(app: &mut App, index: usize) {
     pane.block_region = index.min(count - 1);
     pane.block_row = 0;
     pane.block_col = 1;
+    pane.note_req_tab();
 }
 
 pub(crate) fn active_block_region_count(app: &App) -> usize {
@@ -397,3 +421,7 @@ pub(crate) fn jump_target_region(block_type: &str, n: usize) -> usize {
     let idx = n.saturating_sub(1).min(bands.len() - 1);
     bands[idx]
 }
+
+#[cfg(test)]
+#[path = "req_tab_tests.rs"]
+mod req_tab_tests;

--- a/httui-tui/src/input/apply/blocks_view/req_tab_tests.rs
+++ b/httui-tui/src/input/apply/blocks_view/req_tab_tests.rs
@@ -1,0 +1,129 @@
+use crate::app::{App, BlockRef};
+use crate::config::Config;
+use crate::input::action::Action;
+use crate::input::apply::blocks_view::apply_blocks_view;
+use crate::input::apply::tree_nav::apply_tree_nav;
+use crate::vault::ResolvedVault;
+use httui_core::db::init_db;
+use tempfile::TempDir;
+
+/// App in BLOCKS view with one HTTP block selected. Multi-thread
+/// runtime: `App::new` uses `block_in_place`.
+async fn blocks_app() -> (App, TempDir, TempDir) {
+    let data = TempDir::new().unwrap();
+    let vault = TempDir::new().unwrap();
+    std::fs::write(
+        vault.path().join("api.md"),
+        "# api\n\n```http alias=login\nGET https://x.com\n```\n",
+    )
+    .unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: vault.path().to_path_buf(),
+    };
+    let mut app = App::new(Config::default(), resolved, pool);
+    apply_blocks_view(&mut app, Action::ToggleAppView);
+    if let Some(pane) = app.active_pane_mut() {
+        pane.block_selected = Some(BlockRef {
+            file_idx: 0,
+            block_idx: 0,
+        });
+        pane.block_region = 0;
+    }
+    (app, data, vault)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn visiting_body_is_remembered_when_focus_leaves() {
+    let (mut app, _d, _v) = blocks_app().await;
+    // Request band lands on Headers, Tab flips to Body.
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(2));
+    assert_eq!(app.active_pane().unwrap().block_region, 1);
+    assert_eq!(app.active_pane().unwrap().block_req_tab, 0);
+    apply_blocks_view(&mut app, Action::BlocksPaneNextRegion);
+    assert_eq!(app.active_pane().unwrap().block_region, 2);
+    assert_eq!(app.active_pane().unwrap().block_req_tab, 1);
+    // Jump to the URL band — the Body memory must survive.
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(1));
+    let pane = app.active_pane().unwrap();
+    assert_eq!(pane.block_region, 0);
+    assert_eq!(pane.block_req_tab, 1, "Body tab stays remembered");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn re_entering_the_request_band_lands_on_the_remembered_tab() {
+    let (mut app, _d, _v) = blocks_app().await;
+    // Visit Body, leave for the URL band.
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(2));
+    apply_blocks_view(&mut app, Action::BlocksPaneNextRegion);
+    assert_eq!(app.active_pane().unwrap().block_region, 2);
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(1));
+    // Digit jump back into the Request band → Body, not Headers.
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(2));
+    assert_eq!(
+        app.active_pane().unwrap().block_region,
+        2,
+        "digit re-entry lands on the remembered Body tab"
+    );
+    // Same via vertical band motion: leave upward to URL, walk back
+    // down — still Body.
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(1));
+    apply_blocks_view(&mut app, Action::BlocksPaneRowDown);
+    assert_eq!(
+        app.active_pane().unwrap().block_region,
+        2,
+        "band motion re-entry lands on the remembered Body tab"
+    );
+    // Headers memory works the same way in reverse.
+    apply_blocks_view(&mut app, Action::BlocksPaneNextRegion);
+    assert_eq!(app.active_pane().unwrap().block_region, 1);
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(1));
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(2));
+    assert_eq!(
+        app.active_pane().unwrap().block_region,
+        1,
+        "Headers re-entry after visiting Headers"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reactivating_the_open_block_keeps_region_and_tabs() {
+    let (mut app, _d, _v) = blocks_app().await;
+    apply_blocks_view(&mut app, Action::BlocksPaneJumpRegion(2));
+    apply_blocks_view(&mut app, Action::BlocksPaneNextRegion);
+    assert_eq!(app.active_pane().unwrap().block_region, 2);
+    let tabs_before = app.active_pane().unwrap().tab_count();
+    // Walk the sidebar down to the open block's row. Expanding a
+    // collapsed row needs a refresh to materialize its children —
+    // same dance the TreeActivate handler does.
+    let vault_path = app.vault_path.clone();
+    app.tree.select_first();
+    for _ in 0..50 {
+        let on_block = app
+            .tree
+            .current()
+            .map(|n| n.block.is_some())
+            .unwrap_or(false);
+        if on_block {
+            break;
+        }
+        if app.tree.toggle_expand() {
+            app.tree.refresh(&vault_path);
+        }
+        app.tree.select_next();
+    }
+    assert!(
+        app.tree
+            .current()
+            .map(|n| n.block.is_some())
+            .unwrap_or(false),
+        "fixture: tree cursor must land on a block row"
+    );
+    apply_tree_nav(&mut app, Action::TreeActivate, true);
+    let pane = app.active_pane().unwrap();
+    assert_eq!(
+        pane.block_region, 2,
+        "region survives re-activating the same block"
+    );
+    assert_eq!(pane.tab_count(), tabs_before, "no duplicate tab stacked");
+}

--- a/httui-tui/src/input/apply/misc.rs
+++ b/httui-tui/src/input/apply/misc.rs
@@ -213,10 +213,36 @@ pub(crate) fn apply_misc(app: &mut App, action: Action, recording: bool) {
             }
         }
         Action::InsertChar(c) => {
+            use crate::buffer::autopairs::{self, PairOutcome};
+            let auto = app.auto_pairs_active();
+            let mut typed = true;
             if let Some(doc) = app.document_mut() {
-                doc.insert_char_at_cursor(c);
+                let outcome = if auto {
+                    autopairs::on_insert(c, doc.char_before_cursor(), doc.char_at_cursor())
+                } else {
+                    PairOutcome::Plain
+                };
+                match outcome {
+                    PairOutcome::Skip => {
+                        // Step over the closer instead of duplicating
+                        // it. Not recorded in the insert session — on
+                        // `.` replay the pairing re-creates the closer,
+                        // so replaying the skip would double-advance.
+                        doc.advance_cursor_char();
+                        typed = false;
+                    }
+                    PairOutcome::Pair(closer) => {
+                        doc.insert_char_at_cursor(c);
+                        let between = doc.cursor();
+                        doc.insert_char_at_cursor(closer);
+                        doc.set_cursor(between);
+                    }
+                    PairOutcome::Plain => doc.insert_char_at_cursor(c),
+                }
             }
-            app.vim.insert_session.push_char(c);
+            if typed {
+                app.vim.insert_session.push_char(c);
+            }
             // Typing past the pane edge must pan the viewport like a
             // motion would — without this the caret walks off-screen
             // until the next motion refreshes.
@@ -230,8 +256,17 @@ pub(crate) fn apply_misc(app: &mut App, action: Action, recording: bool) {
             app.refresh_viewport_for_cursor();
         }
         Action::DeleteBackward => {
+            let auto = app.auto_pairs_active();
             if let Some(doc) = app.document_mut() {
+                let empty_pair = auto
+                    && crate::buffer::autopairs::deletes_pair(
+                        doc.char_before_cursor(),
+                        doc.char_at_cursor(),
+                    );
                 doc.delete_char_before_cursor();
+                if empty_pair {
+                    doc.delete_char_at_cursor();
+                }
             }
             app.vim.insert_session.pop_char();
             app.refresh_viewport_for_cursor();

--- a/httui-tui/src/input/apply/misc_tests.rs
+++ b/httui-tui/src/input/apply/misc_tests.rs
@@ -82,3 +82,106 @@ async fn delete_forward_refreshes_the_viewport() {
     let left = app.active_pane().unwrap().viewport_left;
     assert!(left < 200, "DeleteForward must re-clamp the pan");
 }
+
+// ---- auto-pairs ----------------------------------------------------
+
+/// App whose note holds a db block; cursor parked at the end of the
+/// SQL body line (a code context for auto-pairing).
+async fn app_in_block_body() -> (crate::app::App, TempDir, TempDir) {
+    let data = TempDir::new().unwrap();
+    let vault = TempDir::new().unwrap();
+    std::fs::write(
+        vault.path().join("note.md"),
+        "```db-postgres alias=q connection=c\nSELECT 1 \n```\n",
+    )
+    .unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: vault.path().to_path_buf(),
+    };
+    let mut app = crate::app::App::new(Config::default(), resolved, pool);
+    let (seg, off) = {
+        let doc = app.document().expect("note loaded");
+        let seg = doc
+            .segments()
+            .iter()
+            .position(|s| matches!(s, crate::buffer::Segment::Block(_)))
+            .expect("block segment");
+        let raw = match &doc.segments()[seg] {
+            crate::buffer::Segment::Block(b) => b.raw.to_string(),
+            _ => unreachable!(),
+        };
+        // After the trailing space of "SELECT 1 " — neutral context.
+        (seg, raw.find("SELECT 1 ").unwrap() + "SELECT 1 ".len())
+    };
+    if let Some(doc) = app.document_mut() {
+        doc.set_cursor(Cursor::InBlock {
+            segment_idx: seg,
+            offset: off,
+        });
+    }
+    (app, data, vault)
+}
+
+fn block_raw(app: &crate::app::App) -> String {
+    let doc = app.document().unwrap();
+    doc.segments()
+        .iter()
+        .find_map(|s| match s {
+            crate::buffer::Segment::Block(b) => Some(b.raw.to_string()),
+            _ => None,
+        })
+        .expect("block still parsed")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn open_brace_in_block_body_auto_closes() {
+    let (mut app, _d, _v) = app_in_block_body().await;
+    apply_action(&mut app, Action::InsertChar('{'), true);
+    assert!(block_raw(&app).contains("{}"), "pair inserted");
+    let doc = app.document().unwrap();
+    assert_eq!(doc.char_before_cursor(), Some('{'), "caret between pair");
+    assert_eq!(doc.char_at_cursor(), Some('}'));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn typing_closer_over_the_pair_skips_instead_of_duplicating() {
+    let (mut app, _d, _v) = app_in_block_body().await;
+    apply_action(&mut app, Action::InsertChar('{'), true);
+    apply_action(&mut app, Action::InsertChar('}'), true);
+    let raw = block_raw(&app);
+    assert_eq!(raw.matches('}').count(), 1, "no duplicate closer: {raw}");
+    let doc = app.document().unwrap();
+    assert_eq!(doc.char_before_cursor(), Some('}'), "caret stepped over");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backspace_inside_empty_pair_removes_both_halves() {
+    let (mut app, _d, _v) = app_in_block_body().await;
+    apply_action(&mut app, Action::InsertChar('('), true);
+    apply_action(&mut app, Action::DeleteBackward, true);
+    let raw = block_raw(&app);
+    assert!(!raw.contains('('), "opener gone: {raw}");
+    assert!(!raw.contains(')'), "closer gone too: {raw}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prose_typing_never_pairs() {
+    let (mut app, _d, _v) = app_with_long_line().await;
+    prime_pane(&mut app, 0);
+    apply_action(&mut app, Action::InsertChar('('), true);
+    apply_action(&mut app, Action::InsertChar('\''), true);
+    let doc = app.document().unwrap();
+    let text = doc.to_markdown();
+    assert!(!text.contains(')'), "prose must not auto-close: {text}");
+    assert_eq!(text.matches('\'').count(), 1, "apostrophe stays single");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_pairs_off_disables_pairing_in_code() {
+    let (mut app, _d, _v) = app_in_block_body().await;
+    app.config.editor.auto_pairs = false;
+    apply_action(&mut app, Action::InsertChar('{'), true);
+    let raw = block_raw(&app);
+    assert!(!raw.contains('}'), "no closer with the toggle off: {raw}");
+}

--- a/httui-tui/src/input/apply/tree_nav.rs
+++ b/httui-tui/src/input/apply/tree_nav.rs
@@ -76,8 +76,15 @@ pub(crate) fn apply_tree_nav(app: &mut App, action: Action, _recording: bool) {
                 // populated tab → push a new tab and activate it. This
                 // matches the user's mental model (each Enter on the
                 // sidebar leaves a trail of open tabs without needing a
-                // separate `Ctrl+Enter` chord).
+                // separate `Ctrl+Enter` chord). Re-activating the block
+                // already open is a no-op — resetting the region (or
+                // stacking a duplicate tab) would throw away the
+                // user's place inside the card.
                 if let Some(pane) = app.active_pane_mut() {
+                    if pane.block_selected == Some(target) {
+                        app.vim.enter_normal();
+                        return;
+                    }
                     let active_empty = pane.block_selected.is_none();
                     if active_empty {
                         pane.block_selected = Some(target);

--- a/httui-tui/src/pane.rs
+++ b/httui-tui/src/pane.rs
@@ -43,6 +43,11 @@ pub struct Pane {
     /// Default `1` so a fresh focus into Headers lands on "value" — the
     /// most-edited field in practice (Cenário 4 enters on `value`).
     pub block_col: usize,
+    /// Last Request-card sub-tab the focus visited (`0 = Headers`,
+    /// `1 = Body`). The card's tab strip has no state of its own — it
+    /// derives from the focused region — so this memory keeps the tab
+    /// the user left open visible while focus sits on URL/Response.
+    pub block_req_tab: usize,
     /// `Some` while a region field is being edited. The applier captures
     /// every keystroke into the buffer until Esc (commit) or Ctrl+C
     /// (discard); the renderer paints the buffer in place of the field
@@ -86,6 +91,7 @@ impl Pane {
             block_region: 0,
             block_row: 0,
             block_col: 1,
+            block_req_tab: 0,
             block_edit: None,
             block_draft: None,
             block_tabs: vec![BlockTab::empty()],
@@ -105,12 +111,24 @@ impl Pane {
             block_region: 0,
             block_row: 0,
             block_col: 1,
+            block_req_tab: 0,
             block_edit: None,
             block_draft: None,
             // The mirror IS the active tab's truth; the inactive slot
             // starts empty and only gets populated on the first swap.
             block_tabs: vec![BlockTab::empty()],
             block_tab_active: 0,
+        }
+    }
+
+    /// Record which Request-card sub-tab the current region implies
+    /// (`1 → Headers`, `2 → Body`). Other regions leave the memory
+    /// untouched so the card keeps showing the last visited tab.
+    pub fn note_req_tab(&mut self) {
+        match self.block_region {
+            1 => self.block_req_tab = 0,
+            2 => self.block_req_tab = 1,
+            _ => {}
         }
     }
 
@@ -170,6 +188,7 @@ impl Pane {
             block_region: self.block_region,
             block_row: self.block_row,
             block_col: self.block_col,
+            block_req_tab: self.block_req_tab,
             block_edit: None,
             block_draft: None,
             // Splits start with a single empty inactive slot — the
@@ -530,260 +549,5 @@ fn equalize_node(node: &mut PaneNode) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    fn pane_with_path(name: &str) -> Pane {
-        Pane {
-            document: None,
-            document_path: Some(PathBuf::from(name)),
-            viewport_top: 0,
-            viewport_left: 0,
-            viewport_height: 0,
-            viewport_width: 0,
-            block_selected: None,
-            block_region: 0,
-            block_row: 0,
-            block_col: 1,
-            block_edit: None,
-            block_draft: None,
-            block_tabs: vec![BlockTab::empty()],
-            block_tab_active: 0,
-        }
-    }
-
-    #[test]
-    fn snapshot_clone_preserves_cached_result_across_blocks() {
-        // Build a pane whose Document has two HTTP blocks, populate
-        // the second one's cached_result, then clone — the new pane
-        // must keep the cached_result on the same block (split must
-        // not wipe the response card).
-        use crate::buffer::Segment;
-        let md =
-            "```http alias=a\nGET https://x.com\n```\n\n```http alias=b\nGET https://y.com\n```\n";
-        let mut doc = Document::from_markdown(md).unwrap();
-        let cached = serde_json::json!({"status": 200, "body": {"ok": true}});
-        let target = doc
-            .segments()
-            .iter()
-            .position(|s| matches!(s, Segment::Block(b) if b.alias.as_deref() == Some("b")))
-            .unwrap();
-        if let Some(b) = doc.block_at_mut(target) {
-            b.cached_result = Some(cached.clone());
-            b.state = crate::buffer::block::ExecutionState::Success;
-        }
-        let pane = Pane {
-            document: Some(doc),
-            document_path: Some(PathBuf::from("api.md")),
-            viewport_top: 0,
-            viewport_left: 0,
-            viewport_height: 0,
-            viewport_width: 0,
-            block_selected: None,
-            block_region: 0,
-            block_row: 0,
-            block_col: 0,
-            block_edit: None,
-            block_draft: None,
-            block_tabs: vec![BlockTab::empty()],
-            block_tab_active: 0,
-        };
-        let clone = pane.snapshot_clone();
-        let cloned_doc = clone.document.expect("doc cloned");
-        let cloned_b = cloned_doc
-            .segments()
-            .iter()
-            .find_map(|s| match s {
-                Segment::Block(b) if b.alias.as_deref() == Some("b") => Some(b),
-                _ => None,
-            })
-            .expect("block b present");
-        assert_eq!(cloned_b.cached_result.as_ref(), Some(&cached));
-        assert!(matches!(
-            cloned_b.state,
-            crate::buffer::block::ExecutionState::Success
-        ));
-    }
-
-    #[test]
-    fn new_tab_has_single_leaf() {
-        let tab = TabState::new(pane_with_path("a.md"));
-        assert_eq!(tab.leaf_count(), 1);
-        assert_eq!(tab.focused, Vec::<u8>::new());
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-    }
-
-    #[test]
-    fn split_vertical_focuses_new_pane() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        assert_eq!(tab.leaf_count(), 2);
-        assert_eq!(tab.focused, vec![1u8]);
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
-    }
-
-    #[test]
-    fn focus_left_after_vertical_split() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        // We're on b (right). Press Left → land on a.
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-        // Already on the leftmost — Left is no-op.
-        assert!(!tab.focus_dir(FocusDir::Left));
-    }
-
-    #[test]
-    fn focus_down_after_horizontal_split() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
-        // We're on b (bottom). Up → a.
-        assert!(tab.focus_dir(FocusDir::Up));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-        // Down → b again.
-        assert!(tab.focus_dir(FocusDir::Down));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
-    }
-
-    #[test]
-    fn nested_focus_skips_unrelated_split() {
-        // Layout:
-        //   +-------+--------+
-        //   |       | b.md   |
-        //   | a.md  +--------+
-        //   |       | c.md   |
-        //   +-------+--------+
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md")); // focus on b
-        tab.split(SplitDir::Horizontal, pane_with_path("c.md")); // focus on c (below b)
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
-        // From c, Left should walk past the H split and into a.
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-    }
-
-    /// User's actual bug: three columns laid out as V[A, V[B, C]].
-    /// From C (rightmost), Ctrl+W h must land on B (immediate left
-    /// neighbour) — the old `descend_first` always went to A (leftmost
-    /// of the whole layout) by descending into the sibling's `first`
-    /// child no matter what direction we came from.
-    #[test]
-    fn focus_left_descends_toward_origin_in_nested_vertical_splits() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        // Now V[A, B], focused on B = [1].
-        tab.split(SplitDir::Vertical, pane_with_path("c.md"));
-        // Now V[A, V[B, C]], focused on C = [1, 1].
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert_eq!(
-            tab.active_leaf().document_path,
-            Some(PathBuf::from("b.md")),
-            "expected B (immediate left), got: focused path = {:?}",
-            tab.focused
-        );
-    }
-
-    /// Symmetric: H[A, H[B, C]] — from C (bottom) press Up, must
-    /// land on B (the row immediately above), not A (topmost leaf).
-    #[test]
-    fn focus_up_descends_toward_origin_in_nested_horizontal_splits() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
-        tab.split(SplitDir::Horizontal, pane_with_path("c.md"));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
-        assert!(tab.focus_dir(FocusDir::Up));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")),);
-    }
-
-    /// Layout that matches the user's report: vertical root, left
-    /// column is a horizontal split (A top / B bottom), right is a
-    /// vertical split (C / D). From D, `Ctrl+W h` must land on C
-    /// (the adjacent left neighbour), not on A (leftmost leaf).
-    #[test]
-    fn focus_left_from_rightmost_in_4pane_layout_lands_on_immediate_neighbour() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        // Build: V[ H[A, B], V[C, D] ].
-        // Start: just A. After split V → focus is on second leaf [1].
-        tab.split(SplitDir::Vertical, pane_with_path("c.md"));
-        // Now layout: V[A, C]. focused=[1] on C.
-        // Split V from C to create D (right of C) → V[A, V[C, D]],
-        // focused=[1,1] on D.
-        tab.split(SplitDir::Vertical, pane_with_path("d.md"));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("d.md")));
-        // Move focus to A and split horizontally to add B below.
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-        tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
-        // Layout now: V[ H[A, B], V[C, D] ]; focus on B = [0,1].
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
-        // Move focus back to D and test the failing motion.
-        assert!(tab.focus_dir(FocusDir::Right));
-        assert!(tab.focus_dir(FocusDir::Right));
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("d.md")));
-        // Ctrl+W h from D → expect C (immediate neighbour), not A
-        // (which is the leftmost leaf of the whole layout).
-        assert!(tab.focus_dir(FocusDir::Left));
-        assert_eq!(
-            tab.active_leaf().document_path,
-            Some(PathBuf::from("c.md")),
-            "expected C, got: focused path = {:?}",
-            tab.focused
-        );
-    }
-
-    #[test]
-    fn close_focused_promotes_sibling() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        // Close b → only a remains, focus on a.
-        assert_eq!(tab.close_focused(), CloseResult::Closed);
-        assert_eq!(tab.leaf_count(), 1);
-        assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
-    }
-
-    #[test]
-    fn close_focused_on_root_returns_last_leaf() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        assert_eq!(tab.close_focused(), CloseResult::LastLeaf);
-        assert_eq!(tab.leaf_count(), 1);
-    }
-
-    #[test]
-    fn cycle_focus_visits_all_leaves() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        tab.split(SplitDir::Horizontal, pane_with_path("c.md"));
-        // Cycle from c → a → b → c.
-        let mut seen = vec![tab.active_leaf().document_path.clone()];
-        for _ in 0..3 {
-            assert!(tab.cycle_focus());
-            seen.push(tab.active_leaf().document_path.clone());
-        }
-        assert_eq!(seen[0], Some(PathBuf::from("c.md")));
-        assert_eq!(seen[3], Some(PathBuf::from("c.md")));
-        let names: Vec<String> = seen
-            .iter()
-            .filter_map(|p| p.as_ref().map(|p| p.display().to_string()))
-            .collect();
-        assert!(names.contains(&"a.md".to_string()));
-        assert!(names.contains(&"b.md".to_string()));
-    }
-
-    #[test]
-    fn equalize_resets_ratios() {
-        let mut tab = TabState::new(pane_with_path("a.md"));
-        tab.split(SplitDir::Vertical, pane_with_path("b.md"));
-        if let PaneNode::Split { ratio, .. } = &mut tab.root {
-            *ratio = 0.8;
-        }
-        tab.equalize();
-        if let PaneNode::Split { ratio, .. } = &tab.root {
-            assert!((ratio - 0.5).abs() < f32::EPSILON);
-        } else {
-            panic!("root should be a split");
-        }
-    }
-}
+#[path = "pane_tests.rs"]
+mod tests;

--- a/httui-tui/src/pane_tabs.rs
+++ b/httui-tui/src/pane_tabs.rs
@@ -34,6 +34,7 @@ pub struct BlockTab {
     pub block_region: usize,
     pub block_row: usize,
     pub block_col: usize,
+    pub block_req_tab: usize,
     pub block_edit: Option<Box<RegionEdit>>,
     pub block_draft: Option<Box<BlockDraft>>,
 }
@@ -48,6 +49,7 @@ impl BlockTab {
             block_region: 0,
             block_row: 0,
             block_col: 1,
+            block_req_tab: 0,
             block_edit: None,
             block_draft: None,
         }
@@ -82,6 +84,7 @@ impl Pane {
             block_region: self.block_region,
             block_row: self.block_row,
             block_col: self.block_col,
+            block_req_tab: self.block_req_tab,
             block_edit: self.block_edit.take(),
             block_draft: self.block_draft.take(),
         }
@@ -95,6 +98,7 @@ impl Pane {
         self.block_region = tab.block_region;
         self.block_row = tab.block_row;
         self.block_col = tab.block_col;
+        self.block_req_tab = tab.block_req_tab;
         self.block_edit = tab.block_edit;
         self.block_draft = tab.block_draft;
     }
@@ -267,6 +271,7 @@ mod tests {
             block_region: 1,
             block_row: 4,
             block_col: 0,
+            block_req_tab: 0,
             block_edit: None,
             block_draft: None,
         };
@@ -292,6 +297,7 @@ mod tests {
             block_region: 5,
             block_row: 0,
             block_col: 0,
+            block_req_tab: 0,
             block_edit: None,
             block_draft: None,
         };

--- a/httui-tui/src/pane_tests.rs
+++ b/httui-tui/src/pane_tests.rs
@@ -1,0 +1,275 @@
+use super::*;
+use std::path::PathBuf;
+
+fn pane_with_path(name: &str) -> Pane {
+    Pane {
+        document: None,
+        document_path: Some(PathBuf::from(name)),
+        viewport_top: 0,
+        viewport_left: 0,
+        viewport_height: 0,
+        viewport_width: 0,
+        block_selected: None,
+        block_region: 0,
+        block_row: 0,
+        block_col: 1,
+        block_req_tab: 0,
+        block_edit: None,
+        block_draft: None,
+        block_tabs: vec![BlockTab::empty()],
+        block_tab_active: 0,
+    }
+}
+
+#[test]
+fn note_req_tab_tracks_request_regions_only() {
+    let mut p = Pane::empty();
+    p.block_region = 2;
+    p.note_req_tab();
+    assert_eq!(p.block_req_tab, 1, "Body region records the Body tab");
+    // Leaving for URL/Response keeps the memory.
+    p.block_region = 3;
+    p.note_req_tab();
+    assert_eq!(p.block_req_tab, 1);
+    p.block_region = 0;
+    p.note_req_tab();
+    assert_eq!(p.block_req_tab, 1);
+    // Visiting Headers re-records.
+    p.block_region = 1;
+    p.note_req_tab();
+    assert_eq!(p.block_req_tab, 0);
+}
+
+#[test]
+fn snapshot_clone_preserves_cached_result_across_blocks() {
+    // Build a pane whose Document has two HTTP blocks, populate
+    // the second one's cached_result, then clone — the new pane
+    // must keep the cached_result on the same block (split must
+    // not wipe the response card).
+    use crate::buffer::Segment;
+    let md = "```http alias=a\nGET https://x.com\n```\n\n```http alias=b\nGET https://y.com\n```\n";
+    let mut doc = Document::from_markdown(md).unwrap();
+    let cached = serde_json::json!({"status": 200, "body": {"ok": true}});
+    let target = doc
+        .segments()
+        .iter()
+        .position(|s| matches!(s, Segment::Block(b) if b.alias.as_deref() == Some("b")))
+        .unwrap();
+    if let Some(b) = doc.block_at_mut(target) {
+        b.cached_result = Some(cached.clone());
+        b.state = crate::buffer::block::ExecutionState::Success;
+    }
+    let pane = Pane {
+        document: Some(doc),
+        document_path: Some(PathBuf::from("api.md")),
+        viewport_top: 0,
+        viewport_left: 0,
+        viewport_height: 0,
+        viewport_width: 0,
+        block_selected: None,
+        block_region: 0,
+        block_row: 0,
+        block_col: 0,
+        block_req_tab: 0,
+        block_edit: None,
+        block_draft: None,
+        block_tabs: vec![BlockTab::empty()],
+        block_tab_active: 0,
+    };
+    let clone = pane.snapshot_clone();
+    let cloned_doc = clone.document.expect("doc cloned");
+    let cloned_b = cloned_doc
+        .segments()
+        .iter()
+        .find_map(|s| match s {
+            Segment::Block(b) if b.alias.as_deref() == Some("b") => Some(b),
+            _ => None,
+        })
+        .expect("block b present");
+    assert_eq!(cloned_b.cached_result.as_ref(), Some(&cached));
+    assert!(matches!(
+        cloned_b.state,
+        crate::buffer::block::ExecutionState::Success
+    ));
+}
+
+#[test]
+fn new_tab_has_single_leaf() {
+    let tab = TabState::new(pane_with_path("a.md"));
+    assert_eq!(tab.leaf_count(), 1);
+    assert_eq!(tab.focused, Vec::<u8>::new());
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+}
+
+#[test]
+fn split_vertical_focuses_new_pane() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    assert_eq!(tab.leaf_count(), 2);
+    assert_eq!(tab.focused, vec![1u8]);
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
+}
+
+#[test]
+fn focus_left_after_vertical_split() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    // We're on b (right). Press Left → land on a.
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+    // Already on the leftmost — Left is no-op.
+    assert!(!tab.focus_dir(FocusDir::Left));
+}
+
+#[test]
+fn focus_down_after_horizontal_split() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
+    // We're on b (bottom). Up → a.
+    assert!(tab.focus_dir(FocusDir::Up));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+    // Down → b again.
+    assert!(tab.focus_dir(FocusDir::Down));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
+}
+
+#[test]
+fn nested_focus_skips_unrelated_split() {
+    // Layout:
+    //   +-------+--------+
+    //   |       | b.md   |
+    //   | a.md  +--------+
+    //   |       | c.md   |
+    //   +-------+--------+
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md")); // focus on b
+    tab.split(SplitDir::Horizontal, pane_with_path("c.md")); // focus on c (below b)
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
+    // From c, Left should walk past the H split and into a.
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+}
+
+/// User's actual bug: three columns laid out as V[A, V[B, C]].
+/// From C (rightmost), Ctrl+W h must land on B (immediate left
+/// neighbour) — the old `descend_first` always went to A (leftmost
+/// of the whole layout) by descending into the sibling's `first`
+/// child no matter what direction we came from.
+#[test]
+fn focus_left_descends_toward_origin_in_nested_vertical_splits() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    // Now V[A, B], focused on B = [1].
+    tab.split(SplitDir::Vertical, pane_with_path("c.md"));
+    // Now V[A, V[B, C]], focused on C = [1, 1].
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert_eq!(
+        tab.active_leaf().document_path,
+        Some(PathBuf::from("b.md")),
+        "expected B (immediate left), got: focused path = {:?}",
+        tab.focused
+    );
+}
+
+/// Symmetric: H[A, H[B, C]] — from C (bottom) press Up, must
+/// land on B (the row immediately above), not A (topmost leaf).
+#[test]
+fn focus_up_descends_toward_origin_in_nested_horizontal_splits() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
+    tab.split(SplitDir::Horizontal, pane_with_path("c.md"));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("c.md")));
+    assert!(tab.focus_dir(FocusDir::Up));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")),);
+}
+
+/// Layout that matches the user's report: vertical root, left
+/// column is a horizontal split (A top / B bottom), right is a
+/// vertical split (C / D). From D, `Ctrl+W h` must land on C
+/// (the adjacent left neighbour), not on A (leftmost leaf).
+#[test]
+fn focus_left_from_rightmost_in_4pane_layout_lands_on_immediate_neighbour() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    // Build: V[ H[A, B], V[C, D] ].
+    // Start: just A. After split V → focus is on second leaf [1].
+    tab.split(SplitDir::Vertical, pane_with_path("c.md"));
+    // Now layout: V[A, C]. focused=[1] on C.
+    // Split V from C to create D (right of C) → V[A, V[C, D]],
+    // focused=[1,1] on D.
+    tab.split(SplitDir::Vertical, pane_with_path("d.md"));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("d.md")));
+    // Move focus to A and split horizontally to add B below.
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+    tab.split(SplitDir::Horizontal, pane_with_path("b.md"));
+    // Layout now: V[ H[A, B], V[C, D] ]; focus on B = [0,1].
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("b.md")));
+    // Move focus back to D and test the failing motion.
+    assert!(tab.focus_dir(FocusDir::Right));
+    assert!(tab.focus_dir(FocusDir::Right));
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("d.md")));
+    // Ctrl+W h from D → expect C (immediate neighbour), not A
+    // (which is the leftmost leaf of the whole layout).
+    assert!(tab.focus_dir(FocusDir::Left));
+    assert_eq!(
+        tab.active_leaf().document_path,
+        Some(PathBuf::from("c.md")),
+        "expected C, got: focused path = {:?}",
+        tab.focused
+    );
+}
+
+#[test]
+fn close_focused_promotes_sibling() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    // Close b → only a remains, focus on a.
+    assert_eq!(tab.close_focused(), CloseResult::Closed);
+    assert_eq!(tab.leaf_count(), 1);
+    assert_eq!(tab.active_leaf().document_path, Some(PathBuf::from("a.md")));
+}
+
+#[test]
+fn close_focused_on_root_returns_last_leaf() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    assert_eq!(tab.close_focused(), CloseResult::LastLeaf);
+    assert_eq!(tab.leaf_count(), 1);
+}
+
+#[test]
+fn cycle_focus_visits_all_leaves() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    tab.split(SplitDir::Horizontal, pane_with_path("c.md"));
+    // Cycle from c → a → b → c.
+    let mut seen = vec![tab.active_leaf().document_path.clone()];
+    for _ in 0..3 {
+        assert!(tab.cycle_focus());
+        seen.push(tab.active_leaf().document_path.clone());
+    }
+    assert_eq!(seen[0], Some(PathBuf::from("c.md")));
+    assert_eq!(seen[3], Some(PathBuf::from("c.md")));
+    let names: Vec<String> = seen
+        .iter()
+        .filter_map(|p| p.as_ref().map(|p| p.display().to_string()))
+        .collect();
+    assert!(names.contains(&"a.md".to_string()));
+    assert!(names.contains(&"b.md".to_string()));
+}
+
+#[test]
+fn equalize_resets_ratios() {
+    let mut tab = TabState::new(pane_with_path("a.md"));
+    tab.split(SplitDir::Vertical, pane_with_path("b.md"));
+    if let PaneNode::Split { ratio, .. } = &mut tab.root {
+        *ratio = 0.8;
+    }
+    tab.equalize();
+    if let PaneNode::Split { ratio, .. } = &tab.root {
+        assert!((ratio - 0.5).abs() < f32::EPSILON);
+    } else {
+        panic!("root should be a split");
+    }
+}

--- a/httui-tui/src/persist.rs
+++ b/httui-tui/src/persist.rs
@@ -33,12 +33,21 @@ pub fn capture(app: &App) -> TuiViewState {
 fn capture_blocks_workspace(app: &App) -> Option<BlocksWorkspaceSnapshot> {
     let ws = app.blocks_workspace.as_ref()?;
     let tab = app.tabs.tabs.get(app.tabs.active)?;
-    let expanded_files: Vec<String> = ws
+    let mut expanded_files: Vec<String> = ws
         .expanded
         .iter()
         .filter_map(|&fi| ws.index.files.get(fi))
         .map(|f| f.display.clone())
         .collect();
+    // The sidebar tree's expansion (directory AND file paths) rides
+    // in the same list: on restore, entries matching an indexed file
+    // feed `ws.expanded` and everything feeds `tree.expanded`, so old
+    // snapshots (files only) stay valid.
+    for path in &app.tree.expanded {
+        if !expanded_files.contains(path) {
+            expanded_files.push(path.clone());
+        }
+    }
     let cursor = sidebar_pos_for_cursor(ws);
     let root = capture_pane(&tab.root, &ws.index);
     Some(BlocksWorkspaceSnapshot {
@@ -230,6 +239,12 @@ pub fn restore(app: &mut App, snap: &TuiViewState) {
             app.tabs.active = 0;
         }
     }
+
+    // Re-open the sidebar tree exactly as the user left it: every
+    // persisted path (directories and files alike) goes back into the
+    // tree's expansion set, then a refresh rebuilds the visible rows.
+    app.tree.expanded = snap_blocks.expanded_files.iter().cloned().collect();
+    app.tree.refresh(&vault);
 }
 
 fn sidebar_cursor_index(ws: &BlocksWorkspace, pos: &SidebarPos) -> Option<usize> {
@@ -417,337 +432,5 @@ fn canonical_key(vault_path: &std::path::Path) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::app::{BlockIndex, BlocksWorkspace, FileBlocks};
-    use crate::config::Config;
-    use crate::pane::{Pane, SplitDir};
-    use crate::vault::ResolvedVault;
-    use httui_core::db::init_db;
-    use std::path::PathBuf;
-    use tempfile::TempDir;
-
-    async fn app_with_blocks(body: &str) -> (App, TempDir, TempDir) {
-        let data = TempDir::new().unwrap();
-        let vault = TempDir::new().unwrap();
-        std::fs::write(vault.path().join("api.md"), body).unwrap();
-        let pool = init_db(data.path()).await.unwrap();
-        let resolved = ResolvedVault {
-            vault: vault.path().to_path_buf(),
-        };
-        let app = App::new(Config::default(), resolved, pool);
-        (app, data, vault)
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn capture_records_doc_view_by_default() {
-        let (app, _d, _v) =
-            app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
-        let snap = capture(&app);
-        assert_eq!(snap.last_view, "doc");
-        assert!(snap.blocks.is_none());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn capture_records_blocks_view_with_pane_state() {
-        let (mut app, _d, _v) =
-            app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
-        app.view = AppView::Blocks;
-        app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
-        if let Some(ws) = app.blocks_workspace.as_mut() {
-            // Single-file vaults auto-expand, so row 1 is the first
-            // block under the (only) file row.
-            ws.cursor = 1;
-            ws.activate();
-        }
-        if let Some(pane) = app
-            .tabs
-            .tabs
-            .get_mut(app.tabs.active)
-            .map(|t| t.active_leaf_mut())
-        {
-            pane.block_selected = Some(BlockRef {
-                file_idx: 0,
-                block_idx: 0,
-            });
-            pane.block_region = 2;
-        }
-        let snap = capture(&app);
-        assert_eq!(snap.last_view, "blocks");
-        let blocks = snap.blocks.expect("blocks snapshot");
-        assert_eq!(blocks.expanded_files, vec!["api.md".to_string()]);
-        match blocks.root {
-            PaneSnapshot::Leaf(leaf) => {
-                assert_eq!(leaf.file.as_deref(), Some("api.md"));
-                let sel = leaf.block.expect("block selection");
-                assert_eq!(sel.file, "api.md");
-                assert_eq!(sel.key.alias.as_deref(), Some("login"));
-                assert_eq!(leaf.region, 2);
-            }
-            PaneSnapshot::Split(_) => panic!("expected leaf snapshot"),
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn restore_sets_up_blocks_sidebar_and_tree_mode() {
-        let (mut app, _d, _v) =
-            app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
-        app.view = AppView::Blocks;
-        app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
-        app.tree.visible = true;
-        let snap = capture(&app);
-        assert!(snap.sidebar_open);
-
-        let data = TempDir::new().unwrap();
-        let pool = init_db(data.path()).await.unwrap();
-        let resolved = ResolvedVault {
-            vault: app.vault_path.clone(),
-        };
-        let mut app2 = App::new(Config::default(), resolved, pool);
-        restore(&mut app2, &snap);
-
-        assert!(matches!(app2.view, AppView::Blocks));
-        assert!(app2.blocks_workspace.is_some());
-        assert!(app2.tree.block_index.is_some());
-        assert!(app2.tree.visible);
-        // Restore lands on the pane, not the sidebar — Ctrl+W h/j/k/l
-        // require a non-Tree vim mode.
-        assert!(!matches!(app2.vim.mode, crate::vim::mode::Mode::Tree));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn restore_round_trips_blocks_view() {
-        let body = "# api\n\n```http alias=login\nGET https://x.com\n```\n";
-        let (mut app, _d, _v) = app_with_blocks(body).await;
-        app.view = AppView::Blocks;
-        app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
-        if let Some(pane) = app
-            .tabs
-            .tabs
-            .get_mut(app.tabs.active)
-            .map(|t| t.active_leaf_mut())
-        {
-            pane.block_selected = Some(BlockRef {
-                file_idx: 0,
-                block_idx: 0,
-            });
-            pane.block_region = 1;
-        }
-        let snap = capture(&app);
-
-        let data = TempDir::new().unwrap();
-        let pool = init_db(data.path()).await.unwrap();
-        let resolved = ResolvedVault {
-            vault: app.vault_path.clone(),
-        };
-        let mut app2 = App::new(Config::default(), resolved, pool);
-        restore(&mut app2, &snap);
-
-        assert!(matches!(app2.view, AppView::Blocks));
-        let ws = app2.blocks_workspace.as_ref().expect("workspace restored");
-        assert!(ws.expanded.contains(&0));
-        let pane = app2
-            .tabs
-            .tabs
-            .get(app2.tabs.active)
-            .map(|t| t.active_leaf())
-            .expect("active leaf");
-        assert_eq!(pane.block_region, 1);
-        let sel = pane.block_selected.expect("block selected");
-        assert_eq!(sel.block_idx, 0);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn capture_and_restore_multi_tab_pane_strip() {
-        // Two blocks open as tabs in the same pane. After capture +
-        // restore in a fresh App, the strip should rebuild with the
-        // same tabs in the same order and the persisted active tab
-        // still active.
-        let body = "# api\n\n\
-            ```http alias=ping\nGET https://x.com\n```\n\n\
-            ```http alias=save\nPOST https://x.com\n```\n";
-        let (mut app, _d, _v) = app_with_blocks(body).await;
-        app.view = AppView::Blocks;
-        app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
-        if let Some(pane) = app
-            .tabs
-            .tabs
-            .get_mut(app.tabs.active)
-            .map(|t| t.active_leaf_mut())
-        {
-            pane.block_selected = Some(BlockRef {
-                file_idx: 0,
-                block_idx: 0,
-            });
-            let new_tab = BlockTab {
-                block_selected: Some(BlockRef {
-                    file_idx: 0,
-                    block_idx: 1,
-                }),
-                block_region: 3,
-                block_row: 0,
-                block_col: 1,
-                ..BlockTab::empty()
-            };
-            pane.push_block_tab(new_tab);
-        }
-        let snap = capture(&app);
-
-        let data = TempDir::new().unwrap();
-        let pool = init_db(data.path()).await.unwrap();
-        let resolved = ResolvedVault {
-            vault: app.vault_path.clone(),
-        };
-        let mut app2 = App::new(Config::default(), resolved, pool);
-        restore(&mut app2, &snap);
-
-        let pane = app2
-            .tabs
-            .tabs
-            .get(app2.tabs.active)
-            .map(|t| t.active_leaf())
-            .expect("active leaf");
-        assert_eq!(pane.tab_count(), 2, "tab strip restored");
-        assert_eq!(pane.block_tab_active, 1, "active tab persisted");
-        let active_sel = pane.block_selected.expect("active mirror block");
-        assert_eq!(active_sel.block_idx, 1);
-        // The inactive tab carries the original `ping` selection.
-        let inactive = pane.inactive_tab(0).expect("inactive slot 0");
-        assert_eq!(inactive.block_selected.map(|b| b.block_idx), Some(0));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn restore_falls_back_when_block_alias_missing() {
-        let (mut app, _d, _v) =
-            app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
-        app.view = AppView::Blocks;
-        app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
-        if let Some(pane) = app
-            .tabs
-            .tabs
-            .get_mut(app.tabs.active)
-            .map(|t| t.active_leaf_mut())
-        {
-            pane.block_selected = Some(BlockRef {
-                file_idx: 0,
-                block_idx: 0,
-            });
-        }
-        let mut snap = capture(&app);
-        if let Some(b) = snap.blocks.as_mut() {
-            if let PaneSnapshot::Leaf(leaf) = &mut b.root {
-                if let Some(sel) = leaf.block.as_mut() {
-                    sel.key.alias = Some("missing-alias".into());
-                    sel.key.line_start = 9999;
-                }
-            }
-        }
-
-        let data = TempDir::new().unwrap();
-        let pool = init_db(data.path()).await.unwrap();
-        let resolved = ResolvedVault {
-            vault: app.vault_path.clone(),
-        };
-        let mut app2 = App::new(Config::default(), resolved, pool);
-        restore(&mut app2, &snap);
-        let pane = app2
-            .tabs
-            .tabs
-            .get(app2.tabs.active)
-            .map(|t| t.active_leaf())
-            .expect("leaf");
-        assert!(pane.block_selected.is_none());
-        assert!(matches!(app2.view, AppView::Blocks));
-    }
-
-    #[test]
-    fn sanitize_focus_collapses_to_leftmost_when_stale() {
-        let root = PaneNode::Split {
-            direction: SplitDir::Vertical,
-            ratio: 0.5,
-            first: Box::new(PaneNode::Leaf(Pane::empty())),
-            second: Box::new(PaneNode::Leaf(Pane::empty())),
-        };
-        let cleaned = sanitize_focus(&root, &[0, 1, 1]);
-        assert_eq!(cleaned, vec![0]);
-    }
-
-    #[test]
-    fn sanitize_focus_keeps_valid_path() {
-        let root = PaneNode::Split {
-            direction: SplitDir::Vertical,
-            ratio: 0.5,
-            first: Box::new(PaneNode::Leaf(Pane::empty())),
-            second: Box::new(PaneNode::Leaf(Pane::empty())),
-        };
-        assert_eq!(sanitize_focus(&root, &[1]), vec![1]);
-    }
-
-    #[test]
-    fn block_matches_prefers_alias_when_present() {
-        let meta = BlockMeta {
-            alias: Some("login".into()),
-            block_type: "http".into(),
-            line_start: 5,
-        };
-        let alias_match = BlockKey {
-            alias: Some("login".into()),
-            line_start: 999,
-        };
-        assert!(block_matches(&meta, &alias_match));
-        // Mismatching aliases never fall back to line_start — a
-        // renamed block is treated as gone, not as an accidental
-        // line-number coincidence.
-        let alias_miss = BlockKey {
-            alias: Some("other".into()),
-            line_start: 5,
-        };
-        assert!(!block_matches(&meta, &alias_miss));
-    }
-
-    #[test]
-    fn block_matches_falls_back_to_line_start_when_alias_missing() {
-        let meta = BlockMeta {
-            alias: None,
-            block_type: "http".into(),
-            line_start: 7,
-        };
-        assert!(block_matches(
-            &meta,
-            &BlockKey {
-                alias: None,
-                line_start: 7,
-            }
-        ));
-        assert!(!block_matches(
-            &meta,
-            &BlockKey {
-                alias: None,
-                line_start: 8,
-            }
-        ));
-    }
-
-    #[test]
-    fn pane_snapshot_split_round_trips_in_capture() {
-        let mut tab = TabState::new(Pane::empty());
-        tab.split(SplitDir::Vertical, Pane::empty());
-        let snap = capture_pane(
-            &tab.root,
-            &BlockIndex {
-                files: vec![FileBlocks {
-                    path: PathBuf::from("api.md"),
-                    display: "api.md".into(),
-                    blocks: vec![],
-                }],
-            },
-        );
-        match snap {
-            PaneSnapshot::Split(split) => {
-                assert_eq!(split.direction, "vertical");
-                assert!((split.ratio - 0.5).abs() < 1e-6);
-            }
-            PaneSnapshot::Leaf(_) => panic!("expected split"),
-        }
-    }
-}
+#[path = "persist_tests.rs"]
+mod tests;

--- a/httui-tui/src/persist.rs
+++ b/httui-tui/src/persist.rs
@@ -310,6 +310,9 @@ fn restore_leaf(
     pane.block_region = leaf.region as usize;
     pane.block_row = leaf.row as usize;
     pane.block_col = leaf.col as usize;
+    // The request-tab memory isn't persisted — derive it from the
+    // restored region so the card opens on the tab the focus implies.
+    pane.note_req_tab();
     // Multi-tab restore: drop the default single-empty strip and
     // rebuild from the snapshot, then activate the persisted index.
     // Snapshots from old TUIs leave `tabs` empty — the mirror
@@ -325,6 +328,7 @@ fn restore_leaf(
                 block_region: snap.region as usize,
                 block_row: snap.row as usize,
                 block_col: snap.col as usize,
+                block_req_tab: if snap.region == 2 { 1 } else { 0 },
                 block_edit: None,
                 block_draft: None,
             });
@@ -342,6 +346,7 @@ fn restore_leaf(
             pane.block_region = pulled.block_region;
             pane.block_row = pulled.block_row;
             pane.block_col = pulled.block_col;
+            pane.block_req_tab = pulled.block_req_tab;
             pane.viewport_top = pulled.viewport_top;
         }
     }

--- a/httui-tui/src/persist_tests.rs
+++ b/httui-tui/src/persist_tests.rs
@@ -1,0 +1,376 @@
+use super::*;
+use crate::app::{BlockIndex, BlocksWorkspace, FileBlocks};
+use crate::config::Config;
+use crate::pane::{Pane, SplitDir};
+use crate::vault::ResolvedVault;
+use httui_core::db::init_db;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+async fn app_with_blocks(body: &str) -> (App, TempDir, TempDir) {
+    let data = TempDir::new().unwrap();
+    let vault = TempDir::new().unwrap();
+    std::fs::write(vault.path().join("api.md"), body).unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: vault.path().to_path_buf(),
+    };
+    let app = App::new(Config::default(), resolved, pool);
+    (app, data, vault)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capture_records_doc_view_by_default() {
+    let (app, _d, _v) =
+        app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
+    let snap = capture(&app);
+    assert_eq!(snap.last_view, "doc");
+    assert!(snap.blocks.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capture_records_blocks_view_with_pane_state() {
+    let (mut app, _d, _v) =
+        app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
+    app.view = AppView::Blocks;
+    app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
+    if let Some(ws) = app.blocks_workspace.as_mut() {
+        // Single-file vaults auto-expand, so row 1 is the first
+        // block under the (only) file row.
+        ws.cursor = 1;
+        ws.activate();
+    }
+    if let Some(pane) = app
+        .tabs
+        .tabs
+        .get_mut(app.tabs.active)
+        .map(|t| t.active_leaf_mut())
+    {
+        pane.block_selected = Some(BlockRef {
+            file_idx: 0,
+            block_idx: 0,
+        });
+        pane.block_region = 2;
+    }
+    let snap = capture(&app);
+    assert_eq!(snap.last_view, "blocks");
+    let blocks = snap.blocks.expect("blocks snapshot");
+    assert_eq!(blocks.expanded_files, vec!["api.md".to_string()]);
+    match blocks.root {
+        PaneSnapshot::Leaf(leaf) => {
+            assert_eq!(leaf.file.as_deref(), Some("api.md"));
+            let sel = leaf.block.expect("block selection");
+            assert_eq!(sel.file, "api.md");
+            assert_eq!(sel.key.alias.as_deref(), Some("login"));
+            assert_eq!(leaf.region, 2);
+        }
+        PaneSnapshot::Split(_) => panic!("expected leaf snapshot"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_sets_up_blocks_sidebar_and_tree_mode() {
+    let (mut app, _d, _v) =
+        app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
+    app.view = AppView::Blocks;
+    app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
+    app.tree.visible = true;
+    let snap = capture(&app);
+    assert!(snap.sidebar_open);
+
+    let data = TempDir::new().unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: app.vault_path.clone(),
+    };
+    let mut app2 = App::new(Config::default(), resolved, pool);
+    restore(&mut app2, &snap);
+
+    assert!(matches!(app2.view, AppView::Blocks));
+    assert!(app2.blocks_workspace.is_some());
+    assert!(app2.tree.block_index.is_some());
+    assert!(app2.tree.visible);
+    // Restore lands on the pane, not the sidebar — Ctrl+W h/j/k/l
+    // require a non-Tree vim mode.
+    assert!(!matches!(app2.vim.mode, crate::vim::mode::Mode::Tree));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_round_trips_sidebar_tree_expansion() {
+    let (mut app, _d, _v) =
+        app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
+    // A second note inside a subdirectory so the sidebar tree has
+    // a real directory node to expand.
+    std::fs::create_dir_all(app.vault_path.join("sub")).unwrap();
+    std::fs::write(
+        app.vault_path.join("sub/inner.md"),
+        "```http alias=ping\nGET https://y.com\n```\n",
+    )
+    .unwrap();
+    app.view = AppView::Blocks;
+    let index = BlockIndex::build(&app.vault_path);
+    app.blocks_workspace = Some(BlocksWorkspace::new(index.clone()));
+    app.tree.block_index = Some(index);
+    app.tree.visible = true;
+    // User opened the dir and one file before quitting.
+    app.tree.expanded.insert("sub".to_string());
+    app.tree.expanded.insert("sub/inner.md".to_string());
+    let snap = capture(&app);
+    let persisted = &snap.blocks.as_ref().unwrap().expanded_files;
+    assert!(persisted.contains(&"sub".to_string()), "{persisted:?}");
+    assert!(
+        persisted.contains(&"sub/inner.md".to_string()),
+        "{persisted:?}"
+    );
+
+    let data = TempDir::new().unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: app.vault_path.clone(),
+    };
+    let mut app2 = App::new(Config::default(), resolved, pool);
+    restore(&mut app2, &snap);
+
+    assert!(app2.tree.expanded.contains("sub"), "dir stays open");
+    assert!(app2.tree.expanded.contains("sub/inner.md"));
+    // The rebuilt rows actually show the re-opened hierarchy.
+    let names: Vec<&str> = app2.tree.entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"sub"), "rows: {names:?}");
+    assert!(names.contains(&"inner.md"), "rows: {names:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_round_trips_blocks_view() {
+    let body = "# api\n\n```http alias=login\nGET https://x.com\n```\n";
+    let (mut app, _d, _v) = app_with_blocks(body).await;
+    app.view = AppView::Blocks;
+    app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
+    if let Some(pane) = app
+        .tabs
+        .tabs
+        .get_mut(app.tabs.active)
+        .map(|t| t.active_leaf_mut())
+    {
+        pane.block_selected = Some(BlockRef {
+            file_idx: 0,
+            block_idx: 0,
+        });
+        pane.block_region = 1;
+    }
+    let snap = capture(&app);
+
+    let data = TempDir::new().unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: app.vault_path.clone(),
+    };
+    let mut app2 = App::new(Config::default(), resolved, pool);
+    restore(&mut app2, &snap);
+
+    assert!(matches!(app2.view, AppView::Blocks));
+    let ws = app2.blocks_workspace.as_ref().expect("workspace restored");
+    assert!(ws.expanded.contains(&0));
+    let pane = app2
+        .tabs
+        .tabs
+        .get(app2.tabs.active)
+        .map(|t| t.active_leaf())
+        .expect("active leaf");
+    assert_eq!(pane.block_region, 1);
+    let sel = pane.block_selected.expect("block selected");
+    assert_eq!(sel.block_idx, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capture_and_restore_multi_tab_pane_strip() {
+    // Two blocks open as tabs in the same pane. After capture +
+    // restore in a fresh App, the strip should rebuild with the
+    // same tabs in the same order and the persisted active tab
+    // still active.
+    let body = "# api\n\n\
+        ```http alias=ping\nGET https://x.com\n```\n\n\
+        ```http alias=save\nPOST https://x.com\n```\n";
+    let (mut app, _d, _v) = app_with_blocks(body).await;
+    app.view = AppView::Blocks;
+    app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
+    if let Some(pane) = app
+        .tabs
+        .tabs
+        .get_mut(app.tabs.active)
+        .map(|t| t.active_leaf_mut())
+    {
+        pane.block_selected = Some(BlockRef {
+            file_idx: 0,
+            block_idx: 0,
+        });
+        let new_tab = BlockTab {
+            block_selected: Some(BlockRef {
+                file_idx: 0,
+                block_idx: 1,
+            }),
+            block_region: 3,
+            block_row: 0,
+            block_col: 1,
+            ..BlockTab::empty()
+        };
+        pane.push_block_tab(new_tab);
+    }
+    let snap = capture(&app);
+
+    let data = TempDir::new().unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: app.vault_path.clone(),
+    };
+    let mut app2 = App::new(Config::default(), resolved, pool);
+    restore(&mut app2, &snap);
+
+    let pane = app2
+        .tabs
+        .tabs
+        .get(app2.tabs.active)
+        .map(|t| t.active_leaf())
+        .expect("active leaf");
+    assert_eq!(pane.tab_count(), 2, "tab strip restored");
+    assert_eq!(pane.block_tab_active, 1, "active tab persisted");
+    let active_sel = pane.block_selected.expect("active mirror block");
+    assert_eq!(active_sel.block_idx, 1);
+    // The inactive tab carries the original `ping` selection.
+    let inactive = pane.inactive_tab(0).expect("inactive slot 0");
+    assert_eq!(inactive.block_selected.map(|b| b.block_idx), Some(0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_falls_back_when_block_alias_missing() {
+    let (mut app, _d, _v) =
+        app_with_blocks("# api\n\n```http alias=login\nGET https://x.com\n```\n").await;
+    app.view = AppView::Blocks;
+    app.blocks_workspace = Some(BlocksWorkspace::new(BlockIndex::build(&app.vault_path)));
+    if let Some(pane) = app
+        .tabs
+        .tabs
+        .get_mut(app.tabs.active)
+        .map(|t| t.active_leaf_mut())
+    {
+        pane.block_selected = Some(BlockRef {
+            file_idx: 0,
+            block_idx: 0,
+        });
+    }
+    let mut snap = capture(&app);
+    if let Some(b) = snap.blocks.as_mut() {
+        if let PaneSnapshot::Leaf(leaf) = &mut b.root {
+            if let Some(sel) = leaf.block.as_mut() {
+                sel.key.alias = Some("missing-alias".into());
+                sel.key.line_start = 9999;
+            }
+        }
+    }
+
+    let data = TempDir::new().unwrap();
+    let pool = init_db(data.path()).await.unwrap();
+    let resolved = ResolvedVault {
+        vault: app.vault_path.clone(),
+    };
+    let mut app2 = App::new(Config::default(), resolved, pool);
+    restore(&mut app2, &snap);
+    let pane = app2
+        .tabs
+        .tabs
+        .get(app2.tabs.active)
+        .map(|t| t.active_leaf())
+        .expect("leaf");
+    assert!(pane.block_selected.is_none());
+    assert!(matches!(app2.view, AppView::Blocks));
+}
+
+#[test]
+fn sanitize_focus_collapses_to_leftmost_when_stale() {
+    let root = PaneNode::Split {
+        direction: SplitDir::Vertical,
+        ratio: 0.5,
+        first: Box::new(PaneNode::Leaf(Pane::empty())),
+        second: Box::new(PaneNode::Leaf(Pane::empty())),
+    };
+    let cleaned = sanitize_focus(&root, &[0, 1, 1]);
+    assert_eq!(cleaned, vec![0]);
+}
+
+#[test]
+fn sanitize_focus_keeps_valid_path() {
+    let root = PaneNode::Split {
+        direction: SplitDir::Vertical,
+        ratio: 0.5,
+        first: Box::new(PaneNode::Leaf(Pane::empty())),
+        second: Box::new(PaneNode::Leaf(Pane::empty())),
+    };
+    assert_eq!(sanitize_focus(&root, &[1]), vec![1]);
+}
+
+#[test]
+fn block_matches_prefers_alias_when_present() {
+    let meta = BlockMeta {
+        alias: Some("login".into()),
+        block_type: "http".into(),
+        line_start: 5,
+    };
+    let alias_match = BlockKey {
+        alias: Some("login".into()),
+        line_start: 999,
+    };
+    assert!(block_matches(&meta, &alias_match));
+    // Mismatching aliases never fall back to line_start — a
+    // renamed block is treated as gone, not as an accidental
+    // line-number coincidence.
+    let alias_miss = BlockKey {
+        alias: Some("other".into()),
+        line_start: 5,
+    };
+    assert!(!block_matches(&meta, &alias_miss));
+}
+
+#[test]
+fn block_matches_falls_back_to_line_start_when_alias_missing() {
+    let meta = BlockMeta {
+        alias: None,
+        block_type: "http".into(),
+        line_start: 7,
+    };
+    assert!(block_matches(
+        &meta,
+        &BlockKey {
+            alias: None,
+            line_start: 7,
+        }
+    ));
+    assert!(!block_matches(
+        &meta,
+        &BlockKey {
+            alias: None,
+            line_start: 8,
+        }
+    ));
+}
+
+#[test]
+fn pane_snapshot_split_round_trips_in_capture() {
+    let mut tab = TabState::new(Pane::empty());
+    tab.split(SplitDir::Vertical, Pane::empty());
+    let snap = capture_pane(
+        &tab.root,
+        &BlockIndex {
+            files: vec![FileBlocks {
+                path: PathBuf::from("api.md"),
+                display: "api.md".into(),
+                blocks: vec![],
+            }],
+        },
+    );
+    match snap {
+        PaneSnapshot::Split(split) => {
+            assert_eq!(split.direction, "vertical");
+            assert!((split.ratio - 0.5).abs() < 1e-6);
+        }
+        PaneSnapshot::Leaf(_) => panic!("expected split"),
+    }
+}

--- a/httui-tui/src/tree.rs
+++ b/httui-tui/src/tree.rs
@@ -232,13 +232,49 @@ fn flatten(
 }
 
 fn flatten_blocks(index: &BlockIndex, expanded: &HashSet<String>, out: &mut Vec<TreeNode>) {
+    // The block index is a flat, alphabetically-sorted list of
+    // vault-relative paths, so files sharing a directory are
+    // contiguous — re-deriving directory nodes from the path
+    // prefixes yields them in tree order. (The DOC view gets the
+    // hierarchy for free from `list_workspace`'s nested entries.)
+    let mut seen_dirs: HashSet<String> = HashSet::new();
     for (file_idx, file) in index.files.iter().enumerate() {
         let path = file.display.clone();
+        let segments: Vec<&str> = path.split('/').collect();
+        let mut prefix = String::new();
+        let mut depth = 0usize;
+        let mut hidden = false;
+        for seg in &segments[..segments.len().saturating_sub(1)] {
+            if prefix.is_empty() {
+                prefix = (*seg).to_string();
+            } else {
+                prefix = format!("{prefix}/{seg}");
+            }
+            if !hidden && seen_dirs.insert(prefix.clone()) {
+                out.push(TreeNode {
+                    name: (*seg).to_string(),
+                    path: prefix.clone(),
+                    is_dir: true,
+                    depth,
+                    block: None,
+                });
+            }
+            if !expanded.contains(&prefix) {
+                hidden = true;
+            }
+            depth += 1;
+        }
+        if hidden {
+            continue;
+        }
         out.push(TreeNode {
-            name: file.display.clone(),
+            name: segments
+                .last()
+                .map(|s| (*s).to_string())
+                .unwrap_or(path.clone()),
             path: path.clone(),
             is_dir: false,
-            depth: 0,
+            depth,
             block: None,
         });
         if !expanded.contains(&path) {
@@ -249,7 +285,7 @@ fn flatten_blocks(index: &BlockIndex, expanded: &HashSet<String>, out: &mut Vec<
                 name: block.label(),
                 path: path.clone(),
                 is_dir: false,
-                depth: 1,
+                depth: depth + 1,
                 block: Some(TreeBlockMeta {
                     file_idx,
                     block_idx,
@@ -273,6 +309,96 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(&p, "").unwrap();
+    }
+
+    fn write_block_note(dir: &Path, rel: &str) {
+        let p = dir.join(rel);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, "```http alias=a\nGET https://x.com\n```\n").unwrap();
+    }
+
+    fn blocks_tree(vault: &Path) -> FileTree {
+        let mut t = FileTree {
+            block_index: Some(BlockIndex::build(vault)),
+            ..Default::default()
+        };
+        t.refresh(vault);
+        t
+    }
+
+    #[test]
+    fn blocks_tree_renders_directories_as_collapsed_nodes() {
+        let v = TempDir::new().unwrap();
+        write_block_note(v.path(), "root.md");
+        write_block_note(v.path(), "sub/deep/inner.md");
+        let t = blocks_tree(v.path());
+
+        let rows: Vec<(&str, bool, usize)> = t
+            .entries
+            .iter()
+            .map(|e| (e.name.as_str(), e.is_dir, e.depth))
+            .collect();
+        // File at the vault root keeps its short name at depth 0.
+        assert!(rows.contains(&("root.md", false, 0)), "rows: {rows:?}");
+        // The directory chain surfaces as a single collapsed dir node;
+        // nothing inside it leaks out.
+        assert!(rows.contains(&("sub", true, 0)), "rows: {rows:?}");
+        assert!(
+            !rows.iter().any(|(n, ..)| *n == "deep" || *n == "inner.md"),
+            "collapsed dir must hide children: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn blocks_tree_expanding_dirs_reveals_indented_children() {
+        let v = TempDir::new().unwrap();
+        write_block_note(v.path(), "sub/deep/inner.md");
+        let mut t = blocks_tree(v.path());
+        t.expanded.insert("sub".to_string());
+        t.expanded.insert("sub/deep".to_string());
+        t.refresh(v.path());
+
+        let rows: Vec<(&str, bool, usize)> = t
+            .entries
+            .iter()
+            .map(|e| (e.name.as_str(), e.is_dir, e.depth))
+            .collect();
+        assert!(rows.contains(&("sub", true, 0)), "rows: {rows:?}");
+        assert!(rows.contains(&("deep", true, 1)), "rows: {rows:?}");
+        assert!(rows.contains(&("inner.md", false, 2)), "rows: {rows:?}");
+
+        // Expanding the file reveals its block one level deeper, with
+        // the block meta pointing back at the index.
+        t.expanded.insert("sub/deep/inner.md".to_string());
+        t.refresh(v.path());
+        let block_row = t
+            .entries
+            .iter()
+            .find(|e| e.block.is_some())
+            .expect("block row visible");
+        assert_eq!(block_row.depth, 3);
+        assert_eq!(block_row.path, "sub/deep/inner.md");
+    }
+
+    #[test]
+    fn blocks_tree_dir_node_toggles_expansion() {
+        let v = TempDir::new().unwrap();
+        write_block_note(v.path(), "sub/inner.md");
+        let mut t = blocks_tree(v.path());
+        let dir_idx = t
+            .entries
+            .iter()
+            .position(|e| e.is_dir && e.name == "sub")
+            .expect("dir row present");
+        t.selected = dir_idx;
+        assert!(t.toggle_expand(), "dir toggles in block mode");
+        t.refresh(v.path());
+        assert!(
+            t.entries.iter().any(|e| e.name == "inner.md"),
+            "expanded dir reveals its file"
+        );
     }
 
     #[test]

--- a/httui-tui/src/ui/blocks/db_table.rs
+++ b/httui-tui/src/ui/blocks/db_table.rs
@@ -168,7 +168,7 @@ pub(super) fn render_db_inner(
         match result_tab {
             crate::app::ResultPanelTab::Result => {
                 if let Some((table, viewport_selected)) =
-                    build_result_table(b, selected_row, viewport_top)
+                    build_result_table(b, selected_row, viewport_top, MAX_VISIBLE_ROWS)
                 {
                     let mut state = ratatui::widgets::TableState::default();
                     state.select(viewport_selected);
@@ -284,10 +284,14 @@ pub(super) fn clamp_result_viewport(
 }
 
 /// Build a `ratatui::Table` widget for a DB block's `select` result.
+/// `max_rows` caps the visible data rows — the DOC view passes the
+/// fixed card budget (`MAX_VISIBLE_ROWS`), the BLOCKS view passes
+/// whatever its result region's height allows.
 pub(crate) fn build_result_table(
     b: &BlockNode,
     selected_row: Option<usize>,
     viewport_top: Option<&mut u16>,
+    max_rows: usize,
 ) -> Option<(Table<'static>, Option<usize>)> {
     let result = b.cached_result.as_ref()?;
     let first = result
@@ -325,16 +329,17 @@ pub(crate) fn build_result_table(
         .iter()
         .collect();
 
+    let max_rows = max_rows.max(1);
     let total = rows.len();
     let offset = match (viewport_top, selected_row) {
         (Some(slot), Some(sel)) => {
-            let next = clamp_result_viewport(*slot as usize, MAX_VISIBLE_ROWS, sel, total);
+            let next = clamp_result_viewport(*slot as usize, max_rows, sel, total);
             *slot = next as u16;
             next
         }
         _ => 0,
     };
-    let end = (offset + MAX_VISIBLE_ROWS).min(total);
+    let end = (offset + max_rows).min(total);
     let visible_rows: &[&serde_json::Value] = &rows[offset..end];
 
     let mut widths: Vec<u16> = columns
@@ -513,267 +518,5 @@ fn format_cell(v: &serde_json::Value) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::buffer::block::BlockId;
-    use serde_json::json;
-
-    fn db_block(result: Option<serde_json::Value>) -> BlockNode {
-        BlockNode {
-            id: BlockId(0),
-            raw: ropey::Rope::new(),
-            block_type: "db-sqlite".into(),
-            alias: None,
-            display_mode: None,
-            params: json!({"query": "SELECT 1"}),
-            state: if result.is_some() {
-                ExecutionState::Success
-            } else {
-                ExecutionState::Idle
-            },
-            cached_result: result,
-        }
-    }
-
-    #[test]
-    fn db_summary_select_with_count_and_elapsed() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 12},
-            "results": [{"kind": "select", "rows": [{"a": 1}, {"a": 2}], "has_more": false}],
-        })));
-        let s = db_summary(&b).unwrap();
-        assert!(s.contains("2 rows"));
-        assert!(s.contains("12ms"));
-    }
-
-    #[test]
-    fn db_summary_select_has_more_appends_plus() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{"kind": "select", "rows": [{"a": 1}], "has_more": true}],
-        })));
-        let s = db_summary(&b).unwrap();
-        assert!(s.contains("1+"));
-    }
-
-    #[test]
-    fn db_summary_mutation_format() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 4},
-            "results": [{"kind": "mutation", "rows_affected": 3}],
-        })));
-        let s = db_summary(&b).unwrap();
-        assert!(s.contains("3 affected"));
-    }
-
-    #[test]
-    fn db_summary_error_includes_position_suffix() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{"kind": "error", "message": "bad sql", "line": 2, "column": 5}],
-        })));
-        let s = db_summary(&b).unwrap();
-        assert!(s.contains("bad sql"));
-        assert!(s.contains("at 2:5"));
-    }
-
-    #[test]
-    fn db_summary_multi_result_appends_more_suffix() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [
-                {"kind": "select", "rows": [], "has_more": false},
-                {"kind": "select", "rows": [], "has_more": false},
-            ],
-        })));
-        let s = db_summary(&b).unwrap();
-        assert!(s.contains("(+1 more)"));
-    }
-
-    #[test]
-    fn db_summary_returns_none_for_unknown_kind() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{"kind": "wat", "rows": []}],
-        })));
-        assert!(db_summary(&b).is_none());
-    }
-
-    #[test]
-    fn error_position_extracts_line_and_column() {
-        let b = db_block(Some(json!({
-            "results": [{"kind": "error", "line": 7, "column": 3}],
-        })));
-        assert_eq!(error_position(&b), Some((7, 3)));
-    }
-
-    #[test]
-    fn error_position_defaults_column_when_missing() {
-        let b = db_block(Some(json!({
-            "results": [{"kind": "error", "line": 4}],
-        })));
-        assert_eq!(error_position(&b), Some((4, 1)));
-    }
-
-    #[test]
-    fn error_position_returns_none_for_select_result() {
-        let b = db_block(Some(json!({
-            "results": [{"kind": "select", "rows": []}],
-        })));
-        assert!(error_position(&b).is_none());
-    }
-
-    #[test]
-    fn clamp_viewport_no_scroll_when_total_fits_window() {
-        assert_eq!(clamp_result_viewport(0, 10, 4, 5), 0);
-    }
-
-    #[test]
-    fn clamp_viewport_scrolls_down_to_keep_cursor_visible() {
-        assert_eq!(clamp_result_viewport(0, 10, 25, 80), 18);
-    }
-
-    #[test]
-    fn clamp_viewport_scrolls_up_to_keep_cursor_visible() {
-        assert_eq!(clamp_result_viewport(20, 10, 5, 80), 3);
-    }
-
-    #[test]
-    fn clamp_viewport_zero_returns_zero() {
-        assert_eq!(clamp_result_viewport(7, 0, 50, 100), 0);
-    }
-
-    #[test]
-    fn build_result_table_none_without_cache() {
-        let b = db_block(None);
-        assert!(build_result_table(&b, None, None).is_none());
-    }
-
-    #[test]
-    fn build_result_table_none_for_mutation_kind() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{"kind": "mutation", "rows_affected": 3}],
-        })));
-        assert!(build_result_table(&b, None, None).is_none());
-    }
-
-    #[test]
-    fn build_result_table_some_for_select_with_columns() {
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{
-                "kind": "select",
-                "columns": [{"name": "id", "type": "int"}],
-                "rows": [{"id": 1}, {"id": 2}],
-                "has_more": false,
-            }],
-        })));
-        let (_, sel) = build_result_table(&b, Some(1), None).unwrap();
-        assert_eq!(sel, Some(1));
-    }
-
-    #[test]
-    fn build_result_table_persistent_viewport_slides() {
-        let rows: Vec<serde_json::Value> = (0..30).map(|i| json!({"id": i})).collect();
-        let b = db_block(Some(json!({
-            "stats": {"elapsed_ms": 1},
-            "results": [{
-                "kind": "select",
-                "columns": [{"name": "id", "type": "int"}],
-                "rows": rows,
-                "has_more": false,
-            }],
-        })));
-        let mut vt: u16 = 0;
-        build_result_table(&b, Some(15), Some(&mut vt));
-        assert_eq!(vt, 8);
-    }
-
-    #[test]
-    fn db_result_table_height_zero_when_no_cache() {
-        let b = db_block(None);
-        assert_eq!(db_result_table_height(&b), 0);
-    }
-
-    #[test]
-    fn db_result_table_height_for_select_with_rows() {
-        let b = db_block(Some(json!({
-            "results": [{
-                "kind": "select",
-                "columns": [{"name": "id", "type": "int"}],
-                "rows": [{"id": 1}, {"id": 2}, {"id": 3}],
-                "has_more": false,
-            }],
-        })));
-        // header (1) + 3 rows + tab bar + separator = 6
-        assert_eq!(db_result_table_height(&b), 6);
-    }
-
-    #[test]
-    fn db_result_table_height_caps_at_viewport_for_huge_result() {
-        let rows: Vec<serde_json::Value> = (0..40).map(|i| json!({"id": i})).collect();
-        let b = db_block(Some(json!({
-            "results": [{
-                "kind": "select",
-                "columns": [{"name": "id", "type": "int"}],
-                "rows": rows,
-                "has_more": false,
-            }],
-        })));
-        assert_eq!(
-            db_result_table_height(&b),
-            (1 + MAX_VISIBLE_ROWS + 2) as u16
-        );
-    }
-
-    #[test]
-    fn db_result_table_height_error_kind_gets_fixed_panel() {
-        let b = db_block(Some(json!({
-            "results": [{"kind": "error", "message": "x"}],
-        })));
-        // ERROR_PANEL_ROWS (6) + 2 chrome rows = 8
-        assert_eq!(db_result_table_height(&b), 8);
-    }
-
-    #[test]
-    fn is_numeric_type_matches_common_sql_types() {
-        for t in &[
-            "int", "INTEGER", "bigint", "float", "real", "decimal", "numeric", "money", "int4",
-            "FLOAT8",
-        ] {
-            assert!(is_numeric_type(t), "expected {t} numeric");
-        }
-        assert!(!is_numeric_type("text"));
-        assert!(!is_numeric_type("varchar"));
-    }
-
-    #[test]
-    fn truncate_with_ellipsis_passes_short_strings_through() {
-        assert_eq!(truncate_with_ellipsis("abc", 5), "abc");
-        assert_eq!(truncate_with_ellipsis("abc", 3), "abc");
-    }
-
-    #[test]
-    fn truncate_with_ellipsis_drops_with_ellipsis_when_over_width() {
-        let r = truncate_with_ellipsis("abcdef", 4);
-        assert_eq!(r.chars().count(), 4);
-        assert!(r.ends_with('…'));
-    }
-
-    #[test]
-    fn truncate_with_ellipsis_zero_width_yields_empty() {
-        assert_eq!(truncate_with_ellipsis("abc", 0), "");
-    }
-
-    #[test]
-    fn format_cell_translates_each_json_kind() {
-        use serde_json::json;
-        assert_eq!(format_cell(&json!(null)), "(null)");
-        assert_eq!(format_cell(&json!(true)), "true");
-        assert_eq!(format_cell(&json!(42)), "42");
-        assert_eq!(format_cell(&json!("hi")), "hi");
-        assert_eq!(format_cell(&json!([1, 2])), "[…]");
-        assert_eq!(format_cell(&json!({"k": 1})), "{…}");
-    }
-}
+#[path = "db_table_tests.rs"]
+mod tests;

--- a/httui-tui/src/ui/blocks/db_table_tests.rs
+++ b/httui-tui/src/ui/blocks/db_table_tests.rs
@@ -1,0 +1,298 @@
+use super::*;
+use crate::buffer::block::BlockId;
+use serde_json::json;
+
+fn db_block(result: Option<serde_json::Value>) -> BlockNode {
+    BlockNode {
+        id: BlockId(0),
+        raw: ropey::Rope::new(),
+        block_type: "db-sqlite".into(),
+        alias: None,
+        display_mode: None,
+        params: json!({"query": "SELECT 1"}),
+        state: if result.is_some() {
+            ExecutionState::Success
+        } else {
+            ExecutionState::Idle
+        },
+        cached_result: result,
+    }
+}
+
+#[test]
+fn db_summary_select_with_count_and_elapsed() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 12},
+        "results": [{"kind": "select", "rows": [{"a": 1}, {"a": 2}], "has_more": false}],
+    })));
+    let s = db_summary(&b).unwrap();
+    assert!(s.contains("2 rows"));
+    assert!(s.contains("12ms"));
+}
+
+#[test]
+fn db_summary_select_has_more_appends_plus() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{"kind": "select", "rows": [{"a": 1}], "has_more": true}],
+    })));
+    let s = db_summary(&b).unwrap();
+    assert!(s.contains("1+"));
+}
+
+#[test]
+fn db_summary_mutation_format() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 4},
+        "results": [{"kind": "mutation", "rows_affected": 3}],
+    })));
+    let s = db_summary(&b).unwrap();
+    assert!(s.contains("3 affected"));
+}
+
+#[test]
+fn db_summary_error_includes_position_suffix() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{"kind": "error", "message": "bad sql", "line": 2, "column": 5}],
+    })));
+    let s = db_summary(&b).unwrap();
+    assert!(s.contains("bad sql"));
+    assert!(s.contains("at 2:5"));
+}
+
+#[test]
+fn db_summary_multi_result_appends_more_suffix() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [
+            {"kind": "select", "rows": [], "has_more": false},
+            {"kind": "select", "rows": [], "has_more": false},
+        ],
+    })));
+    let s = db_summary(&b).unwrap();
+    assert!(s.contains("(+1 more)"));
+}
+
+#[test]
+fn db_summary_returns_none_for_unknown_kind() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{"kind": "wat", "rows": []}],
+    })));
+    assert!(db_summary(&b).is_none());
+}
+
+#[test]
+fn error_position_extracts_line_and_column() {
+    let b = db_block(Some(json!({
+        "results": [{"kind": "error", "line": 7, "column": 3}],
+    })));
+    assert_eq!(error_position(&b), Some((7, 3)));
+}
+
+#[test]
+fn error_position_defaults_column_when_missing() {
+    let b = db_block(Some(json!({
+        "results": [{"kind": "error", "line": 4}],
+    })));
+    assert_eq!(error_position(&b), Some((4, 1)));
+}
+
+#[test]
+fn error_position_returns_none_for_select_result() {
+    let b = db_block(Some(json!({
+        "results": [{"kind": "select", "rows": []}],
+    })));
+    assert!(error_position(&b).is_none());
+}
+
+#[test]
+fn clamp_viewport_no_scroll_when_total_fits_window() {
+    assert_eq!(clamp_result_viewport(0, 10, 4, 5), 0);
+}
+
+#[test]
+fn clamp_viewport_scrolls_down_to_keep_cursor_visible() {
+    assert_eq!(clamp_result_viewport(0, 10, 25, 80), 18);
+}
+
+#[test]
+fn clamp_viewport_scrolls_up_to_keep_cursor_visible() {
+    assert_eq!(clamp_result_viewport(20, 10, 5, 80), 3);
+}
+
+#[test]
+fn clamp_viewport_zero_returns_zero() {
+    assert_eq!(clamp_result_viewport(7, 0, 50, 100), 0);
+}
+
+#[test]
+fn build_result_table_none_without_cache() {
+    let b = db_block(None);
+    assert!(build_result_table(&b, None, None, MAX_VISIBLE_ROWS).is_none());
+}
+
+#[test]
+fn build_result_table_none_for_mutation_kind() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{"kind": "mutation", "rows_affected": 3}],
+    })));
+    assert!(build_result_table(&b, None, None, MAX_VISIBLE_ROWS).is_none());
+}
+
+#[test]
+fn build_result_table_some_for_select_with_columns() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{
+            "kind": "select",
+            "columns": [{"name": "id", "type": "int"}],
+            "rows": [{"id": 1}, {"id": 2}],
+            "has_more": false,
+        }],
+    })));
+    let (_, sel) = build_result_table(&b, Some(1), None, MAX_VISIBLE_ROWS).unwrap();
+    assert_eq!(sel, Some(1));
+}
+
+fn select_block_with_rows(n: usize) -> BlockNode {
+    let rows: Vec<serde_json::Value> = (0..n).map(|i| json!({"id": i})).collect();
+    db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{
+            "kind": "select",
+            "columns": [{"name": "id", "type": "int"}],
+            "rows": rows,
+            "has_more": false,
+        }],
+    })))
+}
+
+#[test]
+fn build_result_table_persistent_viewport_slides() {
+    let b = select_block_with_rows(30);
+    let mut vt: u16 = 0;
+    build_result_table(&b, Some(15), Some(&mut vt), MAX_VISIBLE_ROWS);
+    assert_eq!(vt, 8);
+}
+
+#[test]
+fn build_result_table_fills_a_taller_window() {
+    // A 25-row budget shows all 25 rows of a 30-row result at
+    // once (the old fixed cap would clip at 10).
+    let b = select_block_with_rows(30);
+    let mut vt: u16 = 0;
+    let (table, _) = build_result_table(&b, Some(0), Some(&mut vt), 25).unwrap();
+    // Window did not need to slide for the first row.
+    assert_eq!(vt, 0);
+    // Visible slice covers max_rows: cursor at the end forces the
+    // window to start at total - max_rows.
+    build_result_table(&b, Some(29), Some(&mut vt), 25).unwrap();
+    assert_eq!(vt as usize, 30 - 25);
+    drop(table);
+}
+
+#[test]
+fn build_result_table_zero_budget_still_shows_one_row() {
+    let b = select_block_with_rows(5);
+    let mut vt: u16 = 0;
+    assert!(build_result_table(&b, Some(0), Some(&mut vt), 0).is_some());
+}
+
+#[test]
+fn clamp_viewport_adapts_to_a_larger_window() {
+    // viewport 25, cursor at the last of 80 rows → window pinned
+    // to the tail (80 - 25 = 55).
+    assert_eq!(clamp_result_viewport(0, 25, 79, 80), 55);
+    // Everything fits → no scroll.
+    assert_eq!(clamp_result_viewport(3, 25, 10, 20), 0);
+}
+
+#[test]
+fn db_result_table_height_zero_when_no_cache() {
+    let b = db_block(None);
+    assert_eq!(db_result_table_height(&b), 0);
+}
+
+#[test]
+fn db_result_table_height_for_select_with_rows() {
+    let b = db_block(Some(json!({
+        "results": [{
+            "kind": "select",
+            "columns": [{"name": "id", "type": "int"}],
+            "rows": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "has_more": false,
+        }],
+    })));
+    // header (1) + 3 rows + tab bar + separator = 6
+    assert_eq!(db_result_table_height(&b), 6);
+}
+
+#[test]
+fn db_result_table_height_caps_at_viewport_for_huge_result() {
+    let rows: Vec<serde_json::Value> = (0..40).map(|i| json!({"id": i})).collect();
+    let b = db_block(Some(json!({
+        "results": [{
+            "kind": "select",
+            "columns": [{"name": "id", "type": "int"}],
+            "rows": rows,
+            "has_more": false,
+        }],
+    })));
+    assert_eq!(
+        db_result_table_height(&b),
+        (1 + MAX_VISIBLE_ROWS + 2) as u16
+    );
+}
+
+#[test]
+fn db_result_table_height_error_kind_gets_fixed_panel() {
+    let b = db_block(Some(json!({
+        "results": [{"kind": "error", "message": "x"}],
+    })));
+    // ERROR_PANEL_ROWS (6) + 2 chrome rows = 8
+    assert_eq!(db_result_table_height(&b), 8);
+}
+
+#[test]
+fn is_numeric_type_matches_common_sql_types() {
+    for t in &[
+        "int", "INTEGER", "bigint", "float", "real", "decimal", "numeric", "money", "int4",
+        "FLOAT8",
+    ] {
+        assert!(is_numeric_type(t), "expected {t} numeric");
+    }
+    assert!(!is_numeric_type("text"));
+    assert!(!is_numeric_type("varchar"));
+}
+
+#[test]
+fn truncate_with_ellipsis_passes_short_strings_through() {
+    assert_eq!(truncate_with_ellipsis("abc", 5), "abc");
+    assert_eq!(truncate_with_ellipsis("abc", 3), "abc");
+}
+
+#[test]
+fn truncate_with_ellipsis_drops_with_ellipsis_when_over_width() {
+    let r = truncate_with_ellipsis("abcdef", 4);
+    assert_eq!(r.chars().count(), 4);
+    assert!(r.ends_with('…'));
+}
+
+#[test]
+fn truncate_with_ellipsis_zero_width_yields_empty() {
+    assert_eq!(truncate_with_ellipsis("abc", 0), "");
+}
+
+#[test]
+fn format_cell_translates_each_json_kind() {
+    use serde_json::json;
+    assert_eq!(format_cell(&json!(null)), "(null)");
+    assert_eq!(format_cell(&json!(true)), "true");
+    assert_eq!(format_cell(&json!(42)), "42");
+    assert_eq!(format_cell(&json!("hi")), "hi");
+    assert_eq!(format_cell(&json!([1, 2])), "[…]");
+    assert_eq!(format_cell(&json!({"k": 1})), "{…}");
+}

--- a/httui-tui/src/ui/blocks/db_table_tests.rs
+++ b/httui-tui/src/ui/blocks/db_table_tests.rs
@@ -296,3 +296,111 @@ fn format_cell_translates_each_json_kind() {
     assert_eq!(format_cell(&json!([1, 2])), "[…]");
     assert_eq!(format_cell(&json!({"k": 1})), "{…}");
 }
+
+// ---- render_db_inner panel -----------------------------------------
+
+fn paint_inner(b: &BlockNode, tab: crate::app::ResultPanelTab, selected: bool) -> String {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let backend = TestBackend::new(60, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let names: crate::ui::blocks::ConnectionNames = std::collections::HashMap::new();
+    let mut vt: u16 = 0;
+    terminal
+        .draw(|f| {
+            render_db_inner(
+                f,
+                ratatui::layout::Rect::new(0, 0, 60, 24),
+                b,
+                Some(0),
+                Some(&mut vt),
+                &names,
+                tab,
+                selected,
+                0,
+            );
+        })
+        .unwrap();
+    let buf = terminal.backend().buffer().clone();
+    (0..24u16)
+        .flat_map(|y| (0..60u16).map(move |x| (x, y)))
+        .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect()
+}
+
+#[test]
+fn render_db_inner_paints_table_panel_with_tab_bar() {
+    let b = select_block_with_rows(5);
+    let text = paint_inner(&b, crate::app::ResultPanelTab::Result, true);
+    assert!(text.contains("id"), "column header visible: {text:?}");
+    assert!(text.contains("Result"), "tab bar visible");
+}
+
+#[test]
+fn render_db_inner_renders_every_result_tab() {
+    let b = select_block_with_rows(3);
+    for tab in [
+        crate::app::ResultPanelTab::Messages,
+        crate::app::ResultPanelTab::Plan,
+        crate::app::ResultPanelTab::Stats,
+        // DB has no Raw — must fall back to Stats, not panic.
+        crate::app::ResultPanelTab::Raw,
+    ] {
+        let _ = paint_inner(&b, tab, true);
+    }
+}
+
+#[test]
+fn render_db_inner_multi_statement_paints_subtabs() {
+    let b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [
+            {
+                "kind": "select",
+                "columns": [{"name": "id", "type": "int"}],
+                "rows": [{"id": 1}],
+                "has_more": false,
+            },
+            {"kind": "mutation", "rows_affected": 2},
+        ],
+    })));
+    let text = paint_inner(&b, crate::app::ResultPanelTab::Result, true);
+    assert!(text.contains("id"), "first statement table painted");
+}
+
+#[test]
+fn render_db_inner_highlights_the_error_line() {
+    let mut b = db_block(Some(json!({
+        "stats": {"elapsed_ms": 1},
+        "results": [{"kind": "error", "message": "boom", "line": 1, "column": 2}],
+    })));
+    b.state = ExecutionState::Error("boom".into());
+    // Painting with an error result exercises the error-line bg and
+    // the error panel branch without panicking.
+    let _ = paint_inner(&b, crate::app::ResultPanelTab::Result, true);
+}
+
+#[test]
+fn render_db_inner_zero_area_is_a_noop() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let b = select_block_with_rows(2);
+    let backend = TestBackend::new(10, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let names: crate::ui::blocks::ConnectionNames = std::collections::HashMap::new();
+    terminal
+        .draw(|f| {
+            render_db_inner(
+                f,
+                ratatui::layout::Rect::new(0, 0, 0, 0),
+                &b,
+                None,
+                None,
+                &names,
+                crate::app::ResultPanelTab::Result,
+                false,
+                0,
+            );
+        })
+        .unwrap();
+}

--- a/httui-tui/src/ui/blocks_view/pane/db.rs
+++ b/httui-tui/src/ui/blocks_view/pane/db.rs
@@ -130,11 +130,15 @@ fn render_db_result_region(
         ResultPanelTab::Result => {
             ctx.result_viewport_top.entry(viewport_key).or_insert(0);
             let selected_row = if focused { Some(pane.block_row) } else { None };
+            // Fill the region: every row the rect can hold minus the
+            // table's own header row.
+            let max_rows = chunks[1].height.saturating_sub(1).max(1) as usize;
             if let Some((table, viewport_selected)) =
                 crate::ui::blocks::db_table::build_result_table(
                     &block_node,
                     selected_row,
                     ctx.result_viewport_top.get_mut(&viewport_key),
+                    max_rows,
                 )
             {
                 let mut state = ratatui::widgets::TableState::default();

--- a/httui-tui/src/ui/blocks_view/pane/http.rs
+++ b/httui-tui/src/ui/blocks_view/pane/http.rs
@@ -22,9 +22,14 @@ pub(super) fn render_http_regions(
 
     // Request region: accent rail + a Headers│Body tab row. The active
     // tab follows the focused region (1=Headers, 2=Body); when focus is
-    // on the URL (0) or Response (3) the region shows Headers, dimmed.
+    // elsewhere (URL, Response) the card keeps showing the last tab
+    // the user visited instead of snapping back to Headers.
     let req_focused = pane_focused && (region == 1 || region == 2);
-    let active_cell = if region == 2 { 1 } else { 0 };
+    let active_cell = match region {
+        1 => 0,
+        2 => 1,
+        _ => pane.block_req_tab.min(1),
+    };
     let inner = region_frame(frame, chunks[0], req_focused);
     if inner.width > 0 && inner.height > 0 {
         let parts = Layout::default()


### PR DESCRIPTION
## What

Nine commits improving day-to-day navigation and editing in httui-tui, all owner-validated manually:

**Horizontal scrolling (cursor-follow on X)**
- New `buffer/viewport2d.rs`: pure follow/clamp math, single char→display-column boundary (`unicode-width`), cursor projection shared by every surface.
- DOC view pans prose lines and the focused block's raw body (`Paragraph::scroll`); chrome stays put. Search/visual overlays shift in lock-step.
- BLOCKS view edit fields (URL, header cells, body/SQL) pan statelessly per frame.
- Insert-mode edits now refresh the viewport, so typing past the pane edge follows the caret.

**DB result table fills its region (BLOCKS view)**
- `build_result_table` takes a `max_rows` budget; the RESULT region passes its rect height instead of the fixed 10-row cap. Scroll window adapts.

**Request card tab memory**
- New `Pane::block_req_tab` remembers the Headers/Body sub-tab; the card keeps showing it while focus sits elsewhere, and re-entering the Request band (digit jump or band motion) lands on the remembered tab.
- Re-activating the already-open block from the sidebar no longer resets the region or stacks a duplicate tab.

**IDE-style auto-pairs (code contexts only)**
- `{` `(` `[` and quotes auto-close with the caret in between; typing the closer over the pair skips; backspace inside an empty pair removes both.
- Applies only to block bodies and BLOCKS-view edit fields — prose never pairs (apostrophes stay single). `editor.auto_pairs` config toggle (default on). `{{ref}}` completion unaffected (`{` twice yields `{{}}`).

**Sidebar as a real tree + persisted expansion**
- BLOCKS-view sidebar now renders directories as expandable, indented nodes (the block index is flat; hierarchy is re-derived from path prefixes).
- Tree expansion (dirs and files) persists across sessions via the existing snapshot list — old snapshots stay valid.

## Tests

Suite grew from 2078 to 2120 tests; every touched file is under the 600-line gate (test modules spilled to `#[path]` siblings where needed) and above the 80% coverage gate.