### PR TITLE
perf(desktop): skip full-doc rescans for tables and merge conflicts

### DIFF
--- a/httui-desktop/src/lib/codemirror/__tests__/cm-merge-conflict.test.tsx
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-merge-conflict.test.tsx
@@ -124,4 +124,32 @@ describe("mergeConflict extension", () => {
     ).dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     expect(view.dom.querySelector(".cm-conflict-toolbar")).toBeNull();
   });
+
+  // The docChanged early-out skips the full rescan when no conflict is
+  // present and the edit inserts no `<`; these assert it stays correct
+  // across every transition (a wrong skip would drop a real conflict).
+  it("stays clean when editing prose with no marker char", () => {
+    mount("# title\n\nsome body text here\nmore lines\n");
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: " word" },
+    });
+    expect(view.dom.querySelector(".cm-conflict-marker")).toBeNull();
+  });
+
+  it("decorates a conflict pasted into a clean doc", () => {
+    mount("# title\n\nbody\n");
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "\n" + CONFLICT },
+    });
+    expect(view.dom.querySelectorAll(".cm-conflict-marker")).toHaveLength(2);
+    expect(view.dom.querySelector(".cm-conflict-toolbar")).toBeTruthy();
+  });
+
+  it("keeps decorating after an edit while a conflict is present", () => {
+    mount(CONFLICT);
+    // edit the surrounding prose (no marker char) — the conflict must
+    // remain decorated, not be dropped by the early-out
+    view.dispatch({ changes: { from: 0, insert: "x" } });
+    expect(view.dom.querySelectorAll(".cm-conflict-marker")).toHaveLength(2);
+  });
 });

--- a/httui-desktop/src/lib/codemirror/__tests__/cm-tables.test.ts
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-tables.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { EditorState, Text } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+import {
+  tables,
+  findTables,
+  formatTable,
+  findTableAtBoundary,
+} from "@/lib/codemirror/cm-tables";
+
+// `| h1 | h2 |` header + separator + one row — the minimal renderable table.
+const TABLE = "| h1 | h2 |\n| --- | --- |\n| a | b |";
+const doc = (s: string) => Text.of(s.split("\n"));
+
+describe("findTables", () => {
+  it("finds a header + separator + body rows", () => {
+    const t = findTables(doc(TABLE));
+    expect(t).toHaveLength(1);
+    expect(t[0].rows).toEqual([
+      ["h1", "h2"],
+      ["a", "b"],
+    ]);
+    expect(t[0].hasHeader).toBe(true);
+  });
+
+  it("ignores a pipe row with no separator beneath it", () => {
+    expect(findTables(doc("| a | b |\nplain text"))).toEqual([]);
+  });
+
+  it("ignores a non-pipe line", () => {
+    expect(findTables(doc("# title\n\nbody"))).toEqual([]);
+  });
+
+  it("collects multiple tables and stops body at the first non-row", () => {
+    const two = `${TABLE}\n\nmid\n\n${TABLE}`;
+    const t = findTables(doc(two));
+    expect(t).toHaveLength(2);
+  });
+
+  it("handles a table at end of document", () => {
+    const t = findTables(doc(`intro\n${TABLE}`));
+    expect(t).toHaveLength(1);
+    expect(t[0].rows).toHaveLength(2);
+  });
+});
+
+describe("formatTable", () => {
+  it("pads columns to align a misaligned table", () => {
+    const d = doc("| a | bbbbb |\n| --- | --- |\n| ccccc | d |");
+    const out = formatTable(d, findTables(d)[0]);
+    expect(out).not.toBeNull();
+    // every body/header row is padded to the same width
+    const widths = out!.split("\n").map((l) => l.length);
+    expect(new Set(widths).size).toBe(1);
+  });
+
+  it("returns null when the table is already aligned", () => {
+    const aligned = "| h1  | h2  |\n| --- | --- |\n| a   | b   |";
+    const d = doc(aligned);
+    expect(formatTable(d, findTables(d)[0])).toBeNull();
+  });
+});
+
+describe("findTableAtBoundary", () => {
+  const d = doc(`intro\n${TABLE}\nafter`);
+
+  it("matches a table whose first line is the queried line going down", () => {
+    // table header is line 2 (1-based)
+    expect(findTableAtBoundary(d, 2, "down")).not.toBeNull();
+    expect(findTableAtBoundary(d, 3, "down")).toBeNull();
+  });
+
+  it("matches a table whose last line is the queried line going up", () => {
+    // table last row is line 4
+    expect(findTableAtBoundary(d, 4, "up")).not.toBeNull();
+    expect(findTableAtBoundary(d, 2, "up")).toBeNull();
+  });
+});
+
+describe("tables extension", () => {
+  let view: EditorView;
+  afterEach(() => view?.destroy());
+
+  // anchor keeps the cursor off the table so it renders as a widget
+  // (cursor inside a table shows the raw markdown instead)
+  function mount(text: string, anchor = 0) {
+    view = new EditorView({
+      state: EditorState.create({
+        doc: text,
+        selection: { anchor },
+        extensions: [tables()],
+      }),
+      parent: document.body,
+    });
+    return view;
+  }
+
+  it("renders a table widget with header + body cells when cursor is outside", () => {
+    mount("intro\n\n" + TABLE);
+    const table = view.dom.querySelector(".cm-table-widget");
+    expect(table).toBeTruthy();
+    expect(table!.querySelectorAll("thead th")).toHaveLength(2);
+    expect(table!.querySelectorAll("tbody td")).toHaveLength(2);
+  });
+
+  it("shows raw lines when the cursor is inside the table", () => {
+    // place the cursor inside the table body
+    mount("intro\n\n" + TABLE, "intro\n\n".length + TABLE.length - 2);
+    expect(view.dom.querySelector(".cm-table-raw")).toBeTruthy();
+    expect(view.dom.querySelector(".cm-table-widget")).toBeNull();
+  });
+
+  it("renders two widgets for a doc with two tables", () => {
+    mount(`intro\n\n${TABLE}\n\nmid\n\n${TABLE}`);
+    expect(view.dom.querySelectorAll(".cm-table-widget")).toHaveLength(2);
+  });
+
+  // The docChanged early-out skips the full rescan when no table is
+  // present and the edit inserts no `|`; these assert it stays correct.
+  it("stays plain when editing prose with no pipe char", () => {
+    mount("# title\n\nbody text\nmore lines\n");
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: " word" },
+    });
+    expect(view.dom.querySelector(".cm-table-widget")).toBeNull();
+  });
+
+  it("renders a table pasted into a clean doc", () => {
+    mount("# title\n\nbody\n"); // cursor stays at 0, outside the table
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "\n" + TABLE },
+    });
+    expect(view.dom.querySelector(".cm-table-widget")).toBeTruthy();
+  });
+
+  it("keeps the table after an unrelated prose edit", () => {
+    mount("intro\n\n" + TABLE);
+    view.dispatch({ changes: { from: 0, insert: "x" } });
+    expect(view.dom.querySelector(".cm-table-widget")).toBeTruthy();
+  });
+});

