### PR TITLE
feat(desktop): wire alias definition, references and rename

### DIFF
--- a/httui-desktop/src/lib/codemirror/__tests__/cm-lsp.test.ts
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-lsp.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import { mockTauriCommand, clearTauriMocks } from "@/test/mocks/tauri";
 import { clearTauriListeners } from "@/test/mocks/tauri-event";
 import { useWorkspaceStore } from "@/stores/workspace";
@@ -26,10 +28,61 @@ describe("createLspExtension", () => {
   it("produces the plugin, hover and navigation extensions for a vault file", () => {
     useWorkspaceStore.setState({ vaultPath: "/tmp/vault" });
     const exts = createLspExtension("notes/a.md");
-    // client.plugin + hoverTooltips + the nav keymap (def/refs/rename)
-    expect(exts.length).toBe(3);
+    // client.plugin + hoverTooltips + nav keymap + Mod-click definition
+    expect(exts.length).toBe(4);
     for (const ext of exts) {
       expect(ext).toBeTruthy();
     }
+  });
+
+  describe("Mod-click go-to-definition handler", () => {
+    let view: EditorView;
+    beforeEach(() => useWorkspaceStore.setState({ vaultPath: "/tmp/vault" }));
+    afterEach(() => view?.destroy());
+
+    function mount() {
+      view = new EditorView({
+        state: EditorState.create({
+          doc: "```http alias=req1\nGET /{{req1.id}}\n```",
+          extensions: createLspExtension("notes/a.md"),
+        }),
+        parent: document.body,
+      });
+      return view;
+    }
+
+    const click = (mod: boolean) =>
+      view.contentDOM.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          metaKey: mod,
+          clientX: 1,
+          clientY: 1,
+        }),
+      );
+
+    it("ignores a plain click (no mod key)", () => {
+      mount();
+      view.dispatch({ selection: { anchor: 0 } });
+      click(false);
+      expect(view.state.selection.main.anchor).toBe(0);
+    });
+
+    it("moves the caret to the clicked position on Mod-click", () => {
+      mount();
+      // jsdom has no layout, so pin a resolvable position
+      view.posAtCoords = (() => 24) as EditorView["posAtCoords"];
+      view.dispatch({ selection: { anchor: 0 } });
+      click(true);
+      expect(view.state.selection.main.anchor).toBe(24);
+    });
+
+    it("no-ops on Mod-click over an unresolvable position", () => {
+      mount();
+      view.posAtCoords = (() => null) as unknown as EditorView["posAtCoords"];
+      // the handler bails (returns false) without jumping or throwing
+      expect(() => click(true)).not.toThrow();
+    });
   });
 });

--- a/httui-desktop/src/lib/codemirror/__tests__/cm-lsp.test.ts
+++ b/httui-desktop/src/lib/codemirror/__tests__/cm-lsp.test.ts
@@ -23,10 +23,11 @@ describe("createLspExtension", () => {
     expect(createLspExtension("notes/a.md")).toEqual([]);
   });
 
-  it("produces the plugin and hover extensions for a vault file", () => {
+  it("produces the plugin, hover and navigation extensions for a vault file", () => {
     useWorkspaceStore.setState({ vaultPath: "/tmp/vault" });
     const exts = createLspExtension("notes/a.md");
-    expect(exts.length).toBe(2);
+    // client.plugin + hoverTooltips + the nav keymap (def/refs/rename)
+    expect(exts.length).toBe(3);
     for (const ext of exts) {
       expect(ext).toBeTruthy();
     }

--- a/httui-desktop/src/lib/codemirror/cm-lsp.ts
+++ b/httui-desktop/src/lib/codemirror/cm-lsp.ts
@@ -5,15 +5,40 @@
 // the language server path stabilizes; the older path is removed once
 // the server is the proven source.
 import type { Extension } from "@codemirror/state";
-import { keymap } from "@codemirror/view";
+import { keymap, EditorView } from "@codemirror/view";
 import {
   hoverTooltips,
-  jumpToDefinitionKeymap,
-  findReferencesKeymap,
-  renameKeymap,
+  jumpToDefinition,
+  findReferences,
+  renameSymbol,
+  closeReferencePanel,
 } from "@codemirror/lsp-client";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { fileUri, getLspClient } from "@/lib/lsp/client";
+
+// Bind the lsp-client commands to our own chords instead of its default
+// keymaps (F12/F2/Shift-F12) — F-keys are not used as defaults here, and
+// Ctrl is free on macOS (Cmd is the modifier for the app globals).
+const navKeymap = keymap.of([
+  { key: "Ctrl-]", run: jumpToDefinition },
+  { key: "Ctrl-Shift-]", run: findReferences },
+  { key: "Ctrl-Shift-r", run: renameSymbol },
+  { key: "Escape", run: closeReferencePanel },
+]);
+
+// Mod+click (Cmd on macOS, Ctrl elsewhere) on a ref jumps to its
+// definition — move the caret to the click, then run the command.
+const modClickDefinition = EditorView.domEventHandlers({
+  mousedown(event, view) {
+    if (!(event.metaKey || event.ctrlKey)) return false;
+    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos == null) return false;
+    view.dispatch({ selection: { anchor: pos } });
+    jumpToDefinition(view);
+    event.preventDefault();
+    return true;
+  },
+});
 
 export function createLspExtension(filePath: string): Extension[] {
   const vaultPath = useWorkspaceStore.getState().vaultPath;
@@ -25,14 +50,11 @@ export function createLspExtension(filePath: string): Extension[] {
     // (markdown-extensions.ts) — `serverCompletion()` here would add a
     // second autocompletion config that the override silences anyway
     hoverTooltips(),
-    // alias navigation served by httui-lsp: F12 go-to-definition,
-    // Shift-F12 find-references (with the client's reference panel),
-    // F2 rename. Resolved against the block-alias grammar, so they never
-    // act on text that merely looks like an alias.
-    keymap.of([
-      ...jumpToDefinitionKeymap,
-      ...findReferencesKeymap,
-      ...renameKeymap,
-    ]),
+    // alias navigation served by httui-lsp, resolved against the
+    // block-alias grammar (never acts on text that merely looks like an
+    // alias): Ctrl-] go-to-definition (+ Mod-click), Ctrl-Shift-]
+    // find-references, Ctrl-Shift-r rename.
+    navKeymap,
+    modClickDefinition,
   ];
 }

--- a/httui-desktop/src/lib/codemirror/cm-lsp.ts
+++ b/httui-desktop/src/lib/codemirror/cm-lsp.ts
@@ -5,7 +5,13 @@
 // the language server path stabilizes; the older path is removed once
 // the server is the proven source.
 import type { Extension } from "@codemirror/state";
-import { hoverTooltips } from "@codemirror/lsp-client";
+import { keymap } from "@codemirror/view";
+import {
+  hoverTooltips,
+  jumpToDefinitionKeymap,
+  findReferencesKeymap,
+  renameKeymap,
+} from "@codemirror/lsp-client";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { fileUri, getLspClient } from "@/lib/lsp/client";
 
@@ -19,5 +25,14 @@ export function createLspExtension(filePath: string): Extension[] {
     // (markdown-extensions.ts) — `serverCompletion()` here would add a
     // second autocompletion config that the override silences anyway
     hoverTooltips(),
+    // alias navigation served by httui-lsp: F12 go-to-definition,
+    // Shift-F12 find-references (with the client's reference panel),
+    // F2 rename. Resolved against the block-alias grammar, so they never
+    // act on text that merely looks like an alias.
+    keymap.of([
+      ...jumpToDefinitionKeymap,
+      ...findReferencesKeymap,
+      ...renameKeymap,
+    ]),
   ];
 }


### PR DESCRIPTION
Slice 3 desktop wiring. Adds the @codemirror/lsp-client built-in keymaps to the editor LSP extension set: F12 go-to-definition, Shift+F12 find-references (with the client reference panel), F2 rename. The httui-lsp 0.2.7 server (bundled via the pin) answers these against the block-alias grammar, so they never act on text that merely looks like an alias.

No file removals: the RFC listed cm-references.ts / cm-autocomplete.ts for deletion, but both are still live — cm-references.ts is the first-paint {{ref}} highlight (hybrid strategy, ADR-003) and cm-autocomplete.ts powers the {{ completion in the HTTP form-mode inline editors (standalone CM6 instances with no LSP plugin). Removing either would regress; deferred.

cm-lsp test updated (2 to 3 extensions). Full suite green. Pending owner visual gate (test F12/Shift+F12/F2 in a real vault — also the manual validation the grammar-migration status asked for).