### PR TITLE
ci: key the release cargo cache by build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release-${{ matrix.target || 'host' }}
+          # Falls back to the bare 'release' key when the matrix entry
+          # passes no explicit target (Linux/Windows) so the caches
+          # already saved under that key stay warm.
+          shared-key: ${{ matrix.target && format('release-{0}', matrix.target) || 'release' }}
           cache-on-failure: true
 
       - name: Install Linux dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,13 +98,14 @@ jobs:
           targets: ${{ matrix.target }}
 
       # Dependency compilation dominates the release build (~20 min on
-      # Windows from a cold target dir). The action keys by OS; the two
-      # macOS targets share a key but their artifacts live in disjoint
-      # target/<triple>/ subdirs, so they coexist in one cache entry.
+      # Windows from a cold target dir). Cache entries are immutable
+      # and the two macOS targets build on the same arm64 host, so the
+      # key must include the target or whichever job saves first leaves
+      # the other target permanently cold.
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release
+          shared-key: release-${{ matrix.target || 'host' }}
           cache-on-failure: true
 
       - name: Install Linux dependencies


### PR DESCRIPTION
Cache entries are immutable and both macOS matrix jobs run on the same arm64 host with the same key, so only the first job to finish saved a cache and the other target would stay cold on every tag. Keying by matrix.target gives each target its own entry (Linux/Windows fall back to 'host' since their matrix entries pass no explicit target).