--- a/httui-desktop/src/lib/codemirror/cm-merge-conflict.tsx
+++ b/httui-desktop/src/lib/codemirror/cm-merge-conflict.tsx
@@ -181,7 +181,20 @@ const conflictField = StateField.define<DecorationSet>({
     return buildDecorations(state.doc);
   },
   update(deco, tr) {
-    return tr.docChanged ? buildDecorations(tr.state.doc) : deco;
+    if (!tr.docChanged) return deco;
+    // A conflict region only exists once a `<<<<<<<` marker line does,
+    // so the only edits that can create one insert a `<`. When the doc
+    // has no conflict and this edit inserts none, map the (empty)
+    // decorations forward instead of rescanning every line — the common
+    // case in a large document with no merge in progress.
+    const mapped = deco.map(tr.changes);
+    if (mapped.size > 0) return buildDecorations(tr.state.doc);
+    let mightStartConflict = false;
+    tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
+      if (!mightStartConflict && inserted.toString().includes("<"))
+        mightStartConflict = true;
+    });
+    return mightStartConflict ? buildDecorations(tr.state.doc) : mapped;
   },
   provide: (f) => EditorView.decorations.from(f),
 });

--- a/httui-desktop/src/lib/codemirror/cm-tables.ts
+++ b/httui-desktop/src/lib/codemirror/cm-tables.ts
@@ -32,7 +32,7 @@ function parseRow(line: string): string[] | null {
   return match[1].split("|").map((cell) => cell.trim());
 }
 
-function findTables(doc: {
+export function findTables(doc: {
   lines: number;
   line(n: number): { from: number; to: number; text: string };
 }): TableRange[] {
@@ -73,7 +73,7 @@ function findTables(doc: {
 
 // ── Table formatting (align columns with spaces) ────────────────────────────
 
-function formatTable(
+export function formatTable(
   doc: EditorState["doc"],
   table: TableRange,
 ): string | null {
@@ -306,7 +306,18 @@ const tableField = StateField.define<DecorationSet>({
       return buildTableDecorations(tr.state, view);
     }
     if (tr.docChanged) {
-      return buildTableDecorations(tr.state);
+      // A table row must start with `|`, so an edit can only create a
+      // table by inserting one. With no table present and no `|`
+      // inserted, map the (empty) decorations forward instead of
+      // rescanning every line — the common case in a large prose doc.
+      const mapped = decos.map(tr.changes);
+      if (mapped.size > 0) return buildTableDecorations(tr.state);
+      let mightStartTable = false;
+      tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
+        if (!mightStartTable && inserted.toString().includes("|"))
+          mightStartTable = true;
+      });
+      return mightStartTable ? buildTableDecorations(tr.state) : mapped;
     }
     return decos;
   },
@@ -315,7 +326,7 @@ const tableField = StateField.define<DecorationSet>({
 
 // ── Arrow key navigation into tables ─────────────────────────────────────────
 
-function findTableAtBoundary(
+export function findTableAtBoundary(
   doc: EditorState["doc"],
   lineNum: number,
   direction: "down" | "up",


### PR DESCRIPTION
Slice 2.5 Fase 4. The frontend typing-lag bench showed the per-keystroke cost scaling 10.5x medium->large -- the signature of the full-document scanners that re-walk every line on each docChanged.

cm-merge-conflict and cm-tables now map their decorations through the change set and only rescan the whole document when a conflict/table is already present OR the edit inserts the sentinel char that could create one (< for a conflict marker, | for a table row). Typing prose in a large doc with no merge/table in progress skips both full scans entirely.

**Measured (vitest bench, jsdom):** large-doc keystroke 6.18ms -> 4.59ms mean (~26%); scaling 10.5x -> 8.8x. Behavior-preserving; owner-validated visually (tables + conflicts still render/update).

**Scope:** stopped at these two safe early-outs. The fence scanner drives the executable block widgets (higher risk) and wikilinks rebuilds via selectionSet every keystroke by design; with the large fixture already under the 8ms p95 retoken budget, incrementalizing them is not justified by the data (same ADR-010 principle that dropped the LSP-analysis optimization).

Tests: cm-tables gains its first test file (findTables / formatTable / findTableAtBoundary unit tests + widget/raw/multi DOM tests, 84.4% line coverage); cm-merge-conflict gains early-out transition tests. Full suite 3223 green.