### PR TITLE
feat(tui): blocks-view caret scroll, json highlight and 0.4.5 prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,66 @@ permissions:
   contents: read
 
 jobs:
+  # Classifies the diff so language-specific jobs can skip entirely on
+  # commits that don't touch them (a TUI-only push shouldn't pay the
+  # full vitest suite, and vice versa). Classification is conservative:
+  # any file that isn't clearly rust-only, frontend-only, or inert
+  # (docs, markdown) turns BOTH areas on. Skipped jobs satisfy required
+  # status checks, so branch protection keeps working.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="origin/${{ github.base_ref }}...HEAD"
+          elif git rev-parse -q --verify "${{ github.event.before }}" >/dev/null 2>&1; then
+            RANGE="${{ github.event.before }}..HEAD"
+          else
+            # Force push or new branch — no usable base; run everything.
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          rust=false
+          frontend=false
+          while IFS= read -r f; do
+            case "$f" in
+              *.md | docs/* | docs-llm/* | LICENSE | .gitignore | httui-web/*)
+                ;;
+              *.rs | *Cargo.toml | Cargo.lock | httui-desktop/src-tauri/* | rust-toolchain*)
+                rust=true ;;
+              httui-desktop/src/* | httui-desktop/index.html | httui-desktop/package.json | \
+              httui-desktop/*.ts | httui-desktop/*.json | httui-sidecar/* | package.json | package-lock.json)
+                frontend=true ;;
+              *)
+                # Unknown territory (workflows, scripts, Makefile...) —
+                # assume it can affect anything.
+                rust=true
+                frontend=true ;;
+            esac
+          done < <(git diff --name-only "$RANGE")
+
+          echo "changed areas: rust=$rust frontend=$frontend"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
+
   rust:
     name: Rust (Linux)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -81,6 +138,8 @@ jobs:
   rust-macos-smoke:
     name: Rust (macOS smoke)
     runs-on: macos-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -102,8 +161,13 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          # vitest --changed needs history to diff against the PR base.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -129,9 +193,18 @@ jobs:
       # Runs the `unit` project only (jsdom). The `browser` project uses
       # @vitest/browser-playwright and would require installing chromium
       # in CI; skip until browser-test coverage is needed in the gate.
+      # PRs run only the tests whose import graph reaches the diff
+      # (--changed); pushes to main run the full suite as the backstop
+      # for anything the graph scoping might miss.
       - name: vitest (httui-desktop, unit)
         if: ${{ !cancelled() }}
-        run: npm run test --workspace httui-desktop -- --project unit
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npm run test --workspace httui-desktop -- --project unit \
+              --changed "origin/${{ github.base_ref }}" --passWithNoTests
+          else
+            npm run test --workspace httui-desktop -- --project unit
+          fi
 
       - name: Build httui-sidecar (smoke)
         if: ${{ !cancelled() }}
@@ -140,51 +213,11 @@ jobs:
   coverage-gate:
     name: Coverage gate (touched files ≥80%)
     runs-on: ubuntu-latest
-    needs: [rust, frontend]
     steps:
       - uses: actions/checkout@v6
         with:
           # Need full history so the script can diff against the base ref.
           fetch-depth: 0
-
-      - name: Install Linux build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: coverage
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      # Same reason as the rust job — bundle.externalBin gate.
-      - name: Stage bundle binary placeholders
-        run: |
-          triple=$(rustc -vV | sed -n 's|host: ||p')
-          mkdir -p httui-desktop/src-tauri/binaries
-          touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
-                "httui-desktop/src-tauri/binaries/httui-$triple" \
-                "httui-desktop/src-tauri/binaries/httui-lsp-$triple"
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install Node dependencies
-        run: npm ci
 
       - name: Resolve base ref
         id: base
@@ -194,6 +227,63 @@ jobs:
           else
             echo "ref=origin/${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
           fi
+
+      # Setup below (apt webkit deps, Rust toolchain, npm ci) costs
+      # ~90s but is only needed for the languages the diff actually
+      # touches — skip what the gate won't use.
+      - name: Detect touched code
+        id: detect
+        env:
+          BASE_REF: ${{ steps.base.outputs.ref }}
+        run: |
+          MODE=detect ./scripts/coverage-check.sh | tee detect.out
+          grep -E '^(has_rs|has_fe|needs_webkit)=' detect.out >> "$GITHUB_OUTPUT"
+
+      - name: Install Linux build dependencies
+        if: steps.detect.outputs.needs_webkit == '1'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install Rust toolchain
+        if: steps.detect.outputs.has_rs == '1'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo
+        if: steps.detect.outputs.has_rs == '1'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: coverage
+
+      - name: Install cargo-llvm-cov
+        if: steps.detect.outputs.has_rs == '1'
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      # Same reason as the rust job — bundle.externalBin gate.
+      - name: Stage bundle binary placeholders
+        if: steps.detect.outputs.has_rs == '1'
+        run: |
+          triple=$(rustc -vV | sed -n 's|host: ||p')
+          mkdir -p httui-desktop/src-tauri/binaries
+          touch "httui-desktop/src-tauri/binaries/httui-tui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-$triple" \
+                "httui-desktop/src-tauri/binaries/httui-lsp-$triple"
+
+      - uses: actions/setup-node@v6
+        if: steps.detect.outputs.has_fe == '1'
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Node dependencies
+        if: steps.detect.outputs.has_fe == '1'
+        run: npm ci
 
       - name: Size gate (≤600 lines per touched file)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Dependency compilation dominates the release build (~20 min on
+      # Windows from a cold target dir). The action keys by OS; the two
+      # macOS targets share a key but their artifacts live in disjoint
+      # target/<triple>/ subdirs, so they coexist in one cache entry.
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+          cache-on-failure: true
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Post-0.4.4 work lands here.
+Post-0.4.5 work lands here.
+
+## [0.4.5] - 2026-06-11
+
+### Added
+
+- **TUI**: JSON request bodies are syntax-highlighted in the BLOCKS view — keys, strings, numbers, booleans and punctuation get the same colours the desktop response viewer uses, with `{{ref}}` chips painted on top. Applies while browsing and while editing.
+
+### Fixed
+
+- **TUI**: editing a body or SQL query taller than its BLOCKS-view region now scrolls vertically with the caret instead of clipping at the region's bottom — same cursor-follow behaviour the horizontal axis gained in 0.4.4.
 
 ## [0.4.4] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Post-0.4.3 work lands here.
+Post-0.4.4 work lands here.
+
+## [0.4.4] - 2026-06-11
+
+### Added
+
+- **Desktop**: LSP-powered editor intelligence for `{{refs}}`. The bundled `httui-lsp` language server ([#78](https://github.com/httuicom/httui/pull/78)) now drives diagnostics, typed hovers with live value previews, and field completion inside HTTP/DB blocks ([#76](https://github.com/httuicom/httui/pull/76), [#77](https://github.com/httuicom/httui/pull/77), [#82](https://github.com/httuicom/httui/pull/82)). The ref grammar gains `{{$prev}}` and numeric path segments (`{{q.rows.0.id}}`) via httui-lang 0.2.1 ([#80](https://github.com/httuicom/httui/pull/80), [#81](https://github.com/httuicom/httui/pull/81)).
+- **TUI**: horizontal scrolling follows the cursor. Long prose lines, request URLs and SQL pan the viewport instead of letting the caret walk off-screen — in the markdown editor, inside block bodies, in BLOCKS-view edit fields, and while typing in insert mode.
+- **TUI**: IDE-style auto-closing pairs when typing code. `{`, `(`, `[` and quotes auto-close with the caret in between, typing the closer skips over it, and backspace inside an empty pair removes both. Applies only to block bodies and BLOCKS-view edit fields (prose is untouched); disable with `editor.auto_pairs = false` in `config.toml`.
+
+### Changed
+
+- **Desktop**: `{{ref}}` highlighting paints on first render via a lezer grammar — no more flash of unstyled text while the LSP warms up ([#83](https://github.com/httuicom/httui/pull/83)).
+- **TUI**: the DB result table fills the available height of the BLOCKS-view result region instead of capping at 10 rows.
+- **TUI**: the BLOCKS-view sidebar renders folders as a real tree — expandable directory nodes with indented children — instead of a flat list of paths.
+
+### Fixed
+
+- **TUI**: the Request card remembers its Headers/Body sub-tab. Leaving the card (or committing an edit with Esc) no longer snaps it back to Headers, and re-entering the band lands on the tab you left open. Re-activating the already-open block from the sidebar keeps your place instead of resetting it.
+- **TUI**: sidebar tree expansion persists across sessions — folders and files you left open are re-opened on the next launch.
 
 ## [0.4.3] - 2026-06-08
 

--- a/httui-tui/src/ui/blocks/http_panel/highlight.rs
+++ b/httui-tui/src/ui/blocks/http_panel/highlight.rs
@@ -260,7 +260,7 @@ pub(super) fn highlight_xml_line(line: &str) -> Vec<Span<'static>> {
 /// across lines (multi-line escape sequences) are rare in
 /// pretty-printed JSON; if they happen, the second half just
 /// renders default.
-pub(super) fn highlight_json_line(line: &str) -> Vec<Span<'static>> {
+pub(crate) fn highlight_json_line(line: &str) -> Vec<Span<'static>> {
     let mut spans: Vec<Span<'static>> = Vec::new();
     let key_style = Style::default().fg(Color::Cyan);
     let str_style = Style::default().fg(Color::Green);

--- a/httui-tui/src/ui/blocks/http_panel/mod.rs
+++ b/httui-tui/src/ui/blocks/http_panel/mod.rs
@@ -19,6 +19,10 @@ use super::{paint_panel_focus_bg, paint_panel_focus_hint, raw_body_text, render_
 mod highlight;
 pub(crate) mod response;
 
+// The BLOCKS view paints HTTP bodies with the same JSON lexer the DOC
+// view uses, so both surfaces colour identically.
+pub(crate) use highlight::highlight_json_line;
+
 pub(super) fn http_header_left_spans(b: &BlockNode, bg: Style) -> Vec<Span<'static>> {
     let alias = b.alias.clone().unwrap_or_else(|| "—".into());
     let method = b

--- a/httui-tui/src/ui/blocks/mod.rs
+++ b/httui-tui/src/ui/blocks/mod.rs
@@ -267,7 +267,7 @@ fn raw_body_text(b: &BlockNode) -> String {
 // the `{{`/`}}` pair. Overlay positionally: reconstruct the line,
 // project span styles onto a per-byte map, then stamp ref ranges on
 // top and collapse runs back into spans.
-fn overlay_refs_on_spans(
+pub(crate) fn overlay_refs_on_spans(
     spans: Vec<Span<'static>>,
     error_refs: &std::collections::HashSet<String>,
 ) -> Vec<Span<'static>> {

--- a/httui-tui/src/ui/blocks_view/pane/mod.rs
+++ b/httui-tui/src/ui/blocks_view/pane/mod.rs
@@ -319,15 +319,18 @@ fn render_multiline_region(
     }
     let active_edit = pane.block_edit.as_ref().filter(|e| field_matches(&e.field));
     let mut pan: u16 = 0;
+    let mut top: u16 = 0;
     let (text, caret): (String, Option<(u16, u16)>) = if let Some(edit) = active_edit {
         let text = edit.current_text();
         let (row, col) = edit_cursor_row_col(edit);
-        // Stateless pan derived from the caret's line each frame; all
-        // lines of the region shift together (vim `nowrap` feel).
+        // Stateless pan derived from the caret each frame, on both
+        // axes — `follow_x` is axis-agnostic, so it also keeps the
+        // caret's ROW inside a region shorter than the body.
         let line = text.split('\n').nth(row).unwrap_or("");
         let cursor_x = crate::buffer::viewport2d::display_col(line.chars(), col);
         pan = crate::buffer::viewport2d::follow_x(0, inner.width, cursor_x);
-        let cy = inner.y.saturating_add(row as u16);
+        top = crate::buffer::viewport2d::follow_x(0, inner.height, row as u16);
+        let cy = inner.y.saturating_add((row as u16).saturating_sub(top));
         let caret = crate::buffer::viewport2d::project_x(cursor_x, pan, inner.x, inner.width)
             .map(|cx| (cx, cy));
         (text, caret)
@@ -340,10 +343,23 @@ fn render_multiline_region(
     // uses (`ui::sql_highlight::highlight`). HTTP body paints `{{ref}}`
     // as chips in NAV; while editing it stays verbatim so the caret
     // column and the visual-selection overlay map 1:1 to bytes.
+    let looks_like_json = text.trim_start().starts_with(['{', '[']);
     let rendered: Vec<Line<'static>> = if block_type.starts_with("db") {
         crate::ui::sql_highlight::highlight(&text)
             .into_iter()
             .map(Line::from)
+            .collect()
+    } else if looks_like_json {
+        // JSON bodies get the same lexer the DOC view uses; the spans
+        // reproduce the text verbatim, so the caret/overlay byte
+        // mapping holds in EDIT just like the SQL branch above.
+        text.split('\n')
+            .map(|l| {
+                Line::from(crate::ui::blocks::overlay_refs_on_spans(
+                    crate::ui::blocks::http_panel::highlight_json_line(l),
+                    &std::collections::HashSet::new(),
+                ))
+            })
             .collect()
     } else if active_edit.is_some() {
         text.split('\n')
@@ -354,7 +370,7 @@ fn render_multiline_region(
             .map(|l| Line::from(refs_spans(l, false)))
             .collect()
     };
-    frame.render_widget(Paragraph::new(rendered).scroll((0, pan)), inner);
+    frame.render_widget(Paragraph::new(rendered).scroll((top, pan)), inner);
     if let Some((cx, cy)) = caret {
         if cx < inner.x + inner.width && cy < inner.y + inner.height {
             frame.set_cursor_position((cx, cy));
@@ -364,7 +380,7 @@ fn render_multiline_region(
     // paints while EDIT is active and the engine is in Visual /
     // VisualLine on the sub-doc.
     if let (Some(edit), Some(overlay)) = (active_edit, visual_overlay) {
-        crate::ui::overlay_visual_selection(frame, inner, &edit.doc, 0, pan, overlay);
+        crate::ui::overlay_visual_selection(frame, inner, &edit.doc, top, pan, overlay);
     }
     caret
 }
@@ -408,109 +424,5 @@ pub(super) fn paint_picker_overlay(frame: &mut Frame, area: Rect, n: usize) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn multiline_edit_pans_to_keep_caret_visible() {
-        use ratatui::backend::{Backend, TestBackend};
-        use ratatui::Terminal;
-        let sql = format!("SELECT {} AS TAILCOL", "x".repeat(60));
-        let mut doc = crate::buffer::Document::from_markdown(&format!("{sql}\n")).unwrap();
-        // Caret on the line's last char → the stateless pan must bring
-        // the tail into a 40-col region.
-        doc.set_cursor(crate::buffer::Cursor::InProse {
-            segment_idx: 0,
-            offset: sql.chars().count() - 1,
-        });
-        let mut pane = crate::pane::Pane::empty();
-        pane.block_edit = Some(Box::new(crate::app::RegionEdit {
-            field: EditField::DbQuery,
-            doc,
-            sub_mode: crate::app::EditSubMode::Insert,
-        }));
-        let backend = TestBackend::new(40, 4);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                render_multiline_region(
-                    f,
-                    Rect::new(0, 0, 40, 4),
-                    "db-postgres",
-                    true,
-                    "",
-                    "(no query)",
-                    &pane,
-                    true,
-                    |f| matches!(f, EditField::DbQuery),
-                    None,
-                );
-            })
-            .unwrap();
-        let cur = terminal.backend_mut().get_cursor_position().unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let text: String = (0..4)
-            .flat_map(|y| (0..40).map(move |x| (x, y)))
-            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
-            .collect();
-        assert!(text.contains("TAILCOL"), "tail visible under pan: {text:?}");
-        assert!(cur.x < 40, "caret inside the region, got {}", cur.x);
-    }
-
-    #[test]
-    fn multiline_nav_mode_renders_unpanned() {
-        use ratatui::backend::TestBackend;
-        use ratatui::Terminal;
-        let pane = crate::pane::Pane::empty();
-        let backend = TestBackend::new(40, 3);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                render_multiline_region(
-                    f,
-                    Rect::new(0, 0, 40, 3),
-                    "db-postgres",
-                    false,
-                    "SELECT HEADCOL FROM t",
-                    "(no query)",
-                    &pane,
-                    true,
-                    |f| matches!(f, EditField::DbQuery),
-                    None,
-                );
-            })
-            .unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let text: String = (0..3)
-            .flat_map(|y| (0..40).map(move |x| (x, y)))
-            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
-            .collect();
-        assert!(text.contains("HEADCOL"), "NAV stays unpanned: {text:?}");
-    }
-
-    #[test]
-    fn refs_spans_chips_a_reference() {
-        let spans = refs_spans("/users/{{id}}", false);
-        let chip = spans
-            .iter()
-            .find(|s| s.content == "{{id}}")
-            .expect("ref chip span");
-        assert_eq!(chip.style, crate::ui::blocks::ref_highlight::normal_style());
-    }
-
-    #[test]
-    fn refs_spans_plain_text_is_a_single_span() {
-        let spans = refs_spans("no refs here", false);
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].content, "no refs here");
-    }
-
-    #[test]
-    fn refs_spans_underlines_every_span_when_focused() {
-        let spans = refs_spans("a {{b}} c", true);
-        assert!(!spans.is_empty());
-        assert!(spans
-            .iter()
-            .all(|s| s.style.add_modifier.contains(Modifier::UNDERLINED)));
-    }
-}
+#[path = "region_tests.rs"]
+mod tests;

--- a/httui-tui/src/ui/blocks_view/pane/region_tests.rs
+++ b/httui-tui/src/ui/blocks_view/pane/region_tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+#[test]
+fn multiline_edit_pans_to_keep_caret_visible() {
+    use ratatui::backend::{Backend, TestBackend};
+    use ratatui::Terminal;
+    let sql = format!("SELECT {} AS TAILCOL", "x".repeat(60));
+    let mut doc = crate::buffer::Document::from_markdown(&format!("{sql}\n")).unwrap();
+    // Caret on the line's last char → the stateless pan must bring
+    // the tail into a 40-col region.
+    doc.set_cursor(crate::buffer::Cursor::InProse {
+        segment_idx: 0,
+        offset: sql.chars().count() - 1,
+    });
+    let mut pane = crate::pane::Pane::empty();
+    pane.block_edit = Some(Box::new(crate::app::RegionEdit {
+        field: EditField::DbQuery,
+        doc,
+        sub_mode: crate::app::EditSubMode::Insert,
+    }));
+    let backend = TestBackend::new(40, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            render_multiline_region(
+                f,
+                Rect::new(0, 0, 40, 4),
+                "db-postgres",
+                true,
+                "",
+                "(no query)",
+                &pane,
+                true,
+                |f| matches!(f, EditField::DbQuery),
+                None,
+            );
+        })
+        .unwrap();
+    let cur = terminal.backend_mut().get_cursor_position().unwrap();
+    let buf = terminal.backend().buffer().clone();
+    let text: String = (0..4)
+        .flat_map(|y| (0..40).map(move |x| (x, y)))
+        .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect();
+    assert!(text.contains("TAILCOL"), "tail visible under pan: {text:?}");
+    assert!(cur.x < 40, "caret inside the region, got {}", cur.x);
+}
+
+#[test]
+fn multiline_edit_scrolls_vertically_to_the_caret_row() {
+    use ratatui::backend::{Backend, TestBackend};
+    use ratatui::Terminal;
+    // 30-line body, caret on the last line — a 4-row region must
+    // scroll down to show it instead of clipping at the top.
+    let body: String = (0..29).map(|i| format!("line{i}\n")).collect::<String>() + "SELECT TAILROW";
+    let mut doc = crate::buffer::Document::from_markdown(&format!("{body}\n")).unwrap();
+    doc.set_cursor(crate::buffer::Cursor::InProse {
+        segment_idx: 0,
+        offset: body.chars().count() - 1,
+    });
+    let mut pane = crate::pane::Pane::empty();
+    pane.block_edit = Some(Box::new(crate::app::RegionEdit {
+        field: EditField::DbQuery,
+        doc,
+        sub_mode: crate::app::EditSubMode::Insert,
+    }));
+    let backend = TestBackend::new(40, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            render_multiline_region(
+                f,
+                Rect::new(0, 0, 40, 4),
+                "db-postgres",
+                true,
+                "",
+                "(no query)",
+                &pane,
+                true,
+                |f| matches!(f, EditField::DbQuery),
+                None,
+            );
+        })
+        .unwrap();
+    let cur = terminal.backend_mut().get_cursor_position().unwrap();
+    let buf = terminal.backend().buffer().clone();
+    let text: String = (0..4)
+        .flat_map(|y| (0..40).map(move |x| (x, y)))
+        .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect();
+    assert!(text.contains("TAILROW"), "last line visible: {text:?}");
+    assert!(!text.contains("line0"), "top scrolled off: {text:?}");
+    assert!(cur.y < 4, "caret row inside the region, got {}", cur.y);
+}
+
+#[test]
+fn multiline_json_body_is_syntax_highlighted() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let body = "{\n  \"name\": \"joao\"\n}";
+    let mut doc = crate::buffer::Document::from_markdown(&format!("{body}\n")).unwrap();
+    doc.set_cursor(crate::buffer::Cursor::InProse {
+        segment_idx: 0,
+        offset: 0,
+    });
+    let mut pane = crate::pane::Pane::empty();
+    pane.block_edit = Some(Box::new(crate::app::RegionEdit {
+        field: EditField::HttpBody,
+        doc,
+        sub_mode: crate::app::EditSubMode::Insert,
+    }));
+    let backend = TestBackend::new(30, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            render_multiline_region(
+                f,
+                Rect::new(0, 0, 30, 5),
+                "http",
+                true,
+                "",
+                "(no body)",
+                &pane,
+                true,
+                |f| matches!(f, EditField::HttpBody),
+                None,
+            );
+        })
+        .unwrap();
+    let buf = terminal.backend().buffer().clone();
+    // Text stays verbatim on screen…
+    let text: String = (0..5)
+        .flat_map(|y| (0..30).map(move |x| (x, y)))
+        .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect();
+    assert!(text.contains("\"name\""), "verbatim JSON: {text:?}");
+    // …and at least one cell carries the JSON key colour (cyan).
+    let has_colour = (0..5)
+        .flat_map(|y| (0..30).map(move |x| (x, y)))
+        .any(|(x, y)| buf.cell((x, y)).unwrap().fg == ratatui::style::Color::Cyan);
+    assert!(has_colour, "JSON keys must be coloured");
+}
+
+#[test]
+fn multiline_nav_mode_renders_unpanned() {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    let pane = crate::pane::Pane::empty();
+    let backend = TestBackend::new(40, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            render_multiline_region(
+                f,
+                Rect::new(0, 0, 40, 3),
+                "db-postgres",
+                false,
+                "SELECT HEADCOL FROM t",
+                "(no query)",
+                &pane,
+                true,
+                |f| matches!(f, EditField::DbQuery),
+                None,
+            );
+        })
+        .unwrap();
+    let buf = terminal.backend().buffer().clone();
+    let text: String = (0..3)
+        .flat_map(|y| (0..40).map(move |x| (x, y)))
+        .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect();
+    assert!(text.contains("HEADCOL"), "NAV stays unpanned: {text:?}");
+}
+
+#[test]
+fn refs_spans_chips_a_reference() {
+    let spans = refs_spans("/users/{{id}}", false);
+    let chip = spans
+        .iter()
+        .find(|s| s.content == "{{id}}")
+        .expect("ref chip span");
+    assert_eq!(chip.style, crate::ui::blocks::ref_highlight::normal_style());
+}
+
+#[test]
+fn refs_spans_plain_text_is_a_single_span() {
+    let spans = refs_spans("no refs here", false);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].content, "no refs here");
+}
+
+#[test]
+fn refs_spans_underlines_every_span_when_focused() {
+    let spans = refs_spans("a {{b}} c", true);
+    assert!(!spans.is_empty());
+    assert!(spans
+        .iter()
+        .all(|s| s.style.add_modifier.contains(Modifier::UNDERLINED)));
+}

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -9,6 +9,10 @@
 #   scripts/coverage-check.sh                # diff: HEAD~1..HEAD
 #   BASE_REF=origin/main scripts/coverage-check.sh   # diff: origin/main...HEAD
 #   MODE=report scripts/coverage-check.sh    # never exit non-zero
+#   MODE=detect scripts/coverage-check.sh    # print has_rs/has_fe/needs_webkit
+#                                            # key=value lines and exit, so CI
+#                                            # can skip toolchain setup it
+#                                            # won't use
 #
 # Files with `// coverage:exclude file` on line 1 are reported as
 # EXCLUDED and don't count against the gate.
@@ -35,6 +39,16 @@ BASE_REF="${BASE_REF:-}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# detect_emit <has_rs> <has_fe> <needs_webkit>
+# Output is GITHUB_OUTPUT-shaped so CI can pipe it straight into step
+# outputs and gate its setup steps on them.
+detect_emit() {
+    echo "has_rs=$1"
+    echo "has_fe=$2"
+    echo "needs_webkit=$3"
+    exit 0
+}
+
 # ---------- changed file set --------------------------------------------------
 
 DIFF_MODE="${DIFF_MODE:-}"
@@ -49,6 +63,7 @@ else
     fi
 
     if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1 && [ -z "$BASE_REF" ]; then
+        [ "$MODE" = "detect" ] && detect_emit 0 0 0
         echo "coverage-check: only one commit in branch; nothing to check"
         exit 0
     fi
@@ -70,6 +85,7 @@ done < <("${DIFF_CMD[@]}" 2>/dev/null \
     || true)
 
 if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+    [ "$MODE" = "detect" ] && detect_emit 0 0 0
     echo "coverage-check: no .rs/.ts/.tsx changes; gate skipped"
     exit 0
 fi
@@ -84,11 +100,10 @@ done
 # of an empty array under `set -u` is an "unbound variable" error,
 # which crashed deletion-only commits before reaching this skip.
 if [ ${#KEPT[@]} -eq 0 ]; then
+    [ "$MODE" = "detect" ] && detect_emit 0 0 0
     echo "coverage-check: all touched files were deleted; gate skipped"
     exit 0
 fi
-
-CHANGED_FILES=("${KEPT[@]}")
 
 CHANGED_FILES=("${KEPT[@]}")
 
@@ -100,6 +115,24 @@ for f in "${CHANGED_FILES[@]}"; do
         *.ts | *.tsx) HAS_FE=1 ;;
     esac
 done
+
+if [ "$MODE" = "detect" ]; then
+    # webkit2gtk is only required when cargo-llvm-cov will compile the
+    # Tauri crate: a touched .rs under httui-desktop/src-tauri/, or an
+    # unrecognized crate (which falls back to a workspace-wide run).
+    NEEDS_WEBKIT=0
+    for f in "${CHANGED_FILES[@]}"; do
+        case "$f" in
+            *.rs)
+                case "$f" in
+                    httui-core/* | httui-tui/* | httui-mcp/* | httui-launcher/*) ;;
+                    *) NEEDS_WEBKIT=1 ;;
+                esac
+                ;;
+        esac
+    done
+    detect_emit "$HAS_RS" "$HAS_FE" "$NEEDS_WEBKIT"
+fi
 
 # ---------- run coverage tools ------------------------------------------------
 
@@ -154,8 +187,27 @@ fi
 
 if [ "$HAS_FE" -eq 1 ]; then
     echo "coverage-check: running vitest --coverage ..."
+    # Scope the run to tests whose import graph reaches the diff
+    # (--changed): any test that can execute a touched file imports it
+    # transitively, so per-file numbers match the full run. In staged
+    # mode HEAD covers staged + worktree edits — a superset, fine for
+    # the report-only hook. Global thresholds are meaningless over a
+    # subset — zero them; the per-file check below is the enforcement.
+    FE_CHANGED_REF="$BASE_REF"
+    if [ "$DIFF_MODE" = "staged" ]; then
+        FE_CHANGED_REF="HEAD"
+    fi
+    FE_ARGS=()
+    if [ -n "$FE_CHANGED_REF" ]; then
+        FE_ARGS+=(--changed "$FE_CHANGED_REF" --passWithNoTests
+            --coverage.thresholds.lines=0
+            --coverage.thresholds.functions=0
+            --coverage.thresholds.statements=0
+            --coverage.thresholds.branches=0)
+    fi
     (cd httui-desktop && npm run --silent test -- --project unit --coverage \
-        --coverage.reporter=lcov --coverage.reporter=text-summary >/dev/null)
+        --coverage.reporter=lcov --coverage.reporter=text-summary \
+        ${FE_ARGS[@]+"${FE_ARGS[@]}"} >/dev/null)
 fi
 
 # ---------- per-file lcov parser ---------------------------------------------


### PR DESCRIPTION
## What

- **TUI**: multiline body/SQL regions in the BLOCKS view scroll vertically to follow the caret (same stateless cursor-follow the horizontal axis uses); JSON request bodies get syntax highlighting via the shared lexer, with ref chips composed on top.
- **CI**: scope jobs and the coverage gate to touched areas; cache cargo dependencies in release builds (owner commits stranded on local main when branch protection landed).
- **Chore**: changelog entries for 0.4.4 (release shipped from the tag; the section never reached main) and 0.4.5.

After merge: tag `v0.4.5` on main to ship the release.

## Tests

2122 passing; clippy `--all-targets -D warnings` clean; size and coverage gates green.