### PR TITLE
feat(desktop): ship httui-lsp on windows

### DIFF
--- a/httui-desktop/package.json
+++ b/httui-desktop/package.json
@@ -52,7 +52,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
-    "@httui/lezer-refs": "https://github.com/httuicom/httui-lang/releases/download/v0.2.2/httui-lezer-refs-0.2.2.tgz",
+    "@httui/lezer-refs": "https://github.com/httuicom/httui-lang/releases/download/v0.2.3/httui-lezer-refs-0.2.3.tgz",
     "@replit/codemirror-vim": "^6.3.0",
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.10.1",

--- a/httui-desktop/src-tauri/Cargo.toml
+++ b/httui-desktop/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ documentation.workspace = true
 
 [package.metadata.httui]
 # Read by scripts/prepare-bundle-bins.sh.
-lang-version = "0.2.2"
+lang-version = "0.2.3"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/httui-desktop/src-tauri/src/lsp_sidecar.rs
+++ b/httui-desktop/src-tauri/src/lsp_sidecar.rs
@@ -41,7 +41,7 @@ fn resolve_binary_from(
         }
     }
     if let Some(dir) = exe_dir {
-        let sibling = dir.join("httui-lsp");
+        let sibling = dir.join(format!("httui-lsp{}", std::env::consts::EXE_SUFFIX));
         if sibling.is_file() {
             return sibling.to_string_lossy().into_owned();
         }
@@ -161,8 +161,9 @@ mod tests {
     #[test]
     fn resolution_prefers_override_then_sibling_then_path() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("httui-lsp"), "").unwrap();
-        let sibling = dir.path().join("httui-lsp").to_string_lossy().into_owned();
+        let name = format!("httui-lsp{}", std::env::consts::EXE_SUFFIX);
+        std::fs::write(dir.path().join(&name), "").unwrap();
+        let sibling = dir.path().join(&name).to_string_lossy().into_owned();
 
         assert_eq!(
             resolve_binary_from(Some("/x/lsp".into()), Some(dir.path().into())),

--- a/httui-desktop/src-tauri/tauri.windows.conf.json
+++ b/httui-desktop/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
-    "externalBin": ["binaries/httui-tui", "binaries/httui"]
+    "resources": {
+      "binaries/libsqlite3-0.dll": "libsqlite3-0.dll"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@codemirror/theme-one-dark": "^6.1.3",
         "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
-        "@httui/lezer-refs": "https://github.com/httuicom/httui-lang/releases/download/v0.2.2/httui-lezer-refs-0.2.2.tgz",
+        "@httui/lezer-refs": "https://github.com/httuicom/httui-lang/releases/download/v0.2.3/httui-lezer-refs-0.2.3.tgz",
         "@replit/codemirror-vim": "^6.3.0",
         "@tanstack/react-virtual": "^3.13.24",
         "@tauri-apps/api": "^2.10.1",
@@ -2294,9 +2294,9 @@
       "license": "MIT"
     },
     "node_modules/@httui/lezer-refs": {
-      "version": "0.2.2",
-      "resolved": "https://github.com/httuicom/httui-lang/releases/download/v0.2.2/httui-lezer-refs-0.2.2.tgz",
-      "integrity": "sha512-44f2KrUHp0Tc/oaxNwSXiyyjHcpGjx1y6MD4zzeoMSJvSavHAojNvuBtWM7jow4pvM8595kfTlSQFpqZPZPTkQ==",
+      "version": "0.2.3",
+      "resolved": "https://github.com/httuicom/httui-lang/releases/download/v0.2.3/httui-lezer-refs-0.2.3.tgz",
+      "integrity": "sha512-LPAIyYoemk9yOtKD7hnkSbvwqFNOghn9De2fO+AjB0vZyzxqXPNMWyIE252m9hXfkinL/1uV9jHR6qPtWvroxQ==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.3",

--- a/scripts/prepare-bundle-bins.sh
+++ b/scripts/prepare-bundle-bins.sh
@@ -10,7 +10,7 @@
 #
 # httui-lsp is downloaded from the httui-lang release pinned in
 # httui-desktop/src-tauri/Cargo.toml; HTTUI_LSP_BUNDLE_BIN overrides
-# with a local build. Windows targets skip it.
+# with a local build.
 
 set -euo pipefail
 
@@ -62,27 +62,34 @@ cp "$SRC_DIR/httui$SUFFIX"     "$OUT_DIR/httui-$TARGET$SUFFIX"
 # non-executable and `httui` in $PATH errors with "Permission denied".
 chmod +x "$OUT_DIR/httui-tui-$TARGET$SUFFIX" "$OUT_DIR/httui-$TARGET$SUFFIX"
 
-if [[ "$TARGET" == *windows* ]]; then
-  echo "skipping httui-lsp: no Windows build yet (desktop degrades gracefully)"
+LSP_DEST="$OUT_DIR/httui-lsp-$TARGET$SUFFIX"
+# rm first: dune outputs are read-only and block in-place overwrite.
+rm -f "$LSP_DEST"
+if [[ -n "${HTTUI_LSP_BUNDLE_BIN:-}" ]]; then
+  echo "staging httui-lsp from HTTUI_LSP_BUNDLE_BIN: $HTTUI_LSP_BUNDLE_BIN"
+  cp "$HTTUI_LSP_BUNDLE_BIN" "$LSP_DEST"
 else
-  LSP_DEST="$OUT_DIR/httui-lsp-$TARGET"
-  # rm first: dune outputs are read-only and block in-place overwrite.
-  rm -f "$LSP_DEST"
-  if [[ -n "${HTTUI_LSP_BUNDLE_BIN:-}" ]]; then
-    echo "staging httui-lsp from HTTUI_LSP_BUNDLE_BIN: $HTTUI_LSP_BUNDLE_BIN"
-    cp "$HTTUI_LSP_BUNDLE_BIN" "$LSP_DEST"
-  else
-    LSP_URL="https://github.com/httuicom/httui-lang/releases/download/v${HTTUI_LANG_VERSION}/httui-lsp-${TARGET}"
-    echo "downloading httui-lsp ${HTTUI_LANG_VERSION} for $TARGET"
-    # -f: a missing asset must fail the release, never ship without lsp.
-    curl -fL --retry 3 -o "$LSP_DEST" "$LSP_URL"
-  fi
-  chmod 755 "$LSP_DEST"
+  LSP_URL="https://github.com/httuicom/httui-lang/releases/download/v${HTTUI_LANG_VERSION}/httui-lsp-${TARGET}${SUFFIX}"
+  echo "downloading httui-lsp ${HTTUI_LANG_VERSION} for $TARGET"
+  # -f: a missing asset must fail the release, never ship without lsp.
+  curl -fL --retry 3 -o "$LSP_DEST" "$LSP_URL"
+fi
+chmod 755 "$LSP_DEST"
+
+if [[ "$TARGET" == *windows* ]]; then
+  # httui-lsp links sqlite3 dynamically on Windows; the dll is bundled
+  # as a resource so it lands next to the exe, where the loader looks.
+  DLL_DEST="$OUT_DIR/libsqlite3-0.dll"
+  rm -f "$DLL_DEST"
+  echo "downloading libsqlite3-0.dll (httui-lsp runtime dependency)"
+  curl -fL --retry 3 -o "$DLL_DEST" \
+    "https://github.com/httuicom/httui-lang/releases/download/v${HTTUI_LANG_VERSION}/libsqlite3-0.dll"
 fi
 
 echo "staged:"
 echo "  $OUT_DIR/httui-tui-$TARGET$SUFFIX"
 echo "  $OUT_DIR/httui-$TARGET$SUFFIX"
-if [[ "$TARGET" != *windows* ]]; then
-  echo "  $OUT_DIR/httui-lsp-$TARGET"
+echo "  $LSP_DEST"
+if [[ "$TARGET" == *windows* ]]; then
+  echo "  $OUT_DIR/libsqlite3-0.dll"
 fi


### PR DESCRIPTION
Enables the Windows LSP path end to end:

- httui-lang v0.2.3 now publishes `httui-lsp-x86_64-pc-windows-msvc.exe` plus `libsqlite3-0.dll` (sqlite3 is linked dynamically; the loader resolves DLLs from the exe directory).
- `prepare-bundle-bins.sh` downloads the lsp for every target (`.exe` suffix on Windows) and stages the dll on Windows; the Windows skip is gone.
- `tauri.windows.conf.json` now only adds the dll as a resource — `externalBin` (with httui-lsp) is inherited from the base config.
- `lsp_sidecar` sibling lookup uses `EXE_SUFFIX` so it finds `httui-lsp.exe` next to the desktop binary.
- Pins bumped to httui-lang 0.2.3 (Cargo.toml `lang-version` + lezer tarball).