### PR TITLE
chore(desktop): scrub task ids from hash docstring

### DIFF
--- a/httui-desktop/src/lib/blocks/hash.ts
+++ b/httui-desktop/src/lib/blocks/hash.ts
@@ -2,8 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 
 /**
  * Compute block hash server-side, including environment + connection context.
- * T31: Hash includes active environment ID and connection ID for cache isolation.
- * T35: Hash computed server-side so frontend cannot spoof it.
+ * The hash covers the active environment ID and connection ID for cache
+ * isolation, and is computed server-side so the frontend cannot spoof it.
  */
 export async function hashBlockContent(
   content: string,


### PR DESCRIPTION
Frontend-only diff to exercise the scoped CI introduced in e3d5406/334b2e9. Expected: Rust jobs skipped by the changes job, vitest running only the tests related to hash.ts (--changed), coverage gate running the scoped FE path without installing webkit/Rust toolchain. The docstring cleanup itself is real (T31/T35 are internal planning vocabulary, banned from code comments) so the PR is mergeable if CI behaves.