### PR TITLE
ci: run the frontend job on an arm64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,9 @@ jobs:
 
   frontend:
     name: Frontend
-    runs-on: ubuntu-latest
+    # arm64 runners are free for public repos and meaningfully faster
+    # than the x64 ubuntu-latest pool — this job is vitest-bound.
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     steps:


### PR DESCRIPTION
Moves the Frontend job to ubuntu-24.04-arm (free for public repos). The PR run only validates that setup/lint/tsc work on arm64 — the vitest full-suite timing gain only shows on the post-merge main push, since PRs run the --changed subset